### PR TITLE
feat: restyle reports and tokens pages

### DIFF
--- a/src/data/stats.json
+++ b/src/data/stats.json
@@ -14,6 +14,6 @@
     }
   },
   "chainCount": 8,
-  "updatedAt": "2026-04-27T18:51:21.689Z",
+  "updatedAt": "2026-04-27T19:08:24.411Z",
   "tvlSource": "live"
 }

--- a/src/data/stats.json
+++ b/src/data/stats.json
@@ -1,19 +1,19 @@
 {
   "reportCount": 25,
   "tvl": {
-    "total": 252339378,
+    "total": 248111793,
     "byChain": {
       "Fantom": 160061,
-      "Base": 2902476,
+      "Base": 2903038,
       "Polygon": 386074,
-      "Katana": 72255839,
-      "Arbitrum": 427805,
+      "Katana": 68009661,
+      "Arbitrum": 427816,
       "OP Mainnet": 2060001,
-      "Ethereum": 173836805,
-      "Hyperliquid L1": 310317
+      "Ethereum": 173854802,
+      "Hyperliquid L1": 310340
     }
   },
   "chainCount": 8,
-  "updatedAt": "2026-04-27T19:08:24.411Z",
+  "updatedAt": "2026-04-27T19:58:48.664Z",
   "tvlSource": "live"
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -79,8 +79,6 @@ const ogImageUrl = new URL(ogImage, Astro.site ?? Astro.url.origin).href;
           <a href="/reports/">Reports</a>
           <a href="/tokens/">Tokens</a>
           <a href="/monitoring/">Monitoring</a>
-
-          <a href="https://app.morpho.org/ethereum/curator/yearn" target="_blank" rel="noopener noreferrer" class="nav-external">Morpho <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></a>
         </nav>
         </div>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle light mode">
@@ -180,14 +178,14 @@ const ogImageUrl = new URL(ogImage, Astro.site ?? Astro.url.origin).href;
     top: 6vh;
     left: -90px;
     transform: rotate(-22deg);
-    animation: float-a 11s ease-in-out infinite;
+    animation: float-a 8.8s ease-in-out infinite;
   }
   .pill-2 {
     width: 220px;
     top: 28vh;
     right: -60px;
     transform: rotate(35deg);
-    animation: float-b 14s ease-in-out infinite;
+    animation: float-b 11.2s ease-in-out infinite;
   }
   .pill-3 {
     width: 160px;
@@ -195,7 +193,7 @@ const ogImageUrl = new URL(ogImage, Astro.site ?? Astro.url.origin).href;
     left: 8vw;
     transform: rotate(12deg);
     opacity: 0.35;
-    animation: float-c 9s ease-in-out infinite;
+    animation: float-c 7.2s ease-in-out infinite;
   }
   .pill-4 {
     width: 280px;
@@ -203,7 +201,7 @@ const ogImageUrl = new URL(ogImage, Astro.site ?? Astro.url.origin).href;
     right: 10vw;
     transform: rotate(-48deg);
     opacity: 0.4;
-    animation: float-a 13s ease-in-out infinite reverse;
+    animation: float-a 10.4s ease-in-out infinite reverse;
   }
   .pill-5 {
     width: 130px;
@@ -211,7 +209,7 @@ const ogImageUrl = new URL(ogImage, Astro.site ?? Astro.url.origin).href;
     left: 38vw;
     transform: rotate(60deg);
     opacity: 0.3;
-    animation: float-b 10s ease-in-out infinite;
+    animation: float-b 8s ease-in-out infinite;
   }
   .pill-6 {
     width: 200px;
@@ -219,7 +217,7 @@ const ogImageUrl = new URL(ogImage, Astro.site ?? Astro.url.origin).href;
     right: -30px;
     transform: rotate(-15deg);
     opacity: 0.32;
-    animation: float-c 12s ease-in-out infinite reverse;
+    animation: float-c 9.6s ease-in-out infinite reverse;
   }
   @keyframes float-a {
     0%, 100% { translate: 0 0; }
@@ -288,9 +286,6 @@ const ogImageUrl = new URL(ogImage, Astro.site ?? Astro.url.origin).href;
     overflow-x: auto;
     scrollbar-width: none;
     -ms-overflow-style: none;
-    /* Soft fade on the right edge so cut-off items hint at scrollability */
-    mask-image: linear-gradient(90deg, #000 calc(100% - 24px), transparent);
-    -webkit-mask-image: linear-gradient(90deg, #000 calc(100% - 24px), transparent);
   }
   .header-nav::-webkit-scrollbar {
     display: none;

--- a/src/pages/monitoring.astro
+++ b/src/pages/monitoring.astro
@@ -5,10 +5,23 @@ import { protocols } from "../data/monitoring";
 ---
 
 <BaseLayout title="Monitoring — Yearn Curation" ogUrl="/monitoring/" ogImage="/og/default.png">
-  <div class="page-header">
-    <div>
-      <h1>Monitoring</h1>
-      <p class="section-desc">Protocols actively monitored by Yearn Curation. Alerts are sent to Telegram in real-time.<br/>Find additional info about our monitoring stack on <a href="https://github.com/yearn/monitoring-scripts-py" target="_blank" rel="noopener noreferrer">GitHub</a>.</p>
+  <section class="page-hero">
+    <div class="section-eyebrow">
+      <span class="pulse-dot"></span>
+      Continuous monitoring
+    </div>
+    <h1>Live protocol monitors</h1>
+    <p class="page-sub">
+      Protocols actively monitored by Yearn Curation. Alerts are streamed to
+      Telegram in real time. Find the open-source monitoring stack on
+      <a href="https://github.com/yearn/monitoring-scripts-py" target="_blank" rel="noopener noreferrer">GitHub</a>.
+    </p>
+  </section>
+
+  <div class="tools-row">
+    <div class="search-wrap">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="search-icon"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input type="text" id="protocol-search" placeholder="Search protocols…" autocomplete="off" />
     </div>
     <a
       href="https://t.me/yearn_curation_alerts"
@@ -16,15 +29,15 @@ import { protocols } from "../data/monitoring";
       rel="noopener noreferrer"
       class="tg-subscribe"
     >
-      <svg class="tg-icon" viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+      <svg class="tg-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
         <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.479.33-.913.492-1.302.48-.428-.012-1.252-.242-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/>
       </svg>
-      Subscribe
+      Subscribe to alerts
     </a>
   </div>
 
-  <div class="search-row">
-    <input type="text" id="protocol-search" placeholder="Search protocols..." autocomplete="off" />
+  <div class="block-head">
+    <span class="block-meta"><span id="visible-count">{protocols.length}</span> of {protocols.length} protocols</span>
   </div>
 
   <div class="protocol-list" id="protocol-list">
@@ -32,11 +45,12 @@ import { protocols } from "../data/monitoring";
       const iconUrl = protocolIconUrl(p.defillamaSlug);
       return (
         <div class="protocol-accordion" data-name={p.name.toLowerCase()}>
+          <div class="card-glow" aria-hidden="true"></div>
           <button class="accordion-trigger" aria-expanded="false">
             <div class="accordion-left">
               <div class="icon-wrap">
                 {iconUrl ? (
-                  <img src={iconUrl} alt="" width="28" height="28" class="protocol-icon" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
+                  <img src={iconUrl} alt="" width="32" height="32" class="protocol-icon" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" />
                 ) : null}
                 <div class="icon-placeholder" style={iconUrl ? "display:none" : ""}>
                   <span>{p.name.charAt(0)}</span>
@@ -44,7 +58,10 @@ import { protocols } from "../data/monitoring";
               </div>
               <div class="protocol-info">
                 <span class="protocol-name">{p.name}</span>
-                <span class="protocol-meta">{p.items.length} monitors &middot; {p.frequency}</span>
+                <span class="protocol-meta">
+                  <span class="meta-pill">{p.items.length} monitors</span>
+                  <span class="meta-pill meta-pill--blue">{p.frequency}</span>
+                </span>
               </div>
             </div>
             <svg class="chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -66,145 +83,286 @@ import { protocols } from "../data/monitoring";
     })}
   </div>
 
-  <script is:inline>
-    // Accordion toggle
-    document.querySelectorAll(".accordion-trigger").forEach((btn) => {
-      btn.addEventListener("click", () => {
-        const expanded = btn.getAttribute("aria-expanded") === "true";
-        btn.setAttribute("aria-expanded", String(!expanded));
-      });
-    });
+  <div class="empty-state" id="empty-state" hidden>
+    <div class="empty-icon">
+      <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+    </div>
+    <p>No monitored protocols match your search.</p>
+  </div>
 
-    // Search
-    const search = document.getElementById("protocol-search");
-    const items = document.querySelectorAll(".protocol-accordion");
-    search.addEventListener("input", () => {
-      const q = search.value.toLowerCase();
-      items.forEach((item) => {
-        item.style.display = item.dataset.name.includes(q) ? "" : "none";
+  <script is:inline>
+    (() => {
+      // Accordion toggle
+      document.querySelectorAll(".accordion-trigger").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const expanded = btn.getAttribute("aria-expanded") === "true";
+          btn.setAttribute("aria-expanded", String(!expanded));
+        });
       });
-    });
+
+      // Search
+      const search = document.getElementById("protocol-search");
+      const items = document.querySelectorAll(".protocol-accordion");
+      const empty = document.getElementById("empty-state");
+      const countEl = document.getElementById("visible-count");
+      const total = items.length;
+      search.addEventListener("input", () => {
+        const q = search.value.toLowerCase().trim();
+        let visible = 0;
+        items.forEach((item) => {
+          const show = item.dataset.name.includes(q);
+          item.style.display = show ? "" : "none";
+          if (show) visible++;
+        });
+        countEl.textContent = visible;
+        empty.hidden = visible > 0;
+      });
+
+      // Mouse-tracking glow on accordion cards
+      items.forEach((item) => {
+        item.addEventListener("pointermove", (e) => {
+          const r = item.getBoundingClientRect();
+          item.style.setProperty("--mx", `${e.clientX - r.left}px`);
+          item.style.setProperty("--my", `${e.clientY - r.top}px`);
+        });
+        item.addEventListener("pointerleave", () => {
+          item.style.removeProperty("--mx");
+          item.style.removeProperty("--my");
+        });
+      });
+    })();
   </script>
 </BaseLayout>
 
 <style>
