### PR TITLE
feat: add CAP, Resolv, and Superstate USTB to monitoring page

### DIFF
--- a/src/data/monitoring.ts
+++ b/src/data/monitoring.ts
@@ -414,35 +414,6 @@ export const protocols: Protocol[] = [
     ],
   },
   {
-    id: "resolv",
-    name: "Resolv",
-    defillamaSlug: "resolv",
-    frequency: "Hourly",
-    items: [
-      {
-        label: "USR Price Stability",
-        description: "Alerts if USR price deviates from $1.00",
-      },
-      {
-        label: "Over-Collateralization",
-        description: "Alerts if reserves fall below 130% of USR supply",
-      },
-      {
-        label: "Redemption Usage",
-        description: "Alerts if usage exceeds 50% of redemption limit",
-      },
-      {
-        label: "Price Data Freshness",
-        description: "Alerts if last price update is older than 24 hours",
-      },
-      {
-        label: "Off-Chain Reserves",
-        description:
-          "TVL, backing assets, market delta, strategy net exposure, and RLP/USR ratio via Apostro dashboard",
-      },
-    ],
-  },
-  {
     id: "rtoken",
     name: "RToken (ETH+)",
     defillamaSlug: "reserve-protocol",
@@ -488,41 +459,6 @@ export const protocols: Protocol[] = [
         label: "Safe Multisig",
         description:
           "3/6 multisig monitoring on Mainnet, Optimism, and Arbitrum",
-      },
-    ],
-  },
-  {
-    id: "superstate-ustb",
-    name: "Superstate USTB",
-    defillamaSlug: "superstate",
-    frequency: "Hourly",
-    items: [
-      {
-        label: "NAV/Share Monotonicity",
-        description:
-          "Alerts if NAV per share decreases — indicates fund losses",
-      },
-      {
-        label: "Oracle Divergence",
-        description:
-          "Alerts if Continuous Price Oracle and Chainlink feed differ by more than 0.5%",
-      },
-      {
-        label: "Redemption Capacity",
-        description: "Alerts if RedemptionIdle USDC balance falls below $500K",
-      },
-      {
-        label: "Supply Changes",
-        description: "Alerts if total supply changes by more than 10%",
-      },
-      {
-        label: "Oracle Staleness",
-        description:
-          "Alerts if oracle checkpoint is older than 4 days (reverts at 5 days)",
-      },
-      {
-        label: "Stablecoin Price",
-        description: "Depeg alert if USTB price falls below $10.50",
       },
     ],
   },

