### PR TITLE
Reassess Superstate USTB: score 2.38→2.33

### DIFF
--- a/reports/report/superstate-ustb.md
+++ b/reports/report/superstate-ustb.md
@@ -289,7 +289,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 
 ### Critical Monitoring Points
 
-- **NAV/Share:** Track Continuous Price Oracle (`latestRoundData()`) and Chainlink feed — should increase monotonically. Alert on any decrease (would indicate fund losses). Current: ~$11.045. **Staleness alert:** if no `NewCheckpoint` event within ~3 days, `latestRoundData()` will revert after 5 days, freezing subscribe/redeem.
+- **NAV/Share:** Track Continuous Price Oracle (`latestRoundData()`) and Chainlink feed — should increase monotonically. Alert on any decrease (would indicate fund losses). Current: ~$11.045. **Staleness alert:** if no `NewCheckpoint` event within 4 days, send alert — `latestRoundData()` will revert after 5 days, freezing subscribe/redeem.
 - **Admin Burns:** Monitor `AdminBurn` events — forced burns from holder addresses are a critical event.
 - **Pause Events:** Monitor `Paused`/`Unpaused` and `AccountingPaused`/`AccountingUnpaused` on USTB Token AND RedemptionIdle.
 - **Contract Upgrades:** Monitor **all 3 ProxyAdmins** for `Upgraded` events — USTB ProxyAdmin (`0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146`), AllowList ProxyAdmin (`0xb819692a58db9dd4d3b403a875439b6ca155c610`), and RedemptionIdle ProxyAdmin (`0xcaba8c12873fffed13431d98bf6b836dff08e869`). Any proxy upgrade executes immediately with no timelock.

--- a/reports/report/superstate-ustb.md
+++ b/reports/report/superstate-ustb.md
@@ -1,23 +1,23 @@
 # Protocol Risk Assessment: Superstate USTB
 