-  .page-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 1rem;
-    margin-bottom: 1.25rem;
+  /* === Hero === */
+  .page-hero {
+    padding: 2rem 0 1.5rem;
+    text-align: center;
   }
-  h1 {
-    margin-bottom: 0.25rem;
+  .page-hero h1 {
+    font-size: clamp(1.75rem, 3.4vw, 2.4rem);
+    letter-spacing: -0.02em;
+    margin: 0 auto 0.75rem;
+    line-height: 1.15;
+    max-width: 22ch;
   }
-  .section-desc {
+  .page-sub {
     color: var(--text-secondary);
-    font-size: 0.85rem;
-    margin: 0;
+    max-width: 60ch;
+    margin: 0 auto;
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+  .page-sub a {
+    color: var(--brand-blue);
   }
 
-  /* Telegram subscribe button */
-  .tg-subscribe {
+  /* === Section eyebrow === */
+  .section-eyebrow {
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
+    color: var(--brand-blue);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+  .pulse-dot {
+    width: 6px;
+    height: 6px;
+    background: var(--brand-blue);
+    border-radius: 50%;
+    box-shadow: 0 0 0 0 rgba(6, 117, 249, 0.6);
+    animation: pulse 2s ease-out infinite;
+  }
+  @keyframes pulse {
+    0% { box-shadow: 0 0 0 0 rgba(6, 117, 249, 0.6); }
+    70% { box-shadow: 0 0 0 8px rgba(6, 117, 249, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(6, 117, 249, 0); }
+  }
+
+  /* === Tools row === */
+  .tools-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 1.5rem 0 0.85rem;
+    flex-wrap: wrap;
+  }
+  .search-wrap {
+    position: relative;
+    max-width: 480px;
+    width: 100%;
+    flex: 1;
+    min-width: 220px;
+  }
+  .search-icon {
+    position: absolute;
+    left: 0.85rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-secondary);
+    pointer-events: none;
+  }
+  .search-wrap input {
+    width: 100%;
+    padding: 0.65rem 0.85rem 0.65rem 2.4rem;
+    background: color-mix(in srgb, var(--bg-card) 55%, transparent);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    font-size: 0.9rem;
+    transition: border-color 0.15s, background 0.15s;
+  }
+  .search-wrap input::placeholder {
+    color: var(--text-secondary);
+  }
+  .search-wrap input:focus {
+    outline: none;
+    border-color: var(--brand-blue);
+    background: color-mix(in srgb, var(--bg-card) 75%, transparent);
+  }
+
+  /* Telegram subscribe */
+  .tg-subscribe {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
     background: #229ED9;
     color: #fff;
-    padding: 0.5rem 1rem;
-    border-radius: 8px;
-    font-size: 0.85rem;
+    padding: 0.65rem 1.1rem;
+    border: 1px solid color-mix(in srgb, #229ED9 70%, #fff 0%);
+    border-radius: 10px;
+    font-size: 0.9rem;
     font-weight: 600;
     text-decoration: none;
     white-space: nowrap;
-    transition: background 0.2s;
+    transition: background 0.15s, transform 0.15s, box-shadow 0.15s;
     flex-shrink: 0;
   }
   .tg-subscribe:hover {
     background: #1a8abf;
     text-decoration: none;
     color: #fff;
+    transform: translateY(-1px);
+    box-shadow: 0 8px 24px -10px rgba(34, 158, 217, 0.5);
   }
-  .tg-icon {
-    flex-shrink: 0;
-  }
+  .tg-icon { flex-shrink: 0; }
 
-  /* Search */
-  .search-row {
-    margin-bottom: 1rem;
+  /* === Block head with count chip === */
+  .block-head {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 0.75rem;
   }
-  .search-row input {
-    width: 100%;
-    max-width: 360px;
-    background: var(--bg-secondary);
-    color: var(--text-primary);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    padding: 0.4rem 0.6rem;
-    font-size: 0.85rem;
-  }
-  .search-row input::placeholder {
+  .block-meta {
+    font-size: 0.78rem;
     color: var(--text-secondary);
+    padding: 0.3rem 0.7rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bg-card) 50%, transparent);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    font-variant-numeric: tabular-nums;
   }
 
-  /* Protocol list */
+  /* === Protocol list === */
   .protocol-list {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    margin-bottom: 3rem;
   }
 
-  /* Accordion */
+  /* === Accordion card === */
   .protocol-accordion {
+    --accent: var(--brand-blue);
+    --mx: 50%;
+    --my: 50%;
+    position: relative;
     border: 1px solid var(--border);
-    border-radius: 8px;
-    background: var(--bg-card);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--bg-card) 60%, transparent);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
     overflow: hidden;
+    isolation: isolate;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
   }
+  .protocol-accordion:hover {
+    border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
+    transform: translateY(-1px);
+    box-shadow:
+      0 12px 30px -18px rgba(0, 0, 0, 0.6),
+      0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
+  }
+  .protocol-accordion:has(.accordion-trigger[aria-expanded="true"]) {
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  }
+  .card-glow {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    opacity: 0;
+    background: radial-gradient(
+      300px circle at var(--mx, 50%) var(--my, 50%),
+      color-mix(in srgb, var(--accent) 14%, transparent),
+      transparent 60%
+    );
+    transition: opacity 0.25s;
+  }
+  .protocol-accordion:hover .card-glow { opacity: 1; }
+
   .accordion-trigger {
     display: flex;
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    padding: 0.75rem 1rem;
+    padding: 0.85rem 1rem;
     background: none;
     border: none;
     color: var(--text-primary);
     cursor: pointer;
     font-size: 0.9rem;
     text-align: left;
-    transition: background 0.15s;
-  }
-  .accordion-trigger:hover {
-    background: rgba(6, 117, 249, 0.06);
+    font-family: inherit;
   }
   .accordion-left {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.85rem;
+    min-width: 0;
+    flex: 1;
   }
 
   /* Icon */
   .icon-wrap {
-    width: 28px;
-    height: 28px;
+    width: 32px;
+    height: 32px;
     flex-shrink: 0;
+    position: relative;
   }
   .protocol-icon {
     display: block;
     border-radius: 50%;
-    width: 28px;
-    height: 28px;
+    width: 32px;
+    height: 32px;
   }
   .icon-placeholder {
-    width: 28px;
-    height: 28px;
+    width: 32px;
+    height: 32px;
     border-radius: 50%;
     background: var(--bg-secondary);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 0.8rem;
+    font-size: 0.85rem;
     font-weight: 700;
     color: var(--text-secondary);
   }
@@ -213,31 +371,58 @@ import { protocols } from "../data/monitoring";
   .protocol-info {
     display: flex;
     flex-direction: column;
+    gap: 0.2rem;
+    min-width: 0;
   }
   .protocol-name {
     font-weight: 600;
     line-height: 1.2;
+    font-size: 0.98rem;
+    letter-spacing: -0.01em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .protocol-meta {
-    font-size: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    font-size: 0.72rem;
+  }
+  .meta-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bg-secondary) 70%, transparent);
     color: var(--text-secondary);
-    line-height: 1.2;
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+  }
+  .meta-pill--blue {
+    background: color-mix(in srgb, var(--brand-blue) 12%, transparent);
+    color: #7eb4ff;
+    border: 1px solid color-mix(in srgb, var(--brand-blue) 25%, transparent);
   }
 
   /* Chevron */
   .chevron {
     color: var(--text-secondary);
-    transition: transform 0.2s;
+    transition: transform 0.2s, color 0.2s;
     flex-shrink: 0;
   }
+  .accordion-trigger:hover .chevron { color: var(--text-primary); }
   .accordion-trigger[aria-expanded="true"] .chevron {
     transform: rotate(180deg);
+    color: var(--brand-blue);
   }
 
   /* Panel */
   .accordion-panel {
     display: none;
-    padding: 0 1rem 0.75rem;
+    padding: 0 1rem 0.85rem;
   }
   .accordion-trigger[aria-expanded="true"] + .accordion-panel {
     display: block;
@@ -248,30 +433,57 @@ import { protocols } from "../data/monitoring";
     list-style: none;
     padding: 0;
     margin: 0;
-    border-top: 1px solid var(--border);
-    padding-top: 0.5rem;
+    border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+    padding-top: 0.6rem;
   }
   .monitor-list li {
     display: flex;
     gap: 0.75rem;
-    padding: 0.35rem 0;
-    font-size: 0.85rem;
-    line-height: 1.4;
+    padding: 0.45rem 0;
+    font-size: 0.86rem;
+    line-height: 1.45;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 35%, transparent);
+  }
+  .monitor-list li:last-child {
+    border-bottom: none;
   }
   .monitor-label {
     font-weight: 600;
     white-space: nowrap;
     color: var(--text-primary);
-    min-width: 160px;
+    min-width: 180px;
     flex-shrink: 0;
+    font-size: 0.85rem;
   }
   .monitor-desc {
     color: var(--text-secondary);
   }
 