--- a/src/data/monitoring.ts
+++ b/src/data/monitoring.ts
@@ -145,30 +145,6 @@ export const protocols: Protocol[] = [
     ],
   },
   {
-    id: "euler",
-    name: "Euler",
-    defillamaSlug: "euler",
-    frequency: "Hourly",
-    items: [
-      {
-        label: "Vault Risk Levels",
-        description: "Computed risk vs maximum threshold",
-      },
-      {
-        label: "Vault Allocation Ratios",
-        description: "Risk-adjusted allocation thresholds",
-      },
-      {
-        label: "Debt Supply Ratio",
-        description: "Alerts if ratio exceeds 60%",
-      },
-      {
-        label: "Safe Multisig",
-        description: "4/7 multisig transaction queue monitoring",
-      },
-    ],
-  },
-  {
     id: "fluid",
     name: "Fluid",
     defillamaSlug: "fluid",
@@ -389,31 +365,6 @@ export const protocols: Protocol[] = [
     ],
   },
   {
-    id: "pendle",
-    name: "Pendle",
-    defillamaSlug: "pendle",
-    frequency: "Hourly",
-    items: [
-      {
-        label: "Safe Multisig",
-        description: "2/4 governance on Mainnet and Arbitrum",
-      },
-      {
-        label: "Proxy Ownership",
-        description: "Governance proxy contract ownership monitoring",
-      },
-      {
-        label: "SY Token Governance",
-        description: "SY token governance and pause functionality",
-      },
-      {
-        label: "Core Contracts",
-        description:
-          "vePENDLE, PENDLE, RewardDistributor, and Voting contract monitoring",
-      },
-    ],
-  },
-  {
     id: "rtoken",
     name: "RToken (ETH+)",
     defillamaSlug: "reserve-protocol",
@@ -459,6 +410,79 @@ export const protocols: Protocol[] = [
         label: "Safe Multisig",
         description:
           "3/6 multisig monitoring on Mainnet, Optimism, and Arbitrum",
+      },
+    ],
+  },
+  {
+    id: "strata",
+    name: "Strata",
+    defillamaSlug: "strata-finance",
+    frequency: "Daily",
+    items: [
+      {
+        label: "srUSDe Exchange Rate",
+        description: "Alerts if exchange rate decreases",
+      },
+      {
+        label: "Senior Coverage Ratio",
+        description: "Alerts if senior coverage falls below 105%",
+      },
+      {
+        label: "Junior Tranche Drain",
+        description: "Alerts on rapid jrUSDe totalAssets drop (>=15%)",
+      },
+      {
+        label: "Strategy Balance",
+        description:
+          "Alerts if sUSDe strategy balance drops significantly (>=20%)",
+      },
+      {
+        label: "TVL",
+        description: "Alerts on >=15% change in Total Value Locked",
+      },
+      {
+        label: "sUSDe Dependency",
+        description:
+          "sUSDe exchange rate monotonicity and cooldown period changes",
+      },
+      {
+        label: "Timelock",
+        description: "48h and 24h timelock monitoring on Mainnet",
+      },
+    ],
+  },
+  {
+    id: "superstate-ustb",
+    name: "Superstate USTB",
+    defillamaSlug: "superstate",
+    frequency: "Hourly",
+    items: [
+      {
+        label: "NAV/Share Monotonicity",
+        description:
+          "Alerts if NAV per share decreases — indicates fund losses",
+      },
+      {
+        label: "Oracle Divergence",
+        description:
+          "Alerts if Continuous Price Oracle and Chainlink feed differ by more than 0.5%",
+      },
+      {
+        label: "Redemption Capacity",
+        description: "Alerts if RedemptionIdle USDC balance falls below $500K",
+      },
+      {
+        label: "Supply Changes",
+        description: "Alerts if total supply changes by more than 10%",
+      },
+      {
+        label: "Oracle Staleness",
+        description:
+          "Alerts if oracle checkpoint is older than 4 days (reverts at 5 days)",
+      },
+      {
+        label: "Stablecoin Price",
+        description: "Depeg alert if USTB price falls below $10.50",
       },
     ],
   },