-- **Assessment Date:** March 5, 2026
+- **Assessment Date:** April 7, 2026
 - **Token:** USTB
 - **Chain:** Ethereum
 - **Token Address:** [`0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e`](https://etherscan.io/address/0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e)
-- **Final Score: 2.38/5.0**
+- **Final Score: 2.33/5.0**
 
 ## Overview + Links
 
 USTB is a tokenized investment fund issued by Superstate Inc. that provides exposure to short-duration U.S. Treasury Bills and Agency securities. The fund's investment objective is to seek current income consistent with liquidity and stability of principal, targeting returns in line with the federal funds rate.
 
-USTB uses a **price appreciation model** (non-rebasing) — each USTB token represents one share in the fund, and the NAV per share increases daily as interest income from Treasury Bills accrues. The token price has grown from ~$10.00 at inception (February 2024) to ~$11.00 as of March 2026.
+USTB uses a **price appreciation model** (non-rebasing) — each USTB token represents one share in the fund, and the NAV per share increases daily as interest income from Treasury Bills accrues. The token price has grown from ~$10.00 at inception (February 2024) to ~$11.05 as of April 2026.
 
-Investors undergo KYC/AML onboarding, get their wallet addresses whitelisted on the AllowList smart contract, and can then subscribe (mint) or redeem (burn) USTB tokens via USDC or USD. On-chain atomic subscription and redemption is available through the Protocol Mint and Redeem system, with a ~$10M USDC instant redemption facility refilled regularly.
+Investors undergo KYC/AML onboarding, get their wallet addresses whitelisted on the AllowList smart contract, and can then subscribe (mint) or redeem (burn) USTB tokens via USDC or USD. On-chain atomic subscription and redemption is available through the Protocol Mint and Redeem system, with a USDC instant redemption facility (currently ~$1.7M, capacity varies as it is refilled regularly).
 
 The fund is structured as a series of **Superstate Asset Trust**, a **Delaware Statutory Trust**, providing bankruptcy remoteness from Superstate Inc. The sub-advisor is **Federated Hermes**, the custodian is **UMB Bank** (OCC-regulated), and the auditor is **Ernst & Young**.
 
-- **Current NAV/Share:** ~$11.00
-- **On-chain Supply (Ethereum):** ~55.49M USTB (~$610M on-chain)
+- **Current NAV/Share:** ~$11.045 (SuperstateOracle: $11.045231, Chainlink: $11.044354 — verified on-chain April 2026)
+- **On-chain Supply (Ethereum):** ~56.59M USTB (~$625M on-chain)
 - **Total AUM:** ~$650M+ (including Solana and book-entry shares)
 - **On-chain Holders (Ethereum):** ~70
 - **Current APY:** ~2.58% (30-day), tracking the federal funds rate
@@ -40,20 +40,33 @@ The fund is structured as a series of **Superstate Asset Trust**, a **Delaware S
 
 ## Contract Addresses
 
+*All addresses verified on-chain April 2026.*
+
 | Contract | Address |
 |----------|---------|
 | USTB Token (Proxy) | [`0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e`](https://etherscan.io/address/0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e) |
-| USTB Implementation (SuperstateTokenV5_1) | [`0x1f50a1ee0ec8275d0c83b7bb08896b4b47d6e8c4`](https://etherscan.io/address/0x1f50a1ee0ec8275d0c83b7bb08896b4b47d6e8c4) |
-| ProxyAdmin | [`0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146`](https://etherscan.io/address/0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146) |
-| AllowList V3 (Proxy) | [`0x02f1fa8b196d21c7b733eb2700b825611d8a38e5`](https://etherscan.io/address/0x02f1fa8b196d21c7b733eb2700b825611d8a38e5) |
-| AllowList V3 Implementation | [`0x2f67d98bd20d9580f52efa5ff70edaed9f2f316d`](https://etherscan.io/address/0x2f67d98bd20d9580f52efa5ff70edaed9f2f316d) |
-| AllowList V3 ProxyAdmin | [`0xb819692a58db9dd4d3b403a875439b6ca155c610`](https://etherscan.io/address/0xb819692a58db9dd4d3b403a875439b6ca155c610) |
-| Superstate Continuous Price Oracle | [`0xe4fa682f94610ccd170680cc3b045d77d9e528a8`](https://etherscan.io/address/0xe4fa682f94610ccd170680cc3b045d77d9e528a8) |
+| USTB Implementation (SuperstateTokenV5_1, VERSION "5") | [`0x1f50a1ee0ec8275d0c83b7bb08896b4b47d6e8c4`](https://etherscan.io/address/0x1f50a1ee0ec8275d0c83b7bb08896b4b47d6e8c4) |
+| USTB ProxyAdmin | [`0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146`](https://etherscan.io/address/0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146) |
+| AllowList V3.1 (Proxy) | [`0x02f1fa8b196d21c7b733eb2700b825611d8a38e5`](https://etherscan.io/address/0x02f1fa8b196d21c7b733eb2700b825611d8a38e5) |
+| AllowList Implementation (Allowlist, VERSION "3.1") | [`0x2f67d98bd20d9580f52efa5ff70edaed9f2f316d`](https://etherscan.io/address/0x2f67d98bd20d9580f52efa5ff70edaed9f2f316d) |
+| AllowList ProxyAdmin | [`0xb819692a58db9dd4d3b403a875439b6ca155c610`](https://etherscan.io/address/0xb819692a58db9dd4d3b403a875439b6ca155c610) |
+| Superstate Continuous Price Oracle (not a proxy) | [`0xe4fa682f94610ccd170680cc3b045d77d9e528a8`](https://etherscan.io/address/0xe4fa682f94610ccd170680cc3b045d77d9e528a8) |
 | Chainlink USTB NAV/Share Oracle | [`0x289B5036cd942e619E1Ee48670F98d214E745AAC`](https://etherscan.io/address/0x289B5036cd942e619E1Ee48670F98d214E745AAC) |
 | RedemptionIdle (Proxy) | [`0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf`](https://etherscan.io/address/0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf) |
-| Token Owner (EOA) | [`0xad309bb6f13074128b4f23ef9ea2fe8552afca83`](https://etherscan.io/address/0xad309bb6f13074128b4f23ef9ea2fe8552afca83) |
-| ProxyAdmin Owner (EOA) | [`0xad309bb6f13074128b4f23ef9ea2fe8552afca83`](https://etherscan.io/address/0xad309bb6f13074128b4f23ef9ea2fe8552afca83) |
-| AllowList V3 Owner (EOA) | [`0x7747940adbc7191f877a9b90596e0da4f8deb2fe`](https://etherscan.io/address/0x7747940adbc7191f877a9b90596e0da4f8deb2fe) |
+| RedemptionIdle Implementation | [`0x8efba8af37af48d2e0a04b0aae60f0e9bc8de007`](https://etherscan.io/address/0x8efba8af37af48d2e0a04b0aae60f0e9bc8de007) |
+| RedemptionIdle ProxyAdmin | [`0xcaba8c12873fffed13431d98bf6b836dff08e869`](https://etherscan.io/address/0xcaba8c12873fffed13431d98bf6b836dff08e869) |
+| USDC Sweep Destination (EOA) | [`0x774AE279c21B6a17a6E2BD5ab5398FF98F398807`](https://etherscan.io/address/0x774AE279c21B6a17a6E2BD5ab5398FF98F398807) |
+
+### Owner Addresses
+
+The system is controlled by **4 distinct EOAs** (all code size 0, no multisig):
+
+| Role | Address |
+|------|---------|
+| USTB Token Owner + USTB ProxyAdmin Owner | [`0xad309bb6f13074128b4f23ef9ea2fe8552afca83`](https://etherscan.io/address/0xad309bb6f13074128b4f23ef9ea2fe8552afca83) |
+| AllowList Owner + AllowList ProxyAdmin Owner | [`0x7747940adbc7191f877a9b90596e0da4f8deb2fe`](https://etherscan.io/address/0x7747940adbc7191f877a9b90596e0da4f8deb2fe) |
+| RedemptionIdle Owner + RedemptionIdle ProxyAdmin Owner | [`0x8cf40e96e7d7fd8A7A9bEf70d3882fbBC4D40765`](https://etherscan.io/address/0x8cf40e96e7d7fd8A7A9bEf70d3882fbBC4D40765) |
+| Oracle Owner | [`0x4B1df64357a5D484563c9b7c16a80eD8B8fB1395`](https://etherscan.io/address/0x4B1df64357a5D484563c9b7c16a80eD8B8fB1395) |
 
 ## Audits and Due Diligence Disclosures
 
@@ -93,16 +106,17 @@ Superstate is **not** listed on the SEAL Safe Harbor registry. This is typical f
 
 ## Historical Track Record
 
-- **Fund Launch:** February 2024 on Ethereum (~13 months in production)
+- **Fund Launch:** February 2024 on Ethereum (~26 months in production)
 - **Contract Deployment:** December 6, 2023 (block 18,725,909)
-- **Contract Upgrades:** Token has been upgraded through 5 versions (V1→V5_1), AllowList through 3 versions (V1→V3). Each upgrade was audited prior to deployment.
+- **Contract Upgrades:** Token has been upgraded through 5 versions (V1→V5_1, VERSION "5"), AllowList through 3 versions (V1→V3.1, VERSION "3.1"). Each upgrade was audited prior to deployment.
 - **Smart Contract Exploits:** None. No security incidents, hacks, or exploits reported.
-- **Price History:** NAV/Share has increased monotonically from ~$10.00 (inception) to ~$11.00 (March 2026), consistent with steady Treasury yield accrual. ATL: $10.29 (Feb 2025), ATH: ~$11.00 (current).
+- **Price History:** NAV/Share has increased monotonically from ~$10.00 (inception) to ~$11.05 (April 2026), consistent with steady Treasury yield accrual. ATL: $10.29 (Feb 2025), ATH: ~$11.05 (current).
 - **AUM Growth:**
   - Feb 2024: Launch
   - Oct 2024: ~$114M (per LlamaRisk report)
   - Mar 2025: ~$300M allocated by Spark alone
   - Mar 2026: ~$650M+ total AUM, ~$572M on-chain TVL (DeFiLlama)
+  - Apr 2026: ~$625M on-chain (56.59M USTB × $11.045 NAV, verified on-chain)
 - **Holder Distribution:** ~70 on-chain holders on Ethereum. Top 10 holders hold ~83.5% of supply. This concentration is expected for an institutional-grade permissioned fund. Top holders include EOAs (institutional investors) and smart contracts (DeFi integrations).
 - **Incidents:** None. No hacks, exploits, or adverse events involving Superstate or USTB.
 
@@ -123,7 +137,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
   - **Off-chain:** USD wire transfer, processed on Market Days (NYSE/Federal Reserve open days).
   - Max subscription fee: 0.1% (10 bps), configurable per stablecoin.
 - **Redemptions (Burning):**
-  - **On-chain atomic:** Via RedemptionIdle contract, burns USTB and sends USDC at Continuous NAV/S price. ~$10M USDC instant redemption facility, regularly replenished.
+  - **On-chain atomic:** Via RedemptionIdle contract, burns USTB and sends USDC at Continuous NAV/S price. USDC instant redemption facility (~$1.7M as of April 2026), regularly replenished.
   - **Off-chain:** Transfer tokens to contract address or call `offchainRedeem()`. Proceeds in USDC or USD wire. T+0 if before 9:00 AM EST on Market Days, otherwise T+1.
   - No redemption fees for standard redemptions.
 - **Geographic Restrictions:** Available to qualified purchasers in the U.S. and select offshore jurisdictions (Cayman Islands, BVI, Bermuda). Not available to sanctioned countries.
@@ -151,7 +165,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 
 ## Liquidity Risk
 
-- **Primary Exit:** On-chain atomic redemption via RedemptionIdle contract at Continuous NAV/S price. ~$10M USDC instant redemption capacity, regularly refilled.
+- **Primary Exit:** On-chain atomic redemption via RedemptionIdle contract at Continuous NAV/S price. USDC instant redemption capacity varies (~$1.7M as of April 2026, regularly refilled).
 - **Secondary Exit:** Off-chain redemption via wire transfer or USDC. T+0 if before 9:00 AM EST on Market Days, otherwise T+1. No withdrawals during weekends/U.S. holidays.
 - **DEX Liquidity:** None. USTB has $0 24h trading volume on DEXs. Not listed on any exchanges. This is by design — the token is a regulated fund product, not a freely tradeable token.
 - **Transfer Restrictions:** All transfers require both sender and receiver to be on the AllowList. Removing an address from the AllowList effectively freezes their tokens.
@@ -178,7 +192,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 
 **Implications for Yearn:** Yearn's vault/strategy contract must be whitelisted by Superstate via protocol address permissions. If Superstate removes this permission (regulatory action, policy change, sanctions, dispute, or operational error), Yearn's entire USTB position becomes frozen and unredeemable. This is a fundamentally different risk profile from permissionless DeFi tokens where DEX liquidity provides a fallback exit.
 
-**On-chain verification (March 2026):** Confirmed that DeFi protocols integrating USTB (e.g., Midas RedemptionVault at [`0x569d7dccbf6923350521ecbc28a555a500c4f0ec`](https://etherscan.io/address/0x569d7dccbf6923350521ecbc28a555a500c4f0ec), Frax FrxUSDCustodian at [`0x5fbaa3a3b489199338fbd85f7e3d444dc0504f33`](https://etherscan.io/address/0x5fbaa3a3b489199338fbd85f7e3d444dc0504f33)) are individually whitelisted on the AllowList with assigned entity IDs. Maple Finance's protocol contracts are NOT whitelisted — Maple's USTB collateral is held by borrowers in their own wallets as off-chain collateral arrangements, not locked in Maple smart contracts.
+**On-chain verification (April 2026):** Confirmed that DeFi protocols integrating USTB (e.g., Midas RedemptionVault at [`0x569d7dccbf6923350521ecbc28a555a500c4f0ec`](https://etherscan.io/address/0x569d7dccbf6923350521ecbc28a555a500c4f0ec), Frax FrxUSDCustodian at [`0x5fbaa3a3b489199338fbd85f7e3d444dc0504f33`](https://etherscan.io/address/0x5fbaa3a3b489199338fbd85f7e3d444dc0504f33)) are individually whitelisted on the AllowList with assigned entity IDs. Maple Finance's protocol contracts are NOT whitelisted — Maple's USTB collateral is held by borrowers in their own wallets as off-chain collateral arrangements, not locked in Maple smart contracts.
 
 ## Centralization & Control Risks
 
@@ -186,20 +200,22 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 
 **Governance Model:** Fully centralized — Superstate Inc. controls all administrative functions. No on-chain governance, no DAO, no community voting.
 
-**Key Privileged Roles (verified on-chain, March 2026):**
+**Key Privileged Roles (verified on-chain, April 2026):**
 
 | Role | Address | Type | Powers |
 |------|---------|------|--------|
-| Token Owner | [`0xad309bb6f13074128b4f23ef9ea2fe8552afca83`](https://etherscan.io/address/0xad309bb6f13074128b4f23ef9ea2fe8552afca83) | **EOA** | `mint`, `bulkMint`, `adminBurn`, `pause`/`unpause`, `accountingPause`/`accountingUnpause`, `setOracle`, `setStablecoinConfig`, `setRedemptionContract`, `setChainIdSupport` |
-| ProxyAdmin Owner | [`0xad309bb6f13074128b4f23ef9ea2fe8552afca83`](https://etherscan.io/address/0xad309bb6f13074128b4f23ef9ea2fe8552afca83) | **EOA** (same as above) | Can upgrade USTB token implementation to arbitrary new code |
-| AllowList V3 Owner | [`0x7747940adbc7191f877a9b90596e0da4f8deb2fe`](https://etherscan.io/address/0x7747940adbc7191f877a9b90596e0da4f8deb2fe) | **EOA** | Can add/remove addresses from AllowList, set entity permissions, set protocol permissions |
+| USTB Token Owner + USTB ProxyAdmin Owner | [`0xad309bb6f13074128b4f23ef9ea2fe8552afca83`](https://etherscan.io/address/0xad309bb6f13074128b4f23ef9ea2fe8552afca83) | **EOA** | `mint`, `bulkMint`, `adminBurn`, `pause`/`unpause`, `accountingPause`/`accountingUnpause`, `setOracle`, `setStablecoinConfig`, `setRedemptionContract`, `setChainIdSupport`, `setMaximumOracleDelay`. Can `upgrade()` / `upgradeAndCall()` USTB token implementation via ProxyAdmin. |
+| AllowList Owner + AllowList ProxyAdmin Owner | [`0x7747940adbc7191f877a9b90596e0da4f8deb2fe`](https://etherscan.io/address/0x7747940adbc7191f877a9b90596e0da4f8deb2fe) | **EOA** | `setEntityIdForAddress`, `setEntityAllowedForPublicInstrument`, `setEntityAllowedForPrivateInstrument`, `setProtocolAddressPermission`. Can `upgrade()` AllowList implementation via ProxyAdmin. |
+| RedemptionIdle Owner + RedemptionIdle ProxyAdmin Owner | [`0x8cf40e96e7d7fd8A7A9bEf70d3882fbBC4D40765`](https://etherscan.io/address/0x8cf40e96e7d7fd8A7A9bEf70d3882fbBC4D40765) | **EOA** | `pause`/`unpause`, `setRedemptionFee`, `setSweepDestination`, `setMaximumOracleDelay`, `withdraw` (extract USDC). Can `upgrade()` RedemptionIdle implementation via ProxyAdmin. |
+| Oracle Owner | [`0x4B1df64357a5D484563c9b7c16a80eD8B8fB1395`](https://etherscan.io/address/0x4B1df64357a5D484563c9b7c16a80eD8B8fB1395) | **EOA** | `addCheckpoint` / `addCheckpoints` (set NAV price), `setMaximumAcceptablePriceDelta`. Oracle is **not** a proxy — cannot be upgraded. |
 
 **Critical centralization concerns:**
 
-1. **EOA-controlled administration** — Both the token owner and ProxyAdmin owner are the **same EOA** (`0xad30...ca83`). There is no multisig, no timelock, and no governance delay. A single private key controls minting, burning from any address, pausing all operations, changing the oracle, and upgrading the contract implementation.
+1. **EOA-controlled administration** — The system is controlled by **4 distinct EOAs**, each with no multisig, no timelock, and no governance delay. The USTB Token Owner (`0xad30...ca83`) controls minting, burning from any address, pausing all operations, changing the oracle, and upgrading the USTB contract implementation. Separate EOAs control the AllowList, RedemptionIdle, and Oracle — splitting control across more keys reduces single-key blast radius but none have multisig protection.
 2. **Admin burn capability** — The owner can call `adminBurn(address, uint256)` to forcibly burn tokens from any holder's address. This is documented as being for "exogenous legal circumstances" (regulatory compliance).
 3. **No timelock on any operation** — Contract upgrades, parameter changes, and critical admin functions execute immediately with no delay period for users to react.
 4. **AllowList control** — Removing an address from the AllowList effectively freezes their tokens (they cannot transfer or redeem). This is a compliance feature but also a centralization vector.
+5. **Oracle pricing control** — The Oracle Owner (`0x4B1d...1395`) controls NAV checkpoints via `addCheckpoint()`. While the oracle uses programmatic linear interpolation between checkpoints, the checkpoint values themselves are set by this EOA. A malicious or compromised oracle owner could post incorrect NAV values affecting subscription/redemption pricing.
 
 **Mitigations:**
 
@@ -254,23 +270,34 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 
 | Contract | Address | Purpose | Key Events/Functions |
 |----------|---------|---------|---------------------|
-| USTB Token | [`0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e`](https://etherscan.io/address/0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e) | Token state | `Mint`, `AdminBurn`, `OffchainRedeem`, `Bridge`, `SubscribeV2`, `Paused`/`Unpaused`, `AccountingPaused`/`AccountingUnpaused`, `totalSupply()` |
-| Continuous Price Oracle | [`0xe4fa682f94610ccd170680cc3b045d77d9e528a8`](https://etherscan.io/address/0xe4fa682f94610ccd170680cc3b045d77d9e528a8) | NAV pricing | `latestRoundData()`, checkpoint updates |
-| AllowList V3 | [`0x02f1fa8b196d21c7b733eb2700b825611d8a38e5`](https://etherscan.io/address/0x02f1fa8b196d21c7b733eb2700b825611d8a38e5) | Permission changes | Entity/protocol permission changes, address additions/removals |
-| RedemptionIdle | [`0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf`](https://etherscan.io/address/0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf) | Redemption liquidity | USDC balance (redemption capacity), large redemptions |
-| ProxyAdmin | [`0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146`](https://etherscan.io/address/0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146) | Implementation upgrades | `Upgraded` events on proxy contracts |
-| Token Owner | [`0xad309bb6f13074128b4f23ef9ea2fe8552afca83`](https://etherscan.io/address/0xad309bb6f13074128b4f23ef9ea2fe8552afca83) | Admin actions | `SetOracle`, `SetStablecoinConfig`, `SetRedemptionContract`, ownership transfer proposals |
+| USTB Token | [`0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e`](https://etherscan.io/address/0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e) | Token state | `Mint`, `AdminBurn`, `OffchainRedeem`, `Bridge`, `SubscribeV2`, `Paused`/`Unpaused`, `AccountingPaused`/`AccountingUnpaused`, `SetOracle`, `SetRedemptionContract`, `SetStablecoinConfig`, `SetMaximumOracleDelay`, `OwnershipTransferStarted`, `totalSupply()` |
+| Continuous Price Oracle | [`0xe4fa682f94610ccd170680cc3b045d77d9e528a8`](https://etherscan.io/address/0xe4fa682f94610ccd170680cc3b045d77d9e528a8) | NAV pricing (not a proxy) | `NewCheckpoint`, `SetMaximumAcceptablePriceDelta`, `OwnershipTransferStarted`, `latestRoundData()` |
+| AllowList V3.1 | [`0x02f1fa8b196d21c7b733eb2700b825611d8a38e5`](https://etherscan.io/address/0x02f1fa8b196d21c7b733eb2700b825611d8a38e5) | Permission changes | `EntityIdSet`, `ProtocolAddressPermissionSet`, `PublicInstrumentPermissionSet`, `PrivateInstrumentPermissionSet`, `OwnershipTransferStarted` |
+| RedemptionIdle | [`0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf`](https://etherscan.io/address/0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf) | Redemption liquidity | `RedeemV2`, `Withdraw`, `SetRedemptionFee`, `SetSweepDestination`, `Paused`/`Unpaused`, `OwnershipTransferStarted`, USDC `balanceOf()` |
+| USTB ProxyAdmin | [`0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146`](https://etherscan.io/address/0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146) | USTB proxy upgrades | `Upgraded` event on USTB proxy, `OwnershipTransferred` |
+| AllowList ProxyAdmin | [`0xb819692a58db9dd4d3b403a875439b6ca155c610`](https://etherscan.io/address/0xb819692a58db9dd4d3b403a875439b6ca155c610) | AllowList proxy upgrades | `Upgraded` event on AllowList proxy, `OwnershipTransferred` |
+| RedemptionIdle ProxyAdmin | [`0xcaba8c12873fffed13431d98bf6b836dff08e869`](https://etherscan.io/address/0xcaba8c12873fffed13431d98bf6b836dff08e869) | RedemptionIdle proxy upgrades | `Upgraded` event on RedemptionIdle proxy, `OwnershipTransferred` |
+
+### Admin EOAs to Monitor
+
+| EOA | Role | Key Actions |
+|-----|------|-------------|
+| [`0xad309bb6f13074128b4f23ef9ea2fe8552afca83`](https://etherscan.io/address/0xad309bb6f13074128b4f23ef9ea2fe8552afca83) | USTB Token + ProxyAdmin Owner | Mint, adminBurn, pause, upgrade USTB impl, set oracle/redemption/stablecoin config |
+| [`0x7747940adbc7191f877a9b90596e0da4f8deb2fe`](https://etherscan.io/address/0x7747940adbc7191f877a9b90596e0da4f8deb2fe) | AllowList + ProxyAdmin Owner | Add/remove addresses, set permissions, upgrade AllowList impl |
+| [`0x8cf40e96e7d7fd8A7A9bEf70d3882fbBC4D40765`](https://etherscan.io/address/0x8cf40e96e7d7fd8A7A9bEf70d3882fbBC4D40765) | RedemptionIdle + ProxyAdmin Owner | Pause redemptions, withdraw USDC, set fees, upgrade RedemptionIdle impl |
+| [`0x4B1df64357a5D484563c9b7c16a80eD8B8fB1395`](https://etherscan.io/address/0x4B1df64357a5D484563c9b7c16a80eD8B8fB1395) | Oracle Owner | Set NAV checkpoints (pricing), set price delta |
 
 ### Critical Monitoring Points
 
-- **NAV/Share:** Track Continuous Price Oracle and Chainlink feed — should increase monotonically. Alert on any decrease (would indicate fund losses).
+- **NAV/Share:** Track Continuous Price Oracle (`latestRoundData()`) and Chainlink feed — should increase monotonically. Alert on any decrease (would indicate fund losses). Current: ~$11.045. Checkpoint expiration: 5 days.
 - **Admin Burns:** Monitor `AdminBurn` events — forced burns from holder addresses are a critical event.
-- **Pause Events:** Monitor `Paused`/`Unpaused` and `AccountingPaused`/`AccountingUnpaused` events.
-- **Contract Upgrades:** Monitor ProxyAdmin for implementation changes on USTB token and AllowList.
-- **Oracle Changes:** Monitor `SetOracle` events — changing the price oracle affects subscription/redemption pricing.
-- **AllowList Changes:** Monitor permission changes, especially protocol address permissions (DeFi integrations).
-- **Redemption Capacity:** Monitor RedemptionIdle USDC balance — depletion could temporarily disable instant on-chain redemption.
-- **Large Supply Changes:** Alert on mints/burns >5% of total supply in 24h.
+- **Pause Events:** Monitor `Paused`/`Unpaused` and `AccountingPaused`/`AccountingUnpaused` on USTB Token AND RedemptionIdle.
+- **Contract Upgrades:** Monitor **all 3 ProxyAdmins** for `Upgraded` events — USTB ProxyAdmin (`0xb9d2...2146`), AllowList ProxyAdmin (`0xb819...c610`), and RedemptionIdle ProxyAdmin (`0xcaba...e869`). Any proxy upgrade executes immediately with no timelock.
+- **Oracle Changes:** Monitor `SetOracle` events on USTB Token and `NewCheckpoint` events on the Oracle. Monitor `SetMaximumAcceptablePriceDelta` on Oracle (current: $1.00).
+- **AllowList Changes:** Monitor `ProtocolAddressPermissionSet` and `EntityIdSet` events, especially protocol address permissions (DeFi integrations).
+- **Redemption Capacity:** Monitor USDC `balanceOf()` on RedemptionIdle — current ~$1.7M. Also monitor `Withdraw` events (owner can extract USDC) and `SetRedemptionFee` (currently 0).
+- **Ownership Transfers:** Monitor `OwnershipTransferStarted` on all 4 contracts (USTB, AllowList, RedemptionIdle, Oracle) and `OwnershipTransferred` on all 3 ProxyAdmins.
+- **Large Supply Changes:** Alert on mints/burns >5% of total supply in 24h. Current supply: ~56.59M USTB.
 - **Recommended Frequency:** Hourly for NAV/pause/admin events. Daily for AllowList and redemption capacity.
 
 ## Risk Summary
@@ -286,7 +313,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 
 ### Key Risks
 
-1. **EOA-controlled admin** — Single EOA controls token minting, forced burning, pausing, oracle changes, and proxy upgrades. No multisig, no timelock. This is the most significant centralization risk.
+1. **EOA-controlled admin** — 4 distinct EOAs control token minting, forced burning, pausing, oracle changes, and proxy upgrades. No multisig, no timelock on any. The separation across 4 keys reduces single-key blast radius but none have multisig protection.
 2. **Off-chain assets** — Underlying Treasury portfolio held off-chain at UMB Bank. Token holders cannot independently verify holdings on-chain. Must rely on NAV agent, auditor, and regulatory framework.
 3. **No DEX liquidity** — Exit exclusively through Superstate's mint/redeem system. No secondary market. Transfer restricted to allowlisted addresses only.
 4. **No formal bug bounty rewards** — Researchers explicitly told not to expect compensation for vulnerability discoveries.
@@ -295,9 +322,9 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 ### Critical Risks
 
 - **AllowList freeze risk** — If Superstate removes an address from the AllowList, the holder's tokens are **completely frozen with zero exit paths**. No transfers, no redemption, no DEX fallback. For DeFi protocols integrating USTB, this means Superstate has unilateral power to freeze an entire protocol's USTB position.
-- **Private key compromise of admin EOA** — A single compromised key (`0xad30...ca83`) could upgrade the contract to malicious code, mint unlimited tokens, or burn tokens from any address, all with no delay. Mitigated by Turnkey secure enclaves but fundamentally a single point of failure.
+- **Private key compromise** — 4 separate EOAs control different parts of the system. Compromise of `0xad30...ca83` alone could upgrade the USTB token to malicious code, mint unlimited tokens, or burn tokens from any address, all with no delay. Other EOAs control AllowList (freeze addresses), RedemptionIdle (withdraw USDC, pause redemptions), and Oracle (manipulate pricing). Mitigated by Turnkey secure enclaves but each remains a single point of failure.
 - **Admin burn capability** — The `adminBurn()` function can confiscate tokens from any holder. While documented as a regulatory compliance tool, this gives Superstate unilateral power over user funds.
-- **No upgrade delay** — Contract upgrades execute immediately with no timelock for users or protocols (like Aave, Morpho, Spark) to react.
+- **No upgrade delay** — All 3 proxy contracts (USTB Token, AllowList, RedemptionIdle) can be upgraded immediately with no timelock for users or protocols (like Aave, Morpho, Spark) to react.
 
 ---
 
@@ -307,37 +334,43 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 
 - [x] **No audit** → **PASS** — 11 audits by 3 firms + Certora formal verification. Great coverage.
 - [x] **Unverifiable reserves** → **PASS** — Off-chain reserves, but verified by independent NAV agent (NAV Consulting), annual EY audit, SEC regulatory framework, bankruptcy-remote trust structure. Chainlink NAV feed provides on-chain pricing. Not fully on-chain verifiable, but multiple independent verification layers.
-- [x] **Total centralization** → **BORDERLINE PASS** — Single EOA controls all admin functions with no multisig or timelock. However, Superstate is a U.S. corporation under SEC regulation, with registered transfer agent status, institutional custodian, and institutional-grade key management via Turnkey secure enclaves. The regulatory accountability and legal framework provide off-chain governance guarantees that partially compensate for the lack of on-chain governance.
+- [x] **Total centralization** → **BORDERLINE PASS** — 4 distinct EOAs control admin functions (token, allowlist, redemption, oracle) with no multisig or timelock on any. However, Superstate is a U.S. corporation under SEC regulation, with registered transfer agent status, institutional custodian, and institutional-grade key management via Turnkey secure enclaves. The separation across 4 keys and the regulatory accountability partially compensate for the lack of on-chain governance.
 
 **Result:** Protocol passes critical gates. Proceeding to category scoring with conservative bias on centralization.
 
 ### Category Scores
 
-#### Category 1: Audits & Historical Track Record (Weight: 20%) — **1.5**
+#### Category 1: Audits & Historical Track Record (Weight: 20%) — **1.25**
 
 | Aspect | Assessment |
 |--------|-----------|
 | Audits | 11 audits by 3 firms (0xMacro ×9, ChainSecurity, Offside Labs) + Certora formal verification. Continuous audit relationship — each version audited before deployment. |
 | Bug Bounty | Self-hosted, no formal monetary rewards. Weaker than Immunefi-style programs. |
-| Time in Production | Fund: ~13 months (Feb 2024). Contracts: ~15 months (Dec 2023). Multiple version upgrades, all audited. |
-| TVL | ~$650M+ total AUM, ~$572M on-chain TVL |
+| Time in Production | Fund: ~26 months (Feb 2024). Contracts: ~28 months (Dec 2023). Multiple version upgrades, all audited. |
+| TVL | ~$650M+ total AUM, ~$625M on-chain (56.59M USTB × $11.045 NAV) |
 | Historical Incidents | None. No security incidents, exploits, or adverse events. |
 
-Great audit coverage (11 audits + formal verification) is among the strongest in the RWA space. Clean operational history with significant AUM. The lack of a formal bug bounty with monetary rewards prevents a perfect score.
+**Subcategory A: Audits — 1.5** Great audit coverage (11 audits + formal verification) is among the strongest in the RWA space. The lack of a formal bug bounty with monetary rewards prevents a perfect score.
 
-**Score: 1.5/5**
+**Subcategory B: Historical — 1.0** Over 2 years in production with zero incidents and sustained TVL >$100M. Clean operational history across 5 token versions and 3 AllowList versions.
+
+**Score: (1.5 + 1.0) / 2 = 1.25/5**
 
 #### Category 2: Centralization & Control Risks (Weight: 30%) — **3.0**
 
 **Subcategory A: Governance — 4.0**
 
-- **Single EOA** (`0xad30...ca83`) controls all admin functions (mint, adminBurn, pause, oracle, stablecoin config) AND proxy upgrades. No multisig.
+- **4 distinct EOAs** control the system with no multisig on any:
+  - `0xad30...ca83` — USTB Token owner + USTB ProxyAdmin owner (mint, adminBurn, pause, oracle, stablecoin config, proxy upgrades)
+  - `0x7747...2bfe` — AllowList owner + AllowList ProxyAdmin owner (permissions, proxy upgrades)
+  - `0x8cf4...0765` — RedemptionIdle owner + RedemptionIdle ProxyAdmin owner (pause redemptions, withdraw USDC, set fees, proxy upgrades)
+  - `0x4B1d...1395` — Oracle owner (NAV checkpoints, price delta)
 - **No timelock** on any operation — upgrades, parameter changes, and critical functions execute immediately
 - No on-chain governance, no DAO, no community voting
-- AllowList controlled by a separate EOA (`0x7747...1bfe`) — also no multisig
-- **Positive:** Turnkey secure enclaves for key management, two-step ownership transfer, renounceOwnership disabled
+- **Positive:** Separation across 4 keys reduces single-key blast radius compared to a single EOA controlling everything
+- **Positive:** Turnkey secure enclaves for key management, two-step ownership transfer (`Ownable2StepUpgradeable`), `renounceOwnership` disabled
 - **Positive:** Regulatory accountability — Superstate is a U.S. corporation with SEC-registered transfer agent, subject to securities law enforcement
-- Despite regulatory mitigations, the on-chain governance structure is a single EOA with unchecked power
+- Despite regulatory mitigations and key separation, the on-chain governance remains EOA-controlled with no multisig or timelock on any contract
 
 **Subcategory B: Programmability — 2.0**
 
@@ -357,7 +390,7 @@ Great audit coverage (11 audits + formal verification) is among the strongest in
 - Chainlink: Established oracle network
 - All external dependencies are institutional-grade with long track records
 
-**Score: (4.0 + 2.0 + 2.0) / 3 = 2.67 → 3.0/5** — Rounded up to 3.0 due to the severity of the EOA-with-no-timelock governance issue, which is the dominant risk factor. While external dependencies and programmability are strong, the governance centralization drags the overall category.
+**Score: (4.0 + 2.0 + 2.0) / 3 = 2.67 → 3.0/5** — Rounded up to 3.0 due to the severity of the EOA-with-no-timelock governance issue, which is the dominant risk factor. The system is now confirmed to use 4 separate EOAs (reducing single-key blast radius compared to a single admin), but each contract still has one EOA with no multisig or timelock. While external dependencies and programmability are strong, the governance centralization drags the overall category.
 
 #### Category 3: Funds Management (Weight: 30%) — **2.25**
 
@@ -387,7 +420,7 @@ Great audit coverage (11 audits + formal verification) is among the strongest in
 
 #### Category 4: Liquidity Risk (Weight: 15%) — **3.0**
 
-- On-chain atomic redemption at NAV/S price via RedemptionIdle (~$10M USDC instant capacity)
+- On-chain atomic redemption at NAV/S price via RedemptionIdle (~$1.7M USDC instant capacity as of April 2026, varies as refilled)
 - Off-chain redemption: T+0 if before 9 AM EST on Market Days, otherwise T+1
 - No DEX liquidity whatsoever — $0 24h volume, not listed on any exchange
 - Transfers restricted to allowlisted addresses only — limits secondary market formation
@@ -417,20 +450,20 @@ Great audit coverage (11 audits + formal verification) is among the strongest in
 
 ```
 Final Score = (Audits × 0.20) + (Centralization × 0.30) + (Funds Mgmt × 0.30) + (Liquidity × 0.15) + (Operational × 0.05)
-            = (1.5 × 0.20) + (3.0 × 0.30) + (2.25 × 0.30) + (3.0 × 0.15) + (1.0 × 0.05)
-            = 0.30 + 0.90 + 0.675 + 0.45 + 0.05
-            = 2.375
-            ≈ 2.38
+            = (1.25 × 0.20) + (3.0 × 0.30) + (2.25 × 0.30) + (3.0 × 0.15) + (1.0 × 0.05)
+            = 0.25 + 0.90 + 0.675 + 0.45 + 0.05
+            = 2.325
+            ≈ 2.33
 ```
 
 | Category | Score | Weight | Weighted |
 |----------|-------|--------|----------|
-| Audits & Historical | 1.5 | 20% | 0.30 |
+| Audits & Historical | 1.25 | 20% | 0.25 |
 | Centralization & Control | 3.0 | 30% | 0.90 |
 | Funds Management | 2.25 | 30% | 0.675 |
 | Liquidity Risk | 3.0 | 15% | 0.45 |
 | Operational Risk | 1.0 | 5% | 0.05 |
-| **Final Score** | | | **2.38 / 5.0** |
+| **Final Score** | | | **2.33 / 5.0** |
 
 ### Risk Tier
 
@@ -444,15 +477,18 @@ Final Score = (Audits × 0.20) + (Centralization × 0.30) + (Funds Mgmt × 0.30)
 
 **Final Risk Tier: LOW RISK**
 
-USTB benefits from the safest possible underlying asset class (U.S. Treasury Bills), great audit coverage, institutional-grade service providers, and a strong legal structure. The primary risk factors are the centralized admin (single EOA with no multisig or timelock) and heavy off-chain dependencies for reserve provability (holdings gated behind investor portal, no Chainlink Proof of Reserves yet). These are partially mitigated by regulatory accountability, secure key management, and the institutional framework around the fund.
+USTB benefits from the safest possible underlying asset class (U.S. Treasury Bills), great audit coverage, institutional-grade service providers, a strong legal structure, and over 2 years of incident-free operation. The primary risk factors are the centralized admin (4 distinct EOAs with no multisig or timelock) and heavy off-chain dependencies for reserve provability (holdings gated behind investor portal, no Chainlink Proof of Reserves yet). These are partially mitigated by key separation across 4 EOAs, regulatory accountability, secure key management (Turnkey TEEs), and the institutional framework around the fund.
+
+**Score change from prior assessment (March 2026: 2.38 → April 2026: 2.33):** Driven by improved Historical subscore (>2 years in production, score 1 vs prior ~2) and updated on-chain verification revealing 4 separate EOAs (modest positive vs prior assumption).
 
 **Key conditions for exposure:**
 
-1. Monitor for any admin EOA changes (ownership transfer events)
-2. Monitor for contract upgrades (ProxyAdmin events)
-3. Monitor oracle changes and NAV/Share feed for anomalies
-4. Monitor RedemptionIdle USDC balance for redemption capacity
-5. Verify Superstate's regulatory standing periodically (SEC filings, transfer agent status)
+1. Monitor all 4 admin EOAs for ownership transfer events
+2. Monitor all 3 ProxyAdmins for contract upgrades (`Upgraded` events)
+3. Monitor Oracle for `NewCheckpoint` events and NAV/Share feed for anomalies
+4. Monitor RedemptionIdle USDC balance for redemption capacity (currently ~$1.7M)
+5. Monitor AllowList for `ProtocolAddressPermissionSet` changes affecting DeFi integrations
+6. Verify Superstate's regulatory standing periodically (SEC filings, transfer agent status)
 
 **Score-improving triggers:**
 
@@ -465,7 +501,7 @@ USTB benefits from the safest possible underlying asset class (U.S. Treasury Bil
 
 ## Reassessment Triggers
 
-- **Time-based:** Reassess in 6 months (September 2026) — longer interval given the stability of the underlying asset and regulatory framework
+- **Time-based:** Reassess in 6 months (October 2026) — longer interval given the stability of the underlying asset and regulatory framework
 - **TVL-based:** Reassess if AUM changes by more than 50%
 - **Incident-based:** Reassess after any exploit, admin key compromise, contract upgrade, governance change, or regulatory action
 - **Governance-based:** Reassess if Superstate adopts multisig, timelock, or other governance improvements (potential score improvement)
@@ -496,3 +532,102 @@ USTB benefits from the safest possible underlying asset class (U.S. Treasury Bil
 | ChainSecurity | 2023 | Compound SUPTB (original token) | [Report](https://www.chainsecurity.com/security-audit/compound-suptb) |
 | Offside Labs | May 2025 | Solana Allowlist | [Superstate Docs](https://docs.superstate.com/welcome-to-superstate/security) |
 | Certora | -- | Formal Verification | [Superstate Docs](https://docs.superstate.com/welcome-to-superstate/security) |
+
+## Appendix B — Contract Architecture
+
+*Verified on-chain April 7, 2026. All owners are EOAs (code size 0). No multisig, no timelock on any contract.*
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                          GOVERNANCE LAYER (4 EOAs)                          │
+│                                                                             │
+│  EOA 0xad30...ca83          EOA 0x7747...2bfe      EOA 0x8cf4...0765       │
+│  ├─ USTB Token owner        ├─ AllowList owner     ├─ RedemptionIdle owner │
+│  └─ USTB ProxyAdmin owner   └─ AL ProxyAdmin owner └─ RI ProxyAdmin owner │
+│                                                                             │
+│  EOA 0x4B1d...1395                                                         │
+│  └─ Oracle owner (addCheckpoint, setMaxAcceptablePriceDelta)               │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                          PROXY ADMIN LAYER                                  │
+│                                                                             │
+│  ProxyAdmin 0xb9d2...2146   ProxyAdmin 0xb819...c610  ProxyAdmin 0xcaba..69│
+│  └─ upgrade(USTB Proxy)     └─ upgrade(AllowList)      └─ upgrade(Redemp.) │
+│     upgradeAndCall()           upgradeAndCall()            upgradeAndCall() │
+│     changeProxyAdmin()         changeProxyAdmin()          changeProxyAdmin │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                          TOKEN LAYER                                        │
+│                                                                             │
+│  ┌──────────────────────────────────────────────────────┐                  │
+│  │  USTB Token (Proxy) 0x4341...1C4e                    │                  │
+│  │  impl: SuperstateTokenV5_1 (VERSION "5")             │                  │
+│  │                                                       │                  │
+│  │  Admin (owner only):                                  │                  │
+│  │  ├── mint() / bulkMint()                              │                  │
+│  │  ├── adminBurn(address, amount)                       │                  │
+│  │  ├── pause() / unpause()                              │                  │
+│  │  ├── accountingPause() / accountingUnpause()          │                  │
+│  │  ├── setOracle(newOracle)                             │                  │
+│  │  ├── setRedemptionContract(newContract)               │                  │
+│  │  ├── setStablecoinConfig(stablecoin, dest, fee)       │                  │
+│  │  ├── setChainIdSupport(chainId, supported)            │                  │
+│  │  └── setMaximumOracleDelay(delay)                     │                  │
+│  │                                                       │                  │
+│  │  User functions (AllowList-gated):                    │                  │
+│  │  ├── subscribe(to, amount, stablecoin)                │                  │
+│  │  ├── offchainRedeem(amount)                           │                  │
+│  │  ├── bridge(amount, dest, chainId)                    │                  │
+│  │  └── transfer / transferFrom                          │                  │
+│  └──────────┬──────────┬─────────────┬──────────────────┘                  │
+│             │          │             │                                       │
+│        reads│     reads│        reads│                                       │
+│             ▼          ▼             ▼                                       │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                      PROTOCOL LAYER                                         │
+│                                                                             │
+│  ┌───────────────────┐  ┌──────────────────────┐  ┌─────────────────────┐  │
+│  │ AllowList V3.1     │  │ SuperstateOracle     │  │ RedemptionIdle      │  │
+│  │ (Proxy) 0x02f1..e5│  │ 0xe4fa..28a8         │  │ (Proxy) 0x4c21..cf  │  │
+│  │                    │  │ (NOT a proxy)        │  │                     │  │
+│  │ Admin:             │  │                      │  │ Admin (owner):      │  │
+│  │ ├ setEntityId..()  │  │ Admin (owner):       │  │ ├ pause/unpause()   │  │
+│  │ ├ setEntity..Pub() │  │ ├ addCheckpoint()    │  │ ├ setRedemptionFee()│  │
+│  │ ├ setEntity..Priv()│  │ ├ addCheckpoints()   │  │ ├ setSweepDest()    │  │
+│  │ ├ setProtocol..()  │  │ ├ setMaxAcceptable.. │  │ ├ setMaxOracleDelay │  │
+│  │ └ transferOwner()  │  │ └ transferOwner()    │  │ ├ withdraw()        │  │
+│  │                    │  │                      │  │ └ transferOwner()   │  │
+│  │ Gating:            │  │ Exposes:             │  │                     │  │
+│  │ isAddressAllowed   │  │ latestRoundData()    │  │ User:               │  │
+│  │ ForFund("USTB")    │  │ (Chainlink-compat)   │  │ └ redeem(amount)    │  │
+│  │ hasAnyProtocol     │  │                      │  │                     │  │
+│  │ Permissions()      │  │ NAV: $11.045/share   │  │ USDC bal: ~$1.7M    │  │
+│  └───────────────────┘  │ Expiry: 5 days       │  │ Oracle delay: 1h    │  │
+│                          └──────────────────────┘  │ Fee: 0              │  │
+│                                                     └─────────────────────┘  │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                      EXTERNAL / UNDERLYING LAYER                            │
+│                                                                             │
+│  ┌────────────┐  ┌──────────────┐  ┌───────────────────────────────────┐   │
+│  │ USDC       │  │ Chainlink    │  │ Off-chain                        │   │
+│  │ 0xA0b8..48 │  │ NAV Feed     │  │ ├── UMB Bank (custodian)         │   │
+│  │            │  │ 0x289B..AAC  │  │ ├── Federated Hermes (sub-adv)   │   │
+│  │ Used for:  │  │              │  │ ├── Ernst & Young (auditor)       │   │
+│  │ subscribe  │  │ Independent  │  │ ├── NAV Consulting (NAV agent)   │   │
+│  │ redeem     │  │ NAV source   │  │ └── U.S. Treasury Bills (~95%)   │   │
+│  └────────────┘  └──────────────┘  └───────────────────────────────────┘   │
+│                                                                             │
+│  Sweep destination (subscription + redemption USDC):                        │
+│  EOA 0x774A...8807                                                          │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Proxy Upgrade Paths
+
+Each proxy can be upgraded immediately (no timelock) by its ProxyAdmin owner:
+
+| Proxy | ProxyAdmin | Owner (EOA) | Functions |
+|-------|-----------|-------------|-----------|
+| USTB Token `0x4341...1C4e` | `0xb9d2...2146` | `0xad30...ca83` | `upgrade()`, `upgradeAndCall()`, `changeProxyAdmin()` |
+| AllowList `0x02f1...38e5` | `0xb819...c610` | `0x7747...2bfe` | `upgrade()`, `upgradeAndCall()`, `changeProxyAdmin()` |
+| RedemptionIdle `0x4c21...54cf` | `0xcaba...e869` | `0x8cf4...0765` | `upgrade()`, `upgradeAndCall()`, `changeProxyAdmin()` |
+
+The Oracle (`0xe4fa...28a8`) is **not a proxy** and cannot be upgraded. However, the USTB Token owner can replace it entirely via `setOracle(newAddress)`.

--- a/reports/report/superstate-ustb.md
+++ b/reports/report/superstate-ustb.md
@@ -137,7 +137,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
   - **Off-chain:** USD wire transfer, processed on Market Days (NYSE/Federal Reserve open days).
   - Max subscription fee: 0.1% (10 bps), configurable per stablecoin.
 - **Redemptions (Burning):**
-  - **On-chain atomic:** Via RedemptionIdle contract, burns USTB and sends USDC at Continuous NAV/S price. USDC instant redemption facility (~$1.7M as of April 2026), regularly replenished.
+  - **On-chain atomic:** Via RedemptionIdle contract, burns USTB and sends USDC at Continuous NAV/S price. USDC instant redemption facility with variable capacity (currently ~$1.7M as of April 2026, verified on-chain via `balanceOf()`). [Docs](https://docs.superstate.com/welcome-to-superstate/smart-contracts) state: "USDC liquidity will be replenished in this contract regularly" — no specific target capacity is documented.
   - **Off-chain:** Transfer tokens to contract address or call `offchainRedeem()`. Proceeds in USDC or USD wire. T+0 if before 9:00 AM EST on Market Days, otherwise T+1.
   - No redemption fees for standard redemptions.
 - **Geographic Restrictions:** Available to qualified purchasers in the U.S. and select offshore jurisdictions (Cayman Islands, BVI, Bermuda). Not available to sanctioned countries.
@@ -211,11 +211,11 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 
 **Critical centralization concerns:**
 
-1. **EOA-controlled administration** — The system is controlled by **4 distinct EOAs**, each with no multisig, no timelock, and no governance delay. The USTB Token Owner (`0xad30...ca83`) controls minting, burning from any address, pausing all operations, changing the oracle, and upgrading the USTB contract implementation. Separate EOAs control the AllowList, RedemptionIdle, and Oracle — splitting control across more keys reduces single-key blast radius but none have multisig protection.
+1. **EOA-controlled administration** — The system is controlled by **4 distinct EOAs**, each with no multisig, no timelock, and no governance delay. The USTB Token Owner (`0xad309bb6f13074128b4f23ef9ea2fe8552afca83`) controls minting, burning from any address, pausing all operations, changing the oracle, and upgrading the USTB contract implementation. Separate EOAs control the AllowList, RedemptionIdle, and Oracle — splitting control across more keys reduces single-key blast radius but none have multisig protection.
 2. **Admin burn capability** — The owner can call `adminBurn(address, uint256)` to forcibly burn tokens from any holder's address. This is documented as being for "exogenous legal circumstances" (regulatory compliance).
 3. **No timelock on any operation** — Contract upgrades, parameter changes, and critical admin functions execute immediately with no delay period for users to react.
 4. **AllowList control** — Removing an address from the AllowList effectively freezes their tokens (they cannot transfer or redeem). This is a compliance feature but also a centralization vector.
-5. **Oracle pricing control** — The Oracle Owner (`0x4B1d...1395`) controls NAV checkpoints via `addCheckpoint()`. While the oracle uses programmatic linear interpolation between checkpoints, the checkpoint values themselves are set by this EOA. A malicious or compromised oracle owner could post incorrect NAV values affecting subscription/redemption pricing.
+5. **Oracle pricing control** — The Oracle Owner (`0x4B1df64357a5D484563c9b7c16a80eD8B8fB1395`) controls NAV checkpoints via `addCheckpoint()`. While the oracle uses programmatic linear interpolation between checkpoints, the checkpoint values themselves are set by this EOA. A malicious or compromised oracle owner could post incorrect NAV values affecting subscription/redemption pricing.
 
 **Mitigations:**
 
@@ -292,7 +292,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 - **NAV/Share:** Track Continuous Price Oracle (`latestRoundData()`) and Chainlink feed — should increase monotonically. Alert on any decrease (would indicate fund losses). Current: ~$11.045. Checkpoint expiration: 5 days.
 - **Admin Burns:** Monitor `AdminBurn` events — forced burns from holder addresses are a critical event.
 - **Pause Events:** Monitor `Paused`/`Unpaused` and `AccountingPaused`/`AccountingUnpaused` on USTB Token AND RedemptionIdle.
-- **Contract Upgrades:** Monitor **all 3 ProxyAdmins** for `Upgraded` events — USTB ProxyAdmin (`0xb9d2...2146`), AllowList ProxyAdmin (`0xb819...c610`), and RedemptionIdle ProxyAdmin (`0xcaba...e869`). Any proxy upgrade executes immediately with no timelock.
+- **Contract Upgrades:** Monitor **all 3 ProxyAdmins** for `Upgraded` events — USTB ProxyAdmin (`0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146`), AllowList ProxyAdmin (`0xb819692a58db9dd4d3b403a875439b6ca155c610`), and RedemptionIdle ProxyAdmin (`0xcaba8c12873fffed13431d98bf6b836dff08e869`). Any proxy upgrade executes immediately with no timelock.
 - **Oracle Changes:** Monitor `SetOracle` events on USTB Token and `NewCheckpoint` events on the Oracle. Monitor `SetMaximumAcceptablePriceDelta` on Oracle (current: $1.00).
 - **AllowList Changes:** Monitor `ProtocolAddressPermissionSet` and `EntityIdSet` events, especially protocol address permissions (DeFi integrations).
 - **Redemption Capacity:** Monitor USDC `balanceOf()` on RedemptionIdle — current ~$1.7M. Also monitor `Withdraw` events (owner can extract USDC) and `SetRedemptionFee` (currently 0).
@@ -322,7 +322,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 ### Critical Risks
 
 - **AllowList freeze risk** — If Superstate removes an address from the AllowList, the holder's tokens are **completely frozen with zero exit paths**. No transfers, no redemption, no DEX fallback. For DeFi protocols integrating USTB, this means Superstate has unilateral power to freeze an entire protocol's USTB position.
-- **Private key compromise** — 4 separate EOAs control different parts of the system. Compromise of `0xad30...ca83` alone could upgrade the USTB token to malicious code, mint unlimited tokens, or burn tokens from any address, all with no delay. Other EOAs control AllowList (freeze addresses), RedemptionIdle (withdraw USDC, pause redemptions), and Oracle (manipulate pricing). Mitigated by Turnkey secure enclaves but each remains a single point of failure.
+- **Private key compromise** — 4 separate EOAs control different parts of the system. Compromise of `0xad309bb6f13074128b4f23ef9ea2fe8552afca83` alone could upgrade the USTB token to malicious code, mint unlimited tokens, or burn tokens from any address, all with no delay. Other EOAs control AllowList (freeze addresses), RedemptionIdle (withdraw USDC, pause redemptions), and Oracle (manipulate pricing). Mitigated by Turnkey secure enclaves but each remains a single point of failure.
 - **Admin burn capability** — The `adminBurn()` function can confiscate tokens from any holder. While documented as a regulatory compliance tool, this gives Superstate unilateral power over user funds.
 - **No upgrade delay** — All 3 proxy contracts (USTB Token, AllowList, RedemptionIdle) can be upgraded immediately with no timelock for users or protocols (like Aave, Morpho, Spark) to react.
 
@@ -346,7 +346,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 |--------|-----------|
 | Audits | 11 audits by 3 firms (0xMacro ×9, ChainSecurity, Offside Labs) + Certora formal verification. Continuous audit relationship — each version audited before deployment. |
 | Bug Bounty | Self-hosted, no formal monetary rewards. Weaker than Immunefi-style programs. |
-| Time in Production | Fund: ~26 months (Feb 2024). Contracts: ~28 months (Dec 2023). Multiple version upgrades, all audited. |
+| Time in Production | ~25 months with TVL >$1M (since Feb 2024 — DeFiLlama first data point Mar 8, 2024 already at ~$38M). Contracts deployed Dec 2023. Multiple version upgrades, all audited. |
 | TVL | ~$650M+ total AUM, ~$625M on-chain (56.59M USTB × $11.045 NAV) |
 | Historical Incidents | None. No security incidents, exploits, or adverse events. |
 
@@ -361,10 +361,10 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 **Subcategory A: Governance — 4.0**
 
 - **4 distinct EOAs** control the system with no multisig on any:
-  - `0xad30...ca83` — USTB Token owner + USTB ProxyAdmin owner (mint, adminBurn, pause, oracle, stablecoin config, proxy upgrades)
-  - `0x7747...2bfe` — AllowList owner + AllowList ProxyAdmin owner (permissions, proxy upgrades)
-  - `0x8cf4...0765` — RedemptionIdle owner + RedemptionIdle ProxyAdmin owner (pause redemptions, withdraw USDC, set fees, proxy upgrades)
-  - `0x4B1d...1395` — Oracle owner (NAV checkpoints, price delta)
+  - `0xad309bb6f13074128b4f23ef9ea2fe8552afca83` — USTB Token owner + USTB ProxyAdmin owner (mint, adminBurn, pause, oracle, stablecoin config, proxy upgrades)
+  - `0x7747940adbc7191f877a9b90596e0da4f8deb2fe` — AllowList owner + AllowList ProxyAdmin owner (permissions, proxy upgrades)
+  - `0x8cf40e96e7d7fd8A7A9bEf70d3882fbBC4D40765` — RedemptionIdle owner + RedemptionIdle ProxyAdmin owner (pause redemptions, withdraw USDC, set fees, proxy upgrades)
+  - `0x4B1df64357a5D484563c9b7c16a80eD8B8fB1395` — Oracle owner (NAV checkpoints, price delta)
 - **No timelock** on any operation — upgrades, parameter changes, and critical functions execute immediately
 - No on-chain governance, no DAO, no community voting
 - **Positive:** Separation across 4 keys reduces single-key blast radius compared to a single EOA controlling everything
@@ -448,14 +448,6 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 
 ### Final Score Calculation
 
-```
-Final Score = (Audits × 0.20) + (Centralization × 0.30) + (Funds Mgmt × 0.30) + (Liquidity × 0.15) + (Operational × 0.05)
-            = (1.25 × 0.20) + (3.0 × 0.30) + (2.25 × 0.30) + (3.0 × 0.15) + (1.0 × 0.05)
-            = 0.25 + 0.90 + 0.675 + 0.45 + 0.05
-            = 2.325
-            ≈ 2.33
-```
-
 | Category | Score | Weight | Weighted |
 |----------|-------|--------|----------|
 | Audits & Historical | 1.25 | 20% | 0.25 |
@@ -538,87 +530,98 @@ USTB benefits from the safest possible underlying asset class (U.S. Treasury Bil
 *Verified on-chain April 7, 2026. All owners are EOAs (code size 0). No multisig, no timelock on any contract.*
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                          GOVERNANCE LAYER (4 EOAs)                          │
-│                                                                             │
-│  EOA 0xad30...ca83          EOA 0x7747...2bfe      EOA 0x8cf4...0765       │
-│  ├─ USTB Token owner        ├─ AllowList owner     ├─ RedemptionIdle owner │
-│  └─ USTB ProxyAdmin owner   └─ AL ProxyAdmin owner └─ RI ProxyAdmin owner │
-│                                                                             │
-│  EOA 0x4B1d...1395                                                         │
-│  └─ Oracle owner (addCheckpoint, setMaxAcceptablePriceDelta)               │
-├─────────────────────────────────────────────────────────────────────────────┤
-│                          PROXY ADMIN LAYER                                  │
-│                                                                             │
-│  ProxyAdmin 0xb9d2...2146   ProxyAdmin 0xb819...c610  ProxyAdmin 0xcaba..69│
-│  └─ upgrade(USTB Proxy)     └─ upgrade(AllowList)      └─ upgrade(Redemp.) │
-│     upgradeAndCall()           upgradeAndCall()            upgradeAndCall() │
-│     changeProxyAdmin()         changeProxyAdmin()          changeProxyAdmin │
-├─────────────────────────────────────────────────────────────────────────────┤
-│                          TOKEN LAYER                                        │
-│                                                                             │
-│  ┌──────────────────────────────────────────────────────┐                  │
-│  │  USTB Token (Proxy) 0x4341...1C4e                    │                  │
-│  │  impl: SuperstateTokenV5_1 (VERSION "5")             │                  │
-│  │                                                       │                  │
-│  │  Admin (owner only):                                  │                  │
-│  │  ├── mint() / bulkMint()                              │                  │
-│  │  ├── adminBurn(address, amount)                       │                  │
-│  │  ├── pause() / unpause()                              │                  │
-│  │  ├── accountingPause() / accountingUnpause()          │                  │
-│  │  ├── setOracle(newOracle)                             │                  │
-│  │  ├── setRedemptionContract(newContract)               │                  │
-│  │  ├── setStablecoinConfig(stablecoin, dest, fee)       │                  │
-│  │  ├── setChainIdSupport(chainId, supported)            │                  │
-│  │  └── setMaximumOracleDelay(delay)                     │                  │
-│  │                                                       │                  │
-│  │  User functions (AllowList-gated):                    │                  │
-│  │  ├── subscribe(to, amount, stablecoin)                │                  │
-│  │  ├── offchainRedeem(amount)                           │                  │
-│  │  ├── bridge(amount, dest, chainId)                    │                  │
-│  │  └── transfer / transferFrom                          │                  │
-│  └──────────┬──────────┬─────────────┬──────────────────┘                  │
-│             │          │             │                                       │
-│        reads│     reads│        reads│                                       │
-│             ▼          ▼             ▼                                       │
-├─────────────────────────────────────────────────────────────────────────────┤
-│                      PROTOCOL LAYER                                         │
-│                                                                             │
-│  ┌───────────────────┐  ┌──────────────────────┐  ┌─────────────────────┐  │
-│  │ AllowList V3.1     │  │ SuperstateOracle     │  │ RedemptionIdle      │  │
-│  │ (Proxy) 0x02f1..e5│  │ 0xe4fa..28a8         │  │ (Proxy) 0x4c21..cf  │  │
-│  │                    │  │ (NOT a proxy)        │  │                     │  │
-│  │ Admin:             │  │                      │  │ Admin (owner):      │  │
-│  │ ├ setEntityId..()  │  │ Admin (owner):       │  │ ├ pause/unpause()   │  │
-│  │ ├ setEntity..Pub() │  │ ├ addCheckpoint()    │  │ ├ setRedemptionFee()│  │
-│  │ ├ setEntity..Priv()│  │ ├ addCheckpoints()   │  │ ├ setSweepDest()    │  │
-│  │ ├ setProtocol..()  │  │ ├ setMaxAcceptable.. │  │ ├ setMaxOracleDelay │  │
-│  │ └ transferOwner()  │  │ └ transferOwner()    │  │ ├ withdraw()        │  │
-│  │                    │  │                      │  │ └ transferOwner()   │  │
-│  │ Gating:            │  │ Exposes:             │  │                     │  │
-│  │ isAddressAllowed   │  │ latestRoundData()    │  │ User:               │  │
-│  │ ForFund("USTB")    │  │ (Chainlink-compat)   │  │ └ redeem(amount)    │  │
-│  │ hasAnyProtocol     │  │                      │  │                     │  │
-│  │ Permissions()      │  │ NAV: $11.045/share   │  │ USDC bal: ~$1.7M    │  │
-│  └───────────────────┘  │ Expiry: 5 days       │  │ Oracle delay: 1h    │  │
-│                          └──────────────────────┘  │ Fee: 0              │  │
-│                                                     └─────────────────────┘  │
-├─────────────────────────────────────────────────────────────────────────────┤
-│                      EXTERNAL / UNDERLYING LAYER                            │
-│                                                                             │
-│  ┌────────────┐  ┌──────────────┐  ┌───────────────────────────────────┐   │
-│  │ USDC       │  │ Chainlink    │  │ Off-chain                        │   │
-│  │ 0xA0b8..48 │  │ NAV Feed     │  │ ├── UMB Bank (custodian)         │   │
-│  │            │  │ 0x289B..AAC  │  │ ├── Federated Hermes (sub-adv)   │   │
-│  │ Used for:  │  │              │  │ ├── Ernst & Young (auditor)       │   │
-│  │ subscribe  │  │ Independent  │  │ ├── NAV Consulting (NAV agent)   │   │
-│  │ redeem     │  │ NAV source   │  │ └── U.S. Treasury Bills (~95%)   │   │
-│  └────────────┘  └──────────────┘  └───────────────────────────────────┘   │
-│                                                                             │
-│  Sweep destination (subscription + redemption USDC):                        │
-│  EOA 0x774A...8807                                                          │
-└─────────────────────────────────────────────────────────────────────────────┘
+GOVERNANCE LAYER (4 EOAs — all code size 0, no multisig)
+═══════════════════════════════════════════════════════════
+
+  [EOA-1] USTB Token owner + USTB ProxyAdmin owner
+  [EOA-2] AllowList owner + AllowList ProxyAdmin owner
+  [EOA-3] RedemptionIdle owner + RedemptionIdle ProxyAdmin owner
+  [EOA-4] Oracle owner (addCheckpoint, setMaxAcceptablePriceDelta)
+          │               │                │               │
+          ▼               ▼                ▼               │
+PROXY ADMIN LAYER                                          │
+═════════════════                                          │
+                                                           │
+  [PA-1] upgrade(USTB)       ← owned by [EOA-1]           │
+  [PA-2] upgrade(AllowList)  ← owned by [EOA-2]           │
+  [PA-3] upgrade(Redemption) ← owned by [EOA-3]           │
+          │               │                │               │
+          ▼               ▼                ▼               │
+TOKEN LAYER                                                │
+═══════════                                                │
+                                                           │
+  [USTB] USTB Token (Proxy)                                │
+  impl: SuperstateTokenV5_1 (VERSION "5")                  │
+                                                           │
+  Admin (owner [EOA-1] only):                              │
+  ├── mint() / bulkMint()  ← no backing check on-chain    │
+  ├── adminBurn(address, amount)                           │
+  ├── pause() / unpause()                                  │
+  ├── accountingPause() / accountingUnpause()              │
+  ├── setOracle(newOracle)                                 │
+  ├── setRedemptionContract(newContract)                   │
+  ├── setStablecoinConfig(stablecoin, dest, fee)           │
+  ├── setChainIdSupport(chainId, supported)                │
+  └── setMaximumOracleDelay(delay)                         │
+                                                           │
+  User functions (AllowList-gated):                        │
+  ├── subscribe(to, amount, stablecoin)                    │
+  ├── offchainRedeem(amount)                               │
+  ├── bridge(amount, dest, chainId)                        │
+  └── transfer / transferFrom                              │
+          │               │                │               │
+     reads│          reads│           reads│               │
+          ▼               ▼                ▼               ▼
+PROTOCOL LAYER
+══════════════
+
+  [AL] AllowList V3.1 (Proxy)    [ORC] SuperstateOracle      [RI] RedemptionIdle (Proxy)
+  owner: [EOA-2]                  (NOT a proxy)                owner: [EOA-3]
+                                  owner: [EOA-4]
+  Admin:                                                       Admin:
+  ├ setEntityIdForAddress()       Admin:                       ├ pause/unpause()
+  ├ setEntityAllowedFor           ├ addCheckpoint()            ├ setRedemptionFee()
+  │ PublicInstrument()            ├ addCheckpoints()           ├ setSweepDestination()
+  ├ setEntityAllowedFor           ├ setMaxAcceptable           ├ setMaximumOracleDelay()
+  │ PrivateInstrument()           │ PriceDelta()               ├ withdraw()
+  ├ setProtocolAddress            └ transferOwnership()        └ transferOwnership()
+  │ Permission()
+  └ transferOwnership()           Exposes:                     User:
+                                  latestRoundData()            └ redeem(amount)
+  Gating:                         (Chainlink-compat)
+  isAddressAllowedForFund()                                    USDC bal: ~$1.7M
+  hasAnyProtocolPermissions()     NAV: $11.045/share           Oracle delay: 1h
+                                  Expiry: 5 days               Fee: 0
+
+EXTERNAL / UNDERLYING LAYER
+════════════════════════════
+
+  [USDC] USDC                 [CL] Chainlink NAV Feed       Off-chain
+  Used for subscribe/redeem   Independent NAV source         ├── UMB Bank (custodian)
+                                                             ├── Federated Hermes (sub-adv)
+  [SWEEP] Sweep destination                                  ├── Ernst & Young (auditor)
+  (subscription + redemption USDC)                           ├── NAV Consulting (NAV agent)
+                                                             └── U.S. Treasury Bills (~95%)
 ```
+
+**Address Legend:**
+
+| Label | Address |
+|-------|---------|
+| [EOA-1] | [`0xad309bb6f13074128b4f23ef9ea2fe8552afca83`](https://etherscan.io/address/0xad309bb6f13074128b4f23ef9ea2fe8552afca83) |
+| [EOA-2] | [`0x7747940adbc7191f877a9b90596e0da4f8deb2fe`](https://etherscan.io/address/0x7747940adbc7191f877a9b90596e0da4f8deb2fe) |
+| [EOA-3] | [`0x8cf40e96e7d7fd8A7A9bEf70d3882fbBC4D40765`](https://etherscan.io/address/0x8cf40e96e7d7fd8A7A9bEf70d3882fbBC4D40765) |
+| [EOA-4] | [`0x4B1df64357a5D484563c9b7c16a80eD8B8fB1395`](https://etherscan.io/address/0x4B1df64357a5D484563c9b7c16a80eD8B8fB1395) |
+| [PA-1] USTB ProxyAdmin | [`0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146`](https://etherscan.io/address/0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146) |
+| [PA-2] AllowList ProxyAdmin | [`0xb819692a58db9dd4d3b403a875439b6ca155c610`](https://etherscan.io/address/0xb819692a58db9dd4d3b403a875439b6ca155c610) |
+| [PA-3] RedemptionIdle ProxyAdmin | [`0xcaba8c12873fffed13431d98bf6b836dff08e869`](https://etherscan.io/address/0xcaba8c12873fffed13431d98bf6b836dff08e869) |
+| [USTB] USTB Token (Proxy) | [`0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e`](https://etherscan.io/address/0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e) |
+| [AL] AllowList V3.1 (Proxy) | [`0x02f1fa8b196d21c7b733eb2700b825611d8a38e5`](https://etherscan.io/address/0x02f1fa8b196d21c7b733eb2700b825611d8a38e5) |
+| [ORC] SuperstateOracle | [`0xe4fa682f94610ccd170680cc3b045d77d9e528a8`](https://etherscan.io/address/0xe4fa682f94610ccd170680cc3b045d77d9e528a8) |
+| [RI] RedemptionIdle (Proxy) | [`0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf`](https://etherscan.io/address/0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf) |
+| [CL] Chainlink NAV Feed | [`0x289B5036cd942e619E1Ee48670F98d214E745AAC`](https://etherscan.io/address/0x289B5036cd942e619E1Ee48670F98d214E745AAC) |
+| [USDC] USDC | [`0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`](https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48) |
+| [SWEEP] Sweep Destination (EOA) | [`0x774AE279c21B6a17a6E2BD5ab5398FF98F398807`](https://etherscan.io/address/0x774AE279c21B6a17a6E2BD5ab5398FF98F398807) |
 
 ### Proxy Upgrade Paths
 
@@ -626,8 +629,8 @@ Each proxy can be upgraded immediately (no timelock) by its ProxyAdmin owner:
 
 | Proxy | ProxyAdmin | Owner (EOA) | Functions |
 |-------|-----------|-------------|-----------|
-| USTB Token `0x4341...1C4e` | `0xb9d2...2146` | `0xad30...ca83` | `upgrade()`, `upgradeAndCall()`, `changeProxyAdmin()` |
-| AllowList `0x02f1...38e5` | `0xb819...c610` | `0x7747...2bfe` | `upgrade()`, `upgradeAndCall()`, `changeProxyAdmin()` |
-| RedemptionIdle `0x4c21...54cf` | `0xcaba...e869` | `0x8cf4...0765` | `upgrade()`, `upgradeAndCall()`, `changeProxyAdmin()` |
+| USTB Token [`0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e`](https://etherscan.io/address/0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e) | [`0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146`](https://etherscan.io/address/0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146) | [`0xad309bb6f13074128b4f23ef9ea2fe8552afca83`](https://etherscan.io/address/0xad309bb6f13074128b4f23ef9ea2fe8552afca83) | `upgrade()`, `upgradeAndCall()`, `changeProxyAdmin()` |
+| AllowList [`0x02f1fa8b196d21c7b733eb2700b825611d8a38e5`](https://etherscan.io/address/0x02f1fa8b196d21c7b733eb2700b825611d8a38e5) | [`0xb819692a58db9dd4d3b403a875439b6ca155c610`](https://etherscan.io/address/0xb819692a58db9dd4d3b403a875439b6ca155c610) | [`0x7747940adbc7191f877a9b90596e0da4f8deb2fe`](https://etherscan.io/address/0x7747940adbc7191f877a9b90596e0da4f8deb2fe) | `upgrade()`, `upgradeAndCall()`, `changeProxyAdmin()` |
+| RedemptionIdle [`0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf`](https://etherscan.io/address/0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf) | [`0xcaba8c12873fffed13431d98bf6b836dff08e869`](https://etherscan.io/address/0xcaba8c12873fffed13431d98bf6b836dff08e869) | [`0x8cf40e96e7d7fd8A7A9bEf70d3882fbBC4D40765`](https://etherscan.io/address/0x8cf40e96e7d7fd8A7A9bEf70d3882fbBC4D40765) | `upgrade()`, `upgradeAndCall()`, `changeProxyAdmin()` |
 
-The Oracle (`0xe4fa...28a8`) is **not a proxy** and cannot be upgraded. However, the USTB Token owner can replace it entirely via `setOracle(newAddress)`.
+The Oracle ([`0xe4fa682f94610ccd170680cc3b045d77d9e528a8`](https://etherscan.io/address/0xe4fa682f94610ccd170680cc3b045d77d9e528a8)) is **not a proxy** and cannot be upgraded. However, the USTB Token owner can replace it entirely via `setOracle(newAddress)`.

--- a/reports/report/superstate-ustb.md
+++ b/reports/report/superstate-ustb.md
@@ -153,7 +153,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 
 ### Provability
 
-- **NAV/Price Updates:** The Superstate Continuous Price Oracle ([`0xe4fa682f94610ccd170680cc3b045d77d9e528a8`](https://etherscan.io/address/0xe4fa682f94610ccd170680cc3b045d77d9e528a8)) extrapolates real-time prices using linear interpolation between NAV/S checkpoints. Updates every second, 24/7/365. Compatible with Chainlink AggregatorV3Interface. **Note:** Since prices are linearly interpolated between checkpoints, the on-chain price is an estimate that may diverge from the actual NAV between checkpoint updates — the price catches up only when the next checkpoint is posted by Superstate.
+- **NAV/Price Updates:** The Superstate Continuous Price Oracle ([`0xe4fa682f94610ccd170680cc3b045d77d9e528a8`](https://etherscan.io/address/0xe4fa682f94610ccd170680cc3b045d77d9e528a8)) extrapolates real-time prices using linear interpolation between NAV/S checkpoints. Updates every second, 24/7/365. Compatible with Chainlink AggregatorV3Interface. **Checkpoint expiration: 5 days** — if the Oracle Owner does not post a new checkpoint within 5 days, `latestRoundData()` reverts with `StaleCheckpoint()`, which causes both `subscribe()` and `redeem()` to revert, freezing all on-chain USTB operations. The 5-day window covers weekends and U.S. holidays. **Note:** Since prices are linearly interpolated between checkpoints, the on-chain price is an estimate that may diverge from the actual NAV between checkpoint updates — the price catches up only when the next checkpoint is posted by Superstate.
 - **Chainlink NAV Feed:** Chainlink provides an independent NAV/Share data feed ([`0x289B5036cd942e619E1Ee48670F98d214E745AAC`](https://etherscan.io/address/0x289B5036cd942e619E1Ee48670F98d214E745AAC)).
 - **On-chain Supply:** Total USTB supply is verifiable on-chain via `totalSupply()`.
 - **Off-chain Assets:** The underlying Treasury portfolio is held off-chain at UMB Bank. Token holders cannot independently verify the specific Treasury holdings on-chain. However:
@@ -289,7 +289,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 
 ### Critical Monitoring Points
 
-- **NAV/Share:** Track Continuous Price Oracle (`latestRoundData()`) and Chainlink feed — should increase monotonically. Alert on any decrease (would indicate fund losses). Current: ~$11.045. Checkpoint expiration: 5 days.
+- **NAV/Share:** Track Continuous Price Oracle (`latestRoundData()`) and Chainlink feed — should increase monotonically. Alert on any decrease (would indicate fund losses). Current: ~$11.045. **Staleness alert:** if no `NewCheckpoint` event within ~3 days, `latestRoundData()` will revert after 5 days, freezing subscribe/redeem.
 - **Admin Burns:** Monitor `AdminBurn` events — forced burns from holder addresses are a critical event.
 - **Pause Events:** Monitor `Paused`/`Unpaused` and `AccountingPaused`/`AccountingUnpaused` on USTB Token AND RedemptionIdle.
 - **Contract Upgrades:** Monitor **all 3 ProxyAdmins** for `Upgraded` events — USTB ProxyAdmin (`0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146`), AllowList ProxyAdmin (`0xb819692a58db9dd4d3b403a875439b6ca155c610`), and RedemptionIdle ProxyAdmin (`0xcaba8c12873fffed13431d98bf6b836dff08e869`). Any proxy upgrade executes immediately with no timelock.

--- a/reports/report/superstate-ustb.md
+++ b/reports/report/superstate-ustb.md
@@ -289,7 +289,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 
 ### Critical Monitoring Points
 
-- **NAV/Share:** Track Continuous Price Oracle (`latestRoundData()`) and Chainlink feed — should increase monotonically. Alert on any decrease (would indicate fund losses). Current: ~$11.045. **Staleness alert:** if no `NewCheckpoint` event within 4 days, send alert — `latestRoundData()` will revert after 5 days, freezing subscribe/redeem.
+- **NAV/Share:** Track Continuous Price Oracle (`latestRoundData()`) and Chainlink feed — should increase monotonically. Alert on any decrease (would indicate fund losses). Current: ~$11.045. **Staleness check:** read `checkpoints(latestRoundData().roundId).effectiveAt`, compute `block.timestamp - effectiveAt`; alert if > 4 days (345600s) — oracle reverts `StaleCheckpoint()` at 5 days (432000s), freezing subscribe/redeem.
 - **Admin Burns:** Monitor `AdminBurn` events — forced burns from holder addresses are a critical event.
 - **Pause Events:** Monitor `Paused`/`Unpaused` and `AccountingPaused`/`AccountingUnpaused` on USTB Token AND RedemptionIdle.
 - **Contract Upgrades:** Monitor **all 3 ProxyAdmins** for `Upgraded` events — USTB ProxyAdmin (`0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146`), AllowList ProxyAdmin (`0xb819692a58db9dd4d3b403a875439b6ca155c610`), and RedemptionIdle ProxyAdmin (`0xcaba8c12873fffed13431d98bf6b836dff08e869`). Any proxy upgrade executes immediately with no timelock.

--- a/reports/report/superstate-ustb.md
+++ b/reports/report/superstate-ustb.md
@@ -137,7 +137,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
   - **Off-chain:** USD wire transfer, processed on Market Days (NYSE/Federal Reserve open days).
   - Max subscription fee: 0.1% (10 bps), configurable per stablecoin.
 - **Redemptions (Burning):**
-  - **On-chain atomic:** Via RedemptionIdle contract, burns USTB and sends USDC at Continuous NAV/S price. USDC instant redemption facility with variable capacity (currently ~$1.7M as of April 2026, verified on-chain via `balanceOf()`). [Docs](https://docs.superstate.com/welcome-to-superstate/smart-contracts) state: "USDC liquidity will be replenished in this contract regularly" — no specific target capacity is documented.
+  - **On-chain atomic:** Via RedemptionIdle contract, burns USTB and sends USDC at Continuous NAV/S price. USDC instant redemption facility with variable capacity (currently ~$1.7M as of April 2026, verified on-chain via `balanceOf()`). Superstate announced "$10M USDC instant redemption facility, refilled twice daily" on the [Aave governance forum (Jan 2025)](https://governance.aave.com/t/arfc-ustb-buidl-gsm/19299/3), but [docs](https://docs.superstate.com/welcome-to-superstate/smart-contracts) only state: "USDC liquidity will be replenished in this contract regularly" — the actual on-chain balance varies significantly.
   - **Off-chain:** Transfer tokens to contract address or call `offchainRedeem()`. Proceeds in USDC or USD wire. T+0 if before 9:00 AM EST on Market Days, otherwise T+1.
   - No redemption fees for standard redemptions.
 - **Geographic Restrictions:** Available to qualified purchasers in the U.S. and select offshore jurisdictions (Cayman Islands, BVI, Bermuda). Not available to sanctioned countries.
@@ -171,7 +171,7 @@ The fund uses a **laddered approach** with holdings spread across various near-t
 - **Transfer Restrictions:** All transfers require both sender and receiver to be on the AllowList. Removing an address from the AllowList effectively freezes their tokens.
 - **DeFi Integrations (Liquidity Venues):**
   - **Spark Protocol (MakerDAO):** $300M allocated to USTB as yield-generating reserve
-  - **Aave Horizon:** USTB accepted as collateral to borrow USDC, GHO, RLUSD
+  - **Aave Horizon:** USTB accepted as collateral to borrow USDC, GHO, RLUSD. ~$19.9M supplied (March 2026), 8.33x max leverage. Uses LlamaGuard NAV Oracle (risk-adjusted, built with Chainlink).
   - **Morpho / Pareto / Gauntlet:** USTB-adjacent via Pareto Credit Vault CV tokens as Morpho collateral; Gauntlet levered RWA strategy (~13% APY, ~$51M collateral)
   - **M^0 Protocol:** USTB designated as first eligible collateral for all M^0 network stablecoins (MetaMask mUSD, Noble USDN)
   - **FalconX:** USTB used as prime brokerage trading collateral


### PR DESCRIPTION
## Summary
- Reassessed Superstate USTB report with full on-chain contract verification (April 2026)
- Discovered **4 distinct admin EOAs** controlling the system (previously documented as 2): USTB Token, AllowList, RedemptionIdle, and Oracle each have separate owners
- Added missing contracts: RedemptionIdle Implementation, RedemptionIdle ProxyAdmin, Oracle Owner, RedemptionIdle Owner
- Added **contract architecture diagram** (Appendix B) with proxy upgrade paths
- Updated RedemptionIdle USDC instant redemption capacity: ~$10M → ~$1.7M
- Updated NAV/share ($11.00 → $11.045), on-chain supply (55.49M → 56.59M USTB), production time (13mo → 26mo)
- Expanded monitoring section with all 3 ProxyAdmins and all 4 admin EOAs

## Score Change: 2.38 → 2.33
- **Audits & Historical**: 1.5 → 1.25 (>2 years production, Historical subscore improved)
- All other category scores unchanged
- Risk tier remains **Low Risk**

## Key Monitoring Finding
3 proxy contracts can be upgraded with no timelock:

| Proxy | ProxyAdmin Owner |
|-------|-----------------|
| USTB Token | EOA `0xad30...ca83` |
| AllowList | EOA `0x7747...2bfe` |
| RedemptionIdle | EOA `0x8cf4...0765` |

Oracle is NOT a proxy but its owner (`0x4B1d...1395`) controls NAV pricing via checkpoints.

## Test plan
- [x] All contract addresses verified on-chain via `cast` calls
- [x] All owner addresses confirmed as EOAs (code size 0)
- [x] Score calculation verified manually
- [x] Review report for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)