+  /* Empty state */
+  .empty-state {
+    margin: 3rem auto;
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+  }
+  .empty-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--bg-card) 60%, transparent);
+    border: 1px solid var(--border);
+    margin-bottom: 0.75rem;
+    color: var(--text-secondary);
+  }
+
   @media (max-width: 640px) {
-    .page-header {
-      flex-direction: column;
+    .tools-row { gap: 0.5rem; }
+    .tg-subscribe {
+      width: 100%;
+      justify-content: center;
     }
     .monitor-list li {
       flex-direction: column;
@@ -280,5 +492,9 @@ import { protocols } from "../data/monitoring";
     .monitor-label {
       min-width: unset;
     }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pulse-dot { animation: none; }
   }
 </style>

--- a/src/pages/reports.astro
+++ b/src/pages/reports.astro
@@ -2,101 +2,497 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import ScoreBadge from "../components/ScoreBadge.astro";
 import { getAllReports } from "../lib/reports";
-import { scoreTier } from "../lib/colors";
+import { scoreColor, scoreTier } from "../lib/colors";
+
+const formatRelative = (ts: number): string => {
+  if (!ts) return "—";
+  const days = Math.max(0, Math.round((Date.now() - ts) / 86_400_000));
+  if (days <= 1) return "today";
+  if (days < 7) return `${days}d ago`;
+  if (days < 30) return `${Math.round(days / 7)}w ago`;
+  if (days < 365) return `${Math.round(days / 30)}mo ago`;
+  return `${Math.round(days / 365)}y ago`;
+};
 
 const reports = getAllReports();
+const tierOrder = [
+  "Minimal Risk",
+  "Low Risk",
+  "Medium Risk",
+  "Elevated Risk",
+  "High Risk",
+];
+const tierCounts = tierOrder.map((t) => ({
+  tier: t,
+  count: reports.filter((r) => scoreTier(r.finalScore) === t).length,
+}));
 ---
 
 <BaseLayout title="Reports — Yearn Curation" ogUrl="/reports/" ogImage="/og/default.png">
-  <h1>Risk Assessment Reports</h1>
+  <section class="reports-hero">
+    <div class="section-eyebrow">
+      <span class="pulse-dot"></span>
+      All assessments
+    </div>
+    <h1>Risk Assessment Reports</h1>
+    <p class="reports-sub">
+      {reports.length} independent assessments across DeFi protocols, vaults
+      and assets. Sorted by score — safest first.
+    </p>
+  </section>
 
-  <div class="search-row">
-    <input type="text" id="report-search" placeholder="Search by protocol, token, or risk tier…" autocomplete="off" />
+  <div class="tools">
+    <div class="tools-row">
+      <div class="search-wrap">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="search-icon"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <input type="text" id="report-search" placeholder="Search by protocol, token, or risk tier…" autocomplete="off" />
+      </div>
+      <div class="view-toggle" role="group" aria-label="View mode">
+        <button class="view-btn is-active" data-view="list" type="button" aria-label="List view" title="List view">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+        </button>
+        <button class="view-btn" data-view="grid" type="button" aria-label="Grid view" title="Grid view">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+        </button>
+      </div>
+    </div>
+    <div class="filter-pills" id="filter-pills">
+      <button class="filter-pill is-active" data-tier="all" type="button">
+        All <span class="pill-count">{reports.length}</span>
+      </button>
+      {tierCounts.filter(t => t.count > 0).map(({ tier, count }) => {
+        const sample = reports.find(r => scoreTier(r.finalScore) === tier);
+        const accent = sample ? scoreColor(sample.finalScore) : "var(--brand-blue)";
+        return (
+          <button
+            class="filter-pill"
+            data-tier={tier}
+            type="button"
+            style={`--pill-accent:${accent};`}
+          >
+            <span class="pill-dot"></span>
+            {tier} <span class="pill-count">{count}</span>
+          </button>
+        );
+      })}
+    </div>
   </div>
 
-  <div class="table-wrap">
-    <table id="reports-table">
-      <thead>
-        <tr>
-          <th class="col-icon"></th>
-          <th>Protocol</th>
-          <th>Token</th>
-          <th>Score</th>
-          <th>Risk Tier</th>
-        </tr>
-      </thead>
-      <tbody>
-        {
-          reports.map((r) => (
-            <tr onclick={`window.location='/report/${r.slug}/'`}>
-              <td class="col-icon">
-                <div class="icon-stack">
-                  {r.iconUrl ? (
-                    <img src={r.iconUrl} alt="" width="24" height="24" class="protocol-icon" loading="lazy" />
-                  ) : (
-                    <div class="icon-placeholder" />
-                  )}
-                  {r.chainIconUrl && (
-                    <img src={r.chainIconUrl} alt="" width="14" height="14" class="chain-icon" loading="lazy" />
-                  )}
-                </div>
-              </td>
-              <td>
-                {r.name}
-                {r.warning && <span class="warning-tag">&#9888; {r.warning}</span>}
-              </td>
-              <td class="mono">{r.token}</td>
-              <td>
-                <ScoreBadge score={r.finalScore} />
-              </td>
-              <td>{scoreTier(r.finalScore)}</td>
-            </tr>
-          ))
-        }
-      </tbody>
-    </table>
+  <div class="reports-grid is-list" id="reports-grid">
+    {reports.map((r) => (
+      <a
+        href={`/report/${r.slug}/`}
+        class="report-card"
+        style={`--accent:${scoreColor(r.finalScore)};`}
+        data-name={r.name.toLowerCase()}
+        data-token={r.token.toLowerCase()}
+        data-tier={scoreTier(r.finalScore)}
+      >
+        <div class="card-glow" aria-hidden="true"></div>
+        <div class="card-head">
+          <div class="icon-stack">
+            {r.iconUrl ? (
+              <img src={r.iconUrl} alt="" width="36" height="36" class="protocol-icon" loading="lazy" />
+            ) : (
+              <div class="icon-placeholder" />
+            )}
+            {r.chainIconUrl && (
+              <img src={r.chainIconUrl} alt="" width="16" height="16" class="chain-icon" loading="lazy" />
+            )}
+          </div>
+          <div class="card-title">
+            <div class="card-name">{r.name}</div>
+            <div class="card-meta">
+              <span class="mono">{r.token}</span>
+              <span class="sep">·</span>
+              <span title={r.date}>{formatRelative(r.dateSortable)}</span>
+            </div>
+          </div>
+          {r.warning && (
+            <div class="warning-banner">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+              <span>{r.warning}</span>
+            </div>
+          )}
+          <ScoreBadge score={r.finalScore} />
+        </div>
+        <div class="card-foot">
+          <span class="tier-sm" style={`color:${scoreColor(r.finalScore)};`}>
+            {scoreTier(r.finalScore)}
+          </span>
+          <div class="score-bar" aria-hidden="true">
+            {[1, 2, 3, 4, 5].map((seg) => (
+              <span
+                class:list={["score-seg", { active: seg <= Math.round(r.finalScore) }]}
+                style={seg <= Math.round(r.finalScore) ? `background:${scoreColor(r.finalScore)};` : ""}
+              />
+            ))}
+          </div>
+        </div>
+      </a>
+    ))}
   </div>
+
+  <div class="empty-state" id="empty-state" hidden>
+    <div class="empty-icon">
+      <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+    </div>
+    <p>No reports match your search.</p>
+  </div>
+
   <script is:inline>
-    const searchInput = document.getElementById("report-search");
-    const rows = document.querySelectorAll("#reports-table tbody tr");
-    searchInput.addEventListener("input", () => {
-      const q = searchInput.value.toLowerCase();
-      rows.forEach((row) => {
-        const text = row.textContent.toLowerCase();
-        row.style.display = text.includes(q) ? "" : "none";
+    (() => {
+      const cards = Array.from(document.querySelectorAll(".report-card"));
+      const search = document.getElementById("report-search");
+      const pills = Array.from(document.querySelectorAll(".filter-pill"));
+      const grid = document.getElementById("reports-grid");
+      const viewBtns = Array.from(document.querySelectorAll(".view-btn"));
+      const empty = document.getElementById("empty-state");
+      let activeTier = "all";
+
+      function apply() {
+        const q = search.value.toLowerCase().trim();
+        let visible = 0;
+        cards.forEach((card) => {
+          const matchTier = activeTier === "all" || card.dataset.tier === activeTier;
+          const haystack = `${card.dataset.name} ${card.dataset.token} ${card.dataset.tier}`.toLowerCase();
+          const matchSearch = !q || haystack.includes(q);
+          const show = matchTier && matchSearch;
+          card.style.display = show ? "" : "none";
+          if (show) visible++;
+        });
+        empty.hidden = visible > 0;
+      }
+
+      function setView(mode) {
+        grid.classList.toggle("is-list", mode === "list");
+        grid.classList.toggle("is-grid", mode === "grid");
+        viewBtns.forEach((b) => b.classList.toggle("is-active", b.dataset.view === mode));
+        try { localStorage.setItem("reports-view", mode); } catch {}
+      }
+
+      // Restore preference (default "list")
+      let savedView = "list";
+      try { savedView = localStorage.getItem("reports-view") || "list"; } catch {}
+      setView(savedView);
+
+      search.addEventListener("input", apply);
+      pills.forEach((p) => {
+        p.addEventListener("click", () => {
+          pills.forEach((x) => x.classList.remove("is-active"));
+          p.classList.add("is-active");
+          activeTier = p.dataset.tier;
+          apply();
+        });
       });
-    });
+      viewBtns.forEach((b) => {
+        b.addEventListener("click", () => setView(b.dataset.view));
+      });
+
+      // Mouse-tracking glow
+      cards.forEach((card) => {
+        card.addEventListener("pointermove", (e) => {
+          const r = card.getBoundingClientRect();
+          card.style.setProperty("--mx", `${e.clientX - r.left}px`);
+          card.style.setProperty("--my", `${e.clientY - r.top}px`);
+        });
+        card.addEventListener("pointerleave", () => {
+          card.style.removeProperty("--mx");
+          card.style.removeProperty("--my");
+        });
+      });
+    })();
   </script>
 </BaseLayout>
 
 <style>
-  h1 {
-    margin-bottom: 1rem;
+  .reports-hero {
+    padding: 2rem 0 1.5rem;
+    text-align: center;
   }
-  .search-row {
-    margin-bottom: 0.75rem;
+  .section-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--brand-blue);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
   }
-  .search-row input {
+  .pulse-dot {
+    width: 6px;
+    height: 6px;
+    background: var(--brand-blue);
+    border-radius: 50%;
+    box-shadow: 0 0 0 0 rgba(6, 117, 249, 0.6);
+    animation: pulse 2s ease-out infinite;
+  }
+  @keyframes pulse {
+    0% { box-shadow: 0 0 0 0 rgba(6, 117, 249, 0.6); }
+    70% { box-shadow: 0 0 0 8px rgba(6, 117, 249, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(6, 117, 249, 0); }
+  }
+  .reports-hero h1 {
+    font-size: clamp(1.75rem, 3.4vw, 2.4rem);
+    letter-spacing: -0.02em;
+    margin: 0 auto 0.75rem;
+    line-height: 1.15;
+    max-width: 22ch;
+  }
+  .reports-sub {
+    color: var(--text-secondary);
+    max-width: 60ch;
+    margin: 0 auto;
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+
+  .tools {
+    margin: 2rem 0 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+  .tools-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .search-wrap {
+    position: relative;
+    max-width: 480px;
     width: 100%;
-    max-width: 360px;
-    background: var(--bg-secondary);
+    flex: 1;
+  }
+  .search-icon {
+    position: absolute;
+    left: 0.85rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-secondary);
+    pointer-events: none;
+  }
+  .search-wrap input {
+    width: 100%;
+    padding: 0.65rem 0.85rem 0.65rem 2.4rem;
+    background: color-mix(in srgb, var(--bg-card) 55%, transparent);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
     color: var(--text-primary);
     border: 1px solid var(--border);
-    border-radius: 4px;
-    padding: 0.4rem 0.6rem;
-    font-size: 0.85rem;
+    border-radius: 10px;
+    font-size: 0.9rem;
+    transition: border-color 0.15s, background 0.15s;
   }
-  .search-row input::placeholder {
+  .search-wrap input::placeholder {
     color: var(--text-secondary);
   }
-  .col-icon {
+  .search-wrap input:focus {
+    outline: none;
+    border-color: var(--brand-blue);
+    background: color-mix(in srgb, var(--bg-card) 75%, transparent);
+  }
+
+  .filter-pills {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .filter-pill {
+    --pill-accent: var(--brand-blue);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.4rem 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bg-card) 50%, transparent);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    color: var(--text-secondary);
+    font-size: 0.82rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+    font-family: inherit;
+  }
+  .filter-pill:hover {
+    color: var(--text-primary);
+    border-color: color-mix(in srgb, var(--pill-accent) 50%, var(--border));
+  }
+  .filter-pill.is-active {
+    color: var(--text-primary);
+    border-color: color-mix(in srgb, var(--pill-accent) 70%, var(--border));
+    background: color-mix(in srgb, var(--pill-accent) 14%, transparent);
+  }
+  .pill-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--pill-accent);
+  }
+  .pill-count {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bg-secondary) 80%, transparent);
+  }
+  .filter-pill.is-active .pill-count {
+    color: var(--text-primary);
+  }
+
+  .view-toggle {
+    display: inline-flex;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--bg-card) 50%, transparent);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+  .view-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     width: 36px;
-    padding-right: 0;
+    height: 36px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+    font-family: inherit;
+  }
+  .view-btn:hover { color: var(--text-primary); }
+  .view-btn.is-active {
+    color: var(--text-primary);
+    background: color-mix(in srgb, var(--brand-blue) 22%, transparent);
+  }
+  .view-btn + .view-btn { border-left: 1px solid var(--border); }
+
+  .reports-grid {
+    display: grid;
+    gap: 0.85rem;
+    margin-bottom: 3rem;
+  }
+  /* Grid view */
+  .reports-grid.is-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  @media (max-width: 880px) {
+    .reports-grid.is-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  }
+  @media (max-width: 540px) {
+    .reports-grid.is-grid { grid-template-columns: 1fr; }
+  }
+  /* List view — single column, horizontal card layout */
+  .reports-grid.is-list {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+  }
+  .reports-grid.is-list .report-card {
+    flex-direction: row;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+  }
+  .reports-grid.is-list .card-head {
+    flex: 1;
+    min-width: 0;
+    flex-wrap: nowrap;
+  }
+  .reports-grid.is-list .warning-banner {
+    order: 0;
+    flex-basis: auto;
+  }
+  .reports-grid.is-list .card-foot {
+    flex-shrink: 0;
+    margin-top: 0;
+    padding-top: 0;
+    align-items: center;
+    gap: 1rem;
+  }
+  .reports-grid.is-list .warning-banner {
+    align-self: center;
+    flex-shrink: 0;
+  }
+  .reports-grid.is-list .tier-sm {
+    min-width: 96px;
+    text-align: right;
+  }
+  @media (max-width: 640px) {
+    .reports-grid.is-list .tier-sm {
+      display: none;
+    }
+    .reports-grid.is-list .warning-banner {
+      display: none;
+    }
+    .reports-grid.is-list .report-card {
+      gap: 0.65rem;
+      padding: 0.65rem 0.85rem;
+    }
+  }
+
+  /* Card */
+  .report-card {
+    --accent: var(--brand-blue);
+    --mx: 50%;
+    --my: 50%;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    padding: 1.1rem;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--bg-card) 65%, transparent);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    color: var(--text-primary);
+    text-decoration: none;
+    overflow: hidden;
+    isolation: isolate;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+  .report-card:hover {
+    text-decoration: none;
+    transform: translateY(-2px);
+    border-color: color-mix(in srgb, var(--accent) 65%, var(--border));
+    box-shadow:
+      0 12px 30px -18px rgba(0, 0, 0, 0.6),
+      0 0 0 1px color-mix(in srgb, var(--accent) 25%, transparent);
+  }
+  .card-glow {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    opacity: 0;
+    background: radial-gradient(
+      260px circle at var(--mx, 50%) var(--my, 50%),
+      color-mix(in srgb, var(--accent) 18%, transparent),
+      transparent 60%
+    );
+    transition: opacity 0.25s;
+  }
+  .report-card:hover .card-glow { opacity: 1; }
+
+  .card-head {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
   }
   .icon-stack {
     position: relative;
-    width: 24px;
-    height: 24px;
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
   }
   .protocol-icon {
     display: block;
@@ -104,53 +500,108 @@ const reports = getAllReports();
   }
   .chain-icon {
     position: absolute;
-    bottom: -4px;
-    right: -6px;
+    bottom: -3px;
+    right: -4px;
     border-radius: 50%;
-    border: 1.5px solid var(--bg-primary);
-    background: var(--bg-primary);
+    border: 2px solid var(--bg-card);
+    background: var(--bg-card);
   }
   .icon-placeholder {
-    width: 24px;
-    height: 24px;
+    width: 100%;
+    height: 100%;
     border-radius: 50%;
     background: var(--bg-secondary);
   }
-  .warning-tag {
-    display: inline-block;
-    background: #dc2626;
-    color: #fff;
-    font-size: 0.7rem;
-    font-weight: 600;
-    padding: 0.15rem 0.4rem;
-    border-radius: 4px;
-    margin-left: 0.5rem;
-    vertical-align: middle;
+  .card-title {
+    flex: 1;
+    min-width: 0;
   }
+  .card-name {
+    font-size: 0.98rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .card-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    margin-top: 0.1rem;
+  }
+  .card-meta .sep { opacity: 0.4; }
   .mono {
     font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 0.85em;
+    font-size: 0.92em;
   }
-  tbody tr {
-    cursor: pointer;
+
+  .warning-banner {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: #fca5a5;
+    background: color-mix(in srgb, #dc2626 18%, transparent);
+    border: 1px solid color-mix(in srgb, #dc2626 35%, transparent);
+    padding: 0.3rem 0.55rem;
+    border-radius: 6px;
+    font-size: 0.74rem;
+    font-weight: 500;
+    /* In grid view: wrap onto its own row inside card-head, after the
+       icon/title/badge row. In list view this is overridden below to
+       sit inline between the title and the score badge. */
+    order: 1;
+    flex-basis: 100%;
+    align-self: flex-start;
   }
-  tbody tr:hover {
-    background: var(--bg-secondary);
+
+  .card-foot {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: auto;
+    padding-top: 0.25rem;
   }
-  table {
-    background: color-mix(in srgb, var(--bg-primary) 65%, transparent);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
-    border-radius: 8px;
-    overflow: hidden;
+  .tier-sm {
+    font-size: 0.74rem;
+    font-weight: 600;
   }
-  @media (max-width: 640px) {
-    table {
-      font-size: 0.8rem;
-    }
-    th,
-    td {
-      padding: 0.4rem 0.5rem;
-    }
+  .score-bar {
+    display: flex;
+    gap: 3px;
+  }
+  .score-seg {
+    width: 10px;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--border);
+    transition: background 0.2s;
+  }
+
+  .empty-state {
+    margin: 3rem auto;
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+  }
+  .empty-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--bg-card) 60%, transparent);
+    border: 1px solid var(--border);
+    margin-bottom: 0.75rem;
+    color: var(--text-secondary);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pulse-dot { animation: none; }
   }
 </style>

--- a/src/pages/tokens.astro
+++ b/src/pages/tokens.astro
@@ -56,18 +56,40 @@ const sortedShared = [...shared].sort((a: any, b: any) => {
 });
 
 const uniqueTokens = [...new Set(dependencies.map((d: any) => d.asset))].sort();
-
 ---
 
-<BaseLayout title="Token Exposures - Yearn Curation">
-  <h1>Token Exposures</h1>
-  <section>
-    <h2>Shared Token Exposure</h2>
-    <p class="section-desc">Tokens accepted by multiple protocols. If one depegs or its parent protocol fails, all listed protocols are affected.</p>
-    <div class="search-row">
+<BaseLayout title="Token Exposures — Yearn Curation" ogUrl="/tokens/" ogImage="/og/default.png">
+  <section class="page-hero">
+    <div class="section-eyebrow">
+      <span class="pulse-dot"></span>
+      Cross-protocol exposure
+    </div>
+    <h1>Token Exposures</h1>
+    <p class="page-sub">
+      Where assets in curated protocols overlap. If a shared token depegs or
+      its parent protocol fails, every protocol that holds it is affected —
+      this page maps the chain.
+    </p>
+  </section>
+
+  <section class="block">
+    <div class="block-head">
+      <div>
+        <h2>Shared Token Exposure</h2>
+      </div>
+      <span class="block-meta">{sortedShared.length} tokens</span>
+    </div>
+    <p class="block-desc">
+      Tokens accepted by multiple curated protocols. Sorted by risk band, then
+      by number of exposed protocols.
+    </p>
+
+    <div class="search-wrap">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="search-icon"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
       <input type="text" id="token-search" placeholder="Search tokens…" autocomplete="off" />
     </div>
-    <div class="table-wrap">
+
+    <div class="table-card">
       <table id="shared-table">
         <thead>
           <tr>
@@ -75,7 +97,7 @@ const uniqueTokens = [...new Set(dependencies.map((d: any) => d.asset))].sort();
             <th>Token</th>
             <th>Parent Protocol</th>
             <th>Exposed Protocols</th>
-            <th class="col-num">Score</th>
+            <th class="col-num">Risk</th>
           </tr>
         </thead>
         <tbody>
@@ -84,16 +106,16 @@ const uniqueTokens = [...new Set(dependencies.map((d: any) => d.asset))].sort();
               <td class="col-icon">
                 {row.address ? (
                   <Fragment>
-                    <img src={tokenIconUrl(row.address)} alt="" width="20" height="20" class="token-icon" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='block'" />
+                    <img src={tokenIconUrl(row.address)} alt="" width="22" height="22" class="token-icon" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='block'" />
                     <div class="icon-placeholder small" style="display:none" />
                   </Fragment>
                 ) : (
                   <div class="icon-placeholder small" />
                 )}
               </td>
-              <td class="mono">{row.asset}</td>
-              <td>{row.parent || <span class="muted">-</span>}</td>
-              <td>{row.protocols.join(", ")}</td>
+              <td class="mono token-cell">{row.asset}</td>
+              <td>{row.parent || <span class="muted">—</span>}</td>
+              <td class="protocols-cell">{row.protocols.join(", ")}</td>
               <td class="col-num">
                 <span class={`risk-badge risk-${tokenRisk(row.asset)}`}>{tokenRisk(row.asset)}</span>
               </td>
@@ -104,15 +126,29 @@ const uniqueTokens = [...new Set(dependencies.map((d: any) => d.asset))].sort();
     </div>
   </section>
 
-  <section>
-    <h2>Protocols</h2>
-    <div class="protocol-cards">
+  <section class="block">
+    <div class="block-head">
+      <div>
+        <div class="section-eyebrow">
+          <span class="pulse-dot"></span>
+          Protocols
+        </div>
+        <h2>Curated protocols</h2>
+      </div>
+      <span class="block-meta">{protocolsWithIcons.length} tracked</span>
+    </div>
+    <p class="block-desc">
+      Click a card to filter the dependency table below to that protocol.
+    </p>
+
+    <div class="protocol-grid">
       {protocolsWithIcons.map((p: any) => (
-        <div class="protocol-card" data-name={p.name}>
-          <div class="card-header">
+        <button class="protocol-card" data-name={p.name} type="button">
+          <div class="card-glow" aria-hidden="true"></div>
+          <div class="card-row">
             <div class="icon-stack">
               {p.iconUrl ? (
-                <img src={p.iconUrl} alt="" width="24" height="24" class="protocol-icon" loading="lazy" />
+                <img src={p.iconUrl} alt="" width="32" height="32" class="protocol-icon" loading="lazy" />
               ) : (
                 <div class="icon-placeholder" />
               )}
@@ -120,37 +156,63 @@ const uniqueTokens = [...new Set(dependencies.map((d: any) => d.asset))].sort();
                 <img src={p.chainIconUrl} alt="" width="14" height="14" class="chain-icon" loading="lazy" />
               )}
             </div>
-            <div class="card-name">{p.name}</div>
+            <div class="card-title">
+              <div class="card-name">{p.name}</div>
+              <div class="card-meta">
+                <span class="mono">{p.chain}</span>
+                <span class="sep">·</span>
+                <span>{p.type.replace(/_/g, " ")}</span>
+              </div>
+            </div>
+            <div class="card-count">
+              <div class="count-num">{p.assetCount}</div>
+              <div class="count-label">tokens</div>
+            </div>
           </div>
-          <div class="card-meta">
-            <span class="mono">{p.chain}</span>
-            <span class="muted">{p.type.replace("_", " ")}</span>
-            <span>{p.assetCount} tokens</span>
-          </div>
-        </div>
+        </button>
       ))}
     </div>
   </section>
 
-  <section>
-    <h2>Full Dependency Table</h2>
-    <div class="filter-row">
-      <label for="protocol-filter">Protocol:</label>
-      <select id="protocol-filter">
-        <option value="all">All</option>
-        {protocols.map((p: any) => (
-          <option value={p.name}>{p.name}</option>
-        ))}
-      </select>
-      <label for="token-filter">Token:</label>
-      <select id="token-filter">
-        <option value="all">All</option>
-        {uniqueTokens.map((t: string) => (
-          <option value={t}>{t}</option>
-        ))}
-      </select>
+  <section class="block">
+    <div class="block-head">
+      <div>
+        <div class="section-eyebrow">
+          <span class="pulse-dot"></span>
+          Full table
+        </div>
+        <h2>Dependencies</h2>
+      </div>
+      <span class="block-meta" id="dep-meta">{dependencies.length} rows</span>
     </div>
-    <div class="table-wrap">
+    <p class="block-desc">
+      Every protocol-token relationship the curation team tracks, with type
+      and allocation when available.
+    </p>
+
+    <div class="filter-row">
+      <div class="select-wrap">
+        <label for="protocol-filter">Protocol</label>
+        <select id="protocol-filter">
+          <option value="all">All</option>
+          {protocols.map((p: any) => (
+            <option value={p.name}>{p.name}</option>
+          ))}
+        </select>
+      </div>
+      <div class="select-wrap">
+        <label for="token-filter">Token</label>
+        <select id="token-filter">
+          <option value="all">All</option>
+          {uniqueTokens.map((t: string) => (
+            <option value={t}>{t}</option>
+          ))}
+        </select>
+      </div>
+      <button class="filter-reset" id="filter-reset" type="button">Reset</button>
+    </div>
+
+    <div class="table-card">
       <table id="dep-table">
         <thead>
           <tr>
@@ -163,13 +225,12 @@ const uniqueTokens = [...new Set(dependencies.map((d: any) => d.asset))].sort();
           </tr>
         </thead>
         <tbody>
-          {dependencies.map((row: any) => {
-            return (
+          {dependencies.map((row: any) => (
             <tr data-protocol={row.protocol} data-token={row.asset}>
               <td class="col-icon">
                 {row.address ? (
                   <Fragment>
-                    <img src={tokenIconUrl(row.address)} alt="" width="20" height="20" class="token-icon" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='block'" />
+                    <img src={tokenIconUrl(row.address)} alt="" width="22" height="22" class="token-icon" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='block'" />
                     <div class="icon-placeholder small" style="display:none" />
                   </Fragment>
                 ) : (
@@ -177,93 +238,324 @@ const uniqueTokens = [...new Set(dependencies.map((d: any) => d.asset))].sort();
                 )}
               </td>
               <td>{row.protocol}</td>
-              <td class="mono">{row.asset}</td>
-              <td><span class={`type-badge type-${row.type}`}>{row.type}</span></td>
-              <td>{row.parent || <span class="muted">-</span>}</td>
-              <td class="mono">{row.allocation || <span class="muted">-</span>}</td>
+              <td class="mono token-cell">{row.asset}</td>
+              <td><span class={`type-badge type-${row.type}`}>{row.type.replace(/_/g, " ")}</span></td>
+              <td>{row.parent || <span class="muted">—</span>}</td>
+              <td class="mono">{row.allocation || <span class="muted">—</span>}</td>
             </tr>
-            );
-          })}
+          ))}
         </tbody>
       </table>
     </div>
   </section>
 
   <script is:inline>
-    // Shared Token Exposure search
-    const tokenSearch = document.getElementById("token-search");
-    const sharedRows = document.querySelectorAll("#shared-table tbody tr");
-    tokenSearch.addEventListener("input", () => {
-      const q = tokenSearch.value.toLowerCase();
-      sharedRows.forEach((row) => {
-        const text = row.textContent.toLowerCase();
-        row.style.display = text.includes(q) ? "" : "none";
+    (() => {
+      // Shared Token Exposure search
+      const tokenSearch = document.getElementById("token-search");
+      const sharedRows = document.querySelectorAll("#shared-table tbody tr");
+      tokenSearch.addEventListener("input", () => {
+        const q = tokenSearch.value.toLowerCase();
+        sharedRows.forEach((row) => {
+          const text = row.textContent.toLowerCase();
+          row.style.display = text.includes(q) ? "" : "none";
+        });
       });
-    });
 
-    // Dependency table filters
-    const protocolFilter = document.getElementById("protocol-filter");
-    const tokenFilter = document.getElementById("token-filter");
-    const depRows = document.querySelectorAll("#dep-table tbody tr");
+      // Dependency filters
+      const protocolFilter = document.getElementById("protocol-filter");
+      const tokenFilter = document.getElementById("token-filter");
+      const reset = document.getElementById("filter-reset");
+      const depRows = document.querySelectorAll("#dep-table tbody tr");
+      const depMeta = document.getElementById("dep-meta");
 
-    function applyDepFilters() {
-      const pVal = protocolFilter.value;
-      const tVal = tokenFilter.value;
-      depRows.forEach((row) => {
-        const matchProtocol = pVal === "all" || row.dataset.protocol === pVal;
-        const matchToken = tVal === "all" || row.dataset.token === tVal;
-        row.style.display = matchProtocol && matchToken ? "" : "none";
-      });
-    }
+      function applyDepFilters() {
+        const pVal = protocolFilter.value;
+        const tVal = tokenFilter.value;
+        let visible = 0;
+        depRows.forEach((row) => {
+          const matchProtocol = pVal === "all" || row.dataset.protocol === pVal;
+          const matchToken = tVal === "all" || row.dataset.token === tVal;
+          const show = matchProtocol && matchToken;
+          row.style.display = show ? "" : "none";
+          if (show) visible++;
+        });
+        depMeta.textContent = visible === depRows.length
+          ? `${depRows.length} rows`
+          : `${visible} of ${depRows.length} rows`;
+      }
 
-    protocolFilter.addEventListener("change", applyDepFilters);
-    tokenFilter.addEventListener("change", applyDepFilters);
-
-    document.querySelectorAll(".protocol-card").forEach((card) => {
-      card.addEventListener("click", () => {
-        protocolFilter.value = card.dataset.name;
+      protocolFilter.addEventListener("change", applyDepFilters);
+      tokenFilter.addEventListener("change", applyDepFilters);
+      reset.addEventListener("click", () => {
+        protocolFilter.value = "all";
         tokenFilter.value = "all";
         applyDepFilters();
-        protocolFilter.scrollIntoView({ behavior: "smooth", block: "start" });
       });
-    });
+
+      // Protocol cards filter the dep table
+      document.querySelectorAll(".protocol-card").forEach((card) => {
+        card.addEventListener("click", () => {
+          protocolFilter.value = card.dataset.name;
+          tokenFilter.value = "all";
+          applyDepFilters();
+          document.getElementById("dep-table").scrollIntoView({ behavior: "smooth", block: "start" });
+        });
+        card.addEventListener("pointermove", (e) => {
+          const r = card.getBoundingClientRect();
+          card.style.setProperty("--mx", `${e.clientX - r.left}px`);
+          card.style.setProperty("--my", `${e.clientY - r.top}px`);
+        });
+        card.addEventListener("pointerleave", () => {
+          card.style.removeProperty("--mx");
+          card.style.removeProperty("--my");
+        });
+      });
+    })();
   </script>
 </BaseLayout>
 
 <style>
-  h1 { margin-bottom: 0.25rem; }
-  section { margin-bottom: 2.5rem; }
-  h2 { margin-bottom: 0.5rem; }
-  .search-row {
-    margin-bottom: 0.75rem;
+  /* === Hero === */
+  .page-hero {
+    padding: 2rem 0 1.5rem;
+    text-align: center;
   }
-  .search-row input {
+  .page-hero h1 {
+    font-size: clamp(1.75rem, 3.4vw, 2.4rem);
+    letter-spacing: -0.02em;
+    margin: 0 auto 0.75rem;
+    line-height: 1.15;
+    max-width: 22ch;
+  }
+  .page-sub {
+    color: var(--text-secondary);
+    max-width: 60ch;
+    margin: 0 auto;
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+
+  /* === Section eyebrow === */
+  .section-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--brand-blue);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+  .pulse-dot {
+    width: 6px;
+    height: 6px;
+    background: var(--brand-blue);
+    border-radius: 50%;
+    box-shadow: 0 0 0 0 rgba(6, 117, 249, 0.6);
+    animation: pulse 2s ease-out infinite;
+  }
+  @keyframes pulse {
+    0% { box-shadow: 0 0 0 0 rgba(6, 117, 249, 0.6); }
+    70% { box-shadow: 0 0 0 8px rgba(6, 117, 249, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(6, 117, 249, 0); }
+  }
+
+  /* === Block === */
+  .block { margin: 2.5rem 0; }
+  .block-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .block h2 {
+    font-size: 1.3rem;
+    letter-spacing: -0.01em;
+  }
+  .block-meta {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    padding: 0.3rem 0.7rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bg-card) 50%, transparent);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    font-variant-numeric: tabular-nums;
+  }
+  .block-desc {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.5;
+    margin-bottom: 1rem;
+    max-width: 70ch;
+  }
+
+  /* === Search === */
+  .search-wrap {
+    position: relative;
+    max-width: 480px;
+    margin-bottom: 0.85rem;
+  }
+  .search-icon {
+    position: absolute;
+    left: 0.85rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-secondary);
+    pointer-events: none;
+  }
+  .search-wrap input {
     width: 100%;
-    max-width: 360px;
-    background: var(--bg-secondary);
+    padding: 0.65rem 0.85rem 0.65rem 2.4rem;
+    background: color-mix(in srgb, var(--bg-card) 55%, transparent);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
     color: var(--text-primary);
     border: 1px solid var(--border);
-    border-radius: 4px;
-    padding: 0.4rem 0.6rem;
-    font-size: 0.85rem;
+    border-radius: 10px;
+    font-size: 0.9rem;
+    transition: border-color 0.15s, background 0.15s;
   }
-  .search-row input::placeholder {
+  .search-wrap input::placeholder {
     color: var(--text-secondary);
   }
-  .section-desc {
-    color: var(--text-secondary);
-    font-size: 0.85rem;
-    margin-bottom: 1rem;
+  .search-wrap input:focus {
+    outline: none;
+    border-color: var(--brand-blue);
+    background: color-mix(in srgb, var(--bg-card) 75%, transparent);
   }
-  .mono { font-family: "SF Mono", "Fira Code", monospace; font-size: 0.85em; }
-  .muted { color: var(--text-secondary); }
-  .col-num { text-align: center; width: 60px; }
-  .risk-badge {
-    display: inline-block;
-    padding: 0.15rem 0.5rem;
-    border-radius: 999px;
-    font-size: 0.8rem;
+
+  /* === Filter row === */
+  .filter-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 0.75rem;
+    margin-bottom: 0.85rem;
+  }
+  .select-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .select-wrap label {
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
     font-weight: 600;
+  }
+  .select-wrap select {
+    appearance: none;
+    -webkit-appearance: none;
+    min-width: 200px;
+    padding: 0.55rem 2.2rem 0.55rem 0.85rem;
+    background: color-mix(in srgb, var(--bg-card) 55%, transparent);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%239d9d9d' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 0.75rem center;
+    transition: border-color 0.15s;
+  }
+  .select-wrap select:focus {
+    outline: none;
+    border-color: var(--brand-blue);
+  }
+  .filter-reset {
+    padding: 0.55rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--bg-card) 50%, transparent);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    font-family: inherit;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+  }
+  .filter-reset:hover {
+    color: var(--text-primary);
+    border-color: var(--text-secondary);
+  }
+
+  /* === Table card === */
+  .table-card {
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--bg-card) 55%, transparent);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    overflow: hidden;
+  }
+  .table-card table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.88rem;
+    margin: 0;
+  }
+  .table-card thead th {
+    background: color-mix(in srgb, var(--bg-secondary) 60%, transparent);
+    color: var(--text-secondary);
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.7rem 0.85rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+  }
+  .table-card tbody td {
+    padding: 0.6rem 0.85rem;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+    vertical-align: middle;
+  }
+  .table-card tbody tr:last-child td { border-bottom: none; }
+  .table-card tbody tr {
+    transition: background 0.15s;
+  }
+  .table-card tbody tr:hover {
+    background: color-mix(in srgb, var(--brand-blue) 6%, transparent);
+  }
+  .table-card .col-icon {
+    width: 36px;
+    padding-right: 0;
+  }
+  .table-card .col-num {
+    text-align: center;
+    width: 60px;
+  }
+  .token-cell { font-weight: 500; }
+  .protocols-cell {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+  }
+  .mono { font-family: "SF Mono", "Fira Code", monospace; font-size: 0.92em; }
+  .muted { color: var(--text-secondary); }
+
+  /* === Risk badges === */
+  .risk-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    height: 24px;
+    padding: 0 0.5rem;
+    border-radius: 6px;
+    font-size: 0.78rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
   }
   .risk-1 { background: #22C55E; color: #0c0c0c; }
   .risk-2 { background: #86EFAC; color: #0c0c0c; }
@@ -272,95 +564,157 @@ const uniqueTokens = [...new Set(dependencies.map((d: any) => d.asset))].sort();
   .risk-5 { background: #EF4444; color: #fff; }
   .risk-\? { background: #64748B; color: #fff; }
 
+  /* === Type badges === */
   .type-badge {
-    font-size: 0.75rem;
-    padding: 0.15rem 0.4rem;
-    border-radius: 4px;
+    display: inline-block;
+    font-size: 0.72rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 999px;
     font-weight: 500;
+    text-transform: capitalize;
+    letter-spacing: 0.01em;
   }
-  .type-collateral { background: var(--brand-blue); color: #fff; }
-  .type-base { background: #22C55E; color: #0c0c0c; }
-  .type-yield_source { background: #A78BFA; color: #0c0c0c; }
+  .type-collateral { background: color-mix(in srgb, var(--brand-blue) 18%, transparent); color: #7eb4ff; border: 1px solid color-mix(in srgb, var(--brand-blue) 35%, transparent); }
+  .type-base { background: color-mix(in srgb, #22C55E 18%, transparent); color: #86EFAC; border: 1px solid color-mix(in srgb, #22C55E 35%, transparent); }
+  .type-yield_source { background: color-mix(in srgb, #A78BFA 18%, transparent); color: #c4b5fd; border: 1px solid color-mix(in srgb, #A78BFA 35%, transparent); }
 
-  .protocol-cards {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-    gap: 0.75rem;
-    margin-bottom: 1rem;
+  /* === Icon stacks === */
+  .icon-stack {
+    position: relative;
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
   }
-  .protocol-card {
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 0.75rem 1rem;
-    background: var(--bg-card);
-    cursor: pointer;
-    transition: border-color 0.2s;
-  }
-  .protocol-card:hover {
-    border-color: var(--brand-blue);
-    background: rgba(6, 117, 249, 0.08);
-  }
-  .card-header {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.25rem;
-  }
-  .card-name { font-weight: 600; }
-
-  .col-icon { width: 36px; padding-right: 0; }
-  .icon-stack { position: relative; width: 24px; height: 24px; flex-shrink: 0; }
   .protocol-icon { display: block; border-radius: 50%; }
   .chain-icon {
     position: absolute;
-    bottom: -4px;
-    right: -6px;
+    bottom: -3px;
+    right: -4px;
     border-radius: 50%;
-    border: 1.5px solid var(--bg-primary);
-    background: var(--bg-primary);
+    border: 2px solid var(--bg-card);
+    background: var(--bg-card);
   }
+  .token-icon { display: block; border-radius: 50%; }
   .icon-placeholder {
-    width: 24px;
-    height: 24px;
+    width: 100%;
+    height: 100%;
     border-radius: 50%;
     background: var(--bg-secondary);
   }
   .icon-placeholder.small {
-    width: 20px;
-    height: 20px;
+    width: 22px;
+    height: 22px;
   }
-  .token-icon {
-    display: block;
-    border-radius: 50%;
+
+  /* === Protocol cards === */
+  .protocol-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+  @media (max-width: 720px) {
+    .protocol-grid { grid-template-columns: 1fr; }
+  }
+  .protocol-card {
+    --accent: var(--brand-blue);
+    --mx: 50%;
+    --my: 50%;
+    position: relative;
+    text-align: left;
+    padding: 0.95rem 1.1rem;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--bg-card) 60%, transparent);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    color: var(--text-primary);
+    cursor: pointer;
+    overflow: hidden;
+    isolation: isolate;
+    font-family: inherit;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+  .protocol-card:hover {
+    transform: translateY(-2px);
+    border-color: color-mix(in srgb, var(--accent) 65%, var(--border));
+    box-shadow:
+      0 12px 30px -18px rgba(0, 0, 0, 0.6),
+      0 0 0 1px color-mix(in srgb, var(--accent) 25%, transparent);
+  }
+  .card-glow {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    opacity: 0;
+    background: radial-gradient(
+      260px circle at var(--mx, 50%) var(--my, 50%),
+      color-mix(in srgb, var(--accent) 18%, transparent),
+      transparent 60%
+    );
+    transition: opacity 0.25s;
+  }
+  .protocol-card:hover .card-glow { opacity: 1; }
+  .card-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .card-title {
+    flex: 1;
+    min-width: 0;
+  }
+  .card-name {
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .card-meta {
     display: flex;
-    gap: 0.5rem;
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-  }
-
-  .filter-row {
-    display: flex;
     align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.75rem;
-    font-size: 0.85rem;
+    gap: 0.4rem;
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    margin-top: 0.15rem;
+    text-transform: capitalize;
   }
-  .filter-row label { color: var(--text-secondary); }
-  .filter-row select {
-    background: var(--bg-secondary);
+  .card-meta .sep { opacity: 0.4; }
+  .card-count {
+    text-align: right;
+    flex-shrink: 0;
+    padding-left: 0.5rem;
+  }
+  .count-num {
+    font-size: 1.25rem;
+    font-weight: 700;
+    line-height: 1;
     color: var(--text-primary);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    padding: 0.3rem 0.5rem;
-    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .count-label {
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-top: 0.2rem;
   }
 
   @media (max-width: 640px) {
-    table { font-size: 0.8rem; }
-    th, td { padding: 0.4rem 0.5rem; }
-    .protocol-cards { grid-template-columns: 1fr; }
-    .filter-row { flex-wrap: wrap; }
+    .table-card { font-size: 0.78rem; }
+    .table-card thead th,
+    .table-card tbody td {
+      padding: 0.5rem 0.6rem;
+    }
+    .protocols-cell { font-size: 0.78rem; }
+    .filter-row { gap: 0.5rem; }
+    .select-wrap select { min-width: 0; width: 100%; }
+    .select-wrap { flex: 1; min-width: 140px; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pulse-dot { animation: none; }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,9 @@
+/*
+ * Design tokens. Treat these as the source of truth for color and width;
+ * pages should never hardcode greys, blues, or backgrounds. New surfaces
+ * follow the existing frosted-glass recipe (color-mix(--bg-card, N%) +
+ * backdrop-filter: blur) — see reports.astro / tokens.astro for examples.
+ */
 :root {
   --brand-blue: #0675f9;
   --bg-primary: #0c0c0c;


### PR DESCRIPTION
## Summary

Brings the **reports** and **tokens** pages in line with the landing page's frosted-glass / brand-blue aesthetic and adds a few small UX refinements.

### Reports page (`/reports/`)
- Hero with eyebrow + pulse dot + sub-copy, matching the landing.
- Frosted-glass search bar with magnifier icon + brand-blue focus ring.
- **Risk-tier filter pills** (Minimal / Low / Medium / Elevated / High) with color-keyed dot and count chip; compose with search.
- Card grid replaces the old table — same card anatomy as the landing's compact cards (icon stack, name, token, relative date, score badge, 5-segment score bar) plus mouse-tracking radial glow on hover.
- **View toggle** (list / grid) next to the search; **list is the default**. Choice persists in `localStorage`.
- In list view the warning pill sits inline between title and score so the score badge stays anchored to the right edge; in grid view the warning wraps to its own row.
- Empty state for no-match search/filter.

### Tokens page (`/tokens/`)
- Same page hero pattern.
- Each section gets a count chip ("32 tokens", "16 tracked", "147 rows") on the right of its header; the dependency count updates live as filters apply.
- Frosted-glass tables with rounded corners, subtle row dividers, brand-blue hover tint.
- Type badges become pill-shaped translucent chips, risk badges sized consistently.
- Curated protocols rendered as cards (hover glow, brand-blue accent border, prominent token count). Clicking still scopes the dependency table and scrolls to it.
- Filter row: labeled, frosted selects with custom chevron + a Reset button.

### Nav / layout
- Drop the external "Morpho" link from the header nav (the landing's Morpho card already surfaces it).
- Remove the right-edge `mask-image` on `.header-nav` that was fading the end of "Monitoring" once the nav fit comfortably.
- Speed up the floating pill animations by ~20%.

## Test plan

- [ ] `npm run build` succeeds; visit `/`, `/reports/`, `/tokens/`, `/monitoring/`, `/report/<slug>/`.
- [ ] `/reports/`: list view loads first; toggle to grid and back; reload — last view persists.
- [ ] Risk-tier pills filter the cards; search composes; "All" returns everything; empty state shows when nothing matches.
- [ ] Card hover: lift + tier-colored border + mouse-tracking glow + score-bar segments correct.
- [ ] Cards with warnings (e.g. compound v3 strats): warning sits inline before score in list view; on its own row in grid view; score badge always at the right.
- [ ] `/tokens/`: hero renders, each section's count chip is correct.
- [ ] Shared Token Exposure search filters live.
- [ ] Protocol cards: clicking sets the dependency-table protocol filter and scrolls to it; "X of Y rows" chip updates.
- [ ] Reset button clears both selects.
- [ ] Header nav is `Home / Reports / Tokens / Monitoring` — no Morpho link, no fade on the right of "Monitoring".
- [ ] Pills feel ~20% snappier (durations went 11s → 8.8s, 14s → 11.2s, …).
- [ ] Mobile (≤540px): all layouts collapse cleanly; filter pills wrap; cards stack to single column.
- [ ] `prefers-reduced-motion`: pulse dots and pill float animations stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)