--- a/src/data/monitoring.ts
+++ b/src/data/monitoring.ts
@@ -74,6 +74,23 @@ export const protocols: Protocol[] = [
     ],
   },
   {
+    id: "cap",
+    name: "CAP",
+    defillamaSlug: "cap-protocol",
+    frequency: "Daily",
+    items: [
+      {
+        label: "Withdrawable Liquidity",
+        description:
+          "Alerts if total withdrawable liquidity across all cUSD assets falls below $100M",
+      },
+      {
+        label: "Timelock",
+        description: "Timelock monitoring with 24-hour delay on Mainnet",
+      },
+    ],
+  },
+  {
     id: "compound-v3",
     name: "Compound V3",
     defillamaSlug: "compound-v3",
@@ -397,6 +414,35 @@ export const protocols: Protocol[] = [
     ],
   },
   {
+    id: "resolv",
+    name: "Resolv",
+    defillamaSlug: "resolv",
+    frequency: "Hourly",
+    items: [
+      {
+        label: "USR Price Stability",
+        description: "Alerts if USR price deviates from $1.00",
+      },
+      {
+        label: "Over-Collateralization",
+        description: "Alerts if reserves fall below 130% of USR supply",
+      },
+      {
+        label: "Redemption Usage",
+        description: "Alerts if usage exceeds 50% of redemption limit",
+      },
+      {
+        label: "Price Data Freshness",
+        description: "Alerts if last price update is older than 24 hours",
+      },
+      {
+        label: "Off-Chain Reserves",
+        description:
+          "TVL, backing assets, market delta, strategy net exposure, and RLP/USR ratio via Apostro dashboard",
+      },
+    ],
+  },
+  {
     id: "rtoken",
     name: "RToken (ETH+)",
     defillamaSlug: "reserve-protocol",
@@ -442,6 +488,41 @@ export const protocols: Protocol[] = [
         label: "Safe Multisig",
         description:
           "3/6 multisig monitoring on Mainnet, Optimism, and Arbitrum",
+      },
+    ],
+  },
+  {
+    id: "superstate-ustb",
+    name: "Superstate USTB",
+    defillamaSlug: "superstate",
+    frequency: "Hourly",
+    items: [
+      {
+        label: "NAV/Share Monotonicity",
+        description:
+          "Alerts if NAV per share decreases — indicates fund losses",
+      },
+      {
+        label: "Oracle Divergence",
+        description:
+          "Alerts if Continuous Price Oracle and Chainlink feed differ by more than 0.5%",
+      },
+      {
+        label: "Redemption Capacity",
+        description: "Alerts if RedemptionIdle USDC balance falls below $500K",
+      },
+      {
+        label: "Supply Changes",
+        description: "Alerts if total supply changes by more than 10%",
+      },
+      {
+        label: "Oracle Staleness",
+        description:
+          "Alerts if oracle checkpoint is older than 4 days (reverts at 5 days)",
+      },
+      {
+        label: "Stablecoin Price",
+        description: "Depeg alert if USTB price falls below $10.50",
       },
     ],
   },

--- a/src/data/monitoring.ts
+++ b/src/data/monitoring.ts
@@ -145,6 +145,30 @@ export const protocols: Protocol[] = [
     ],
   },
   {
+    id: "euler",
+    name: "Euler",
+    defillamaSlug: "euler",
+    frequency: "Hourly",
+    items: [
+      {
+        label: "Vault Risk Levels",
+        description: "Computed risk vs maximum threshold",
+      },
+      {
+        label: "Vault Allocation Ratios",
+        description: "Risk-adjusted allocation thresholds",
+      },
+      {
+        label: "Debt Supply Ratio",
+        description: "Alerts if ratio exceeds 60%",
+      },
+      {
+        label: "Safe Multisig",
+        description: "4/7 multisig transaction queue monitoring",
+      },
+    ],
+  },
+  {
     id: "fluid",
     name: "Fluid",
     defillamaSlug: "fluid",
@@ -361,6 +385,31 @@ export const protocols: Protocol[] = [
       {
         label: "Market Allocation",
         description: "Risk-adjusted allocation ratio monitoring",
+      },
+    ],
+  },
+  {
+    id: "pendle",
+    name: "Pendle",
+    defillamaSlug: "pendle",
+    frequency: "Hourly",
+    items: [
+      {
+        label: "Safe Multisig",
+        description: "2/4 governance on Mainnet and Arbitrum",
+      },
+      {
+        label: "Proxy Ownership",
+        description: "Governance proxy contract ownership monitoring",
+      },
+      {
+        label: "SY Token Governance",
+        description: "SY token governance and pause functionality",
+      },
+      {
+        label: "Core Contracts",
+        description:
+          "vePENDLE, PENDLE, RewardDistributor, and Voting contract monitoring",
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Add **CAP** protocol monitoring (daily: withdrawable liquidity, timelock)
- Add **Resolv** protocol monitoring (hourly: USR price stability, over-collateralization, redemption usage, price freshness, off-chain reserves)
- Add **Superstate USTB** monitoring (hourly: NAV/share monotonicity, oracle divergence, redemption capacity, supply changes, oracle staleness, stablecoin price)

Monitoring page now shows 21 protocols (was 18).

## Test plan
- [x] `astro build` succeeds
- [x] Verify protocol icons load from DeFi Llama
- [x] Verify new protocol cards render correctly on monitoring page

🤖 Generated with [Claude Code](https://claude.com/claude-code)