### PR TITLE
feat: automate reassessment issue scan for stale reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/reassessment.yml
+++ b/.github/ISSUE_TEMPLATE/reassessment.yml
@@ -1,0 +1,61 @@
+name: Reassessment
+description: Reassess an existing risk assessment report
+title: "Reassessment: "
+labels: ["reassessment"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to track the reassessment of an existing risk assessment report.
+        Reports are flagged for reassessment automatically once they pass the staleness
+        threshold (60 days since the last assessment date), but this template can also be
+        filed manually when a protocol change warrants a fresh review.
+
+  - type: input
+    id: report-name
+    attributes:
+      label: Report Name
+      description: The name of the report due for reassessment.
+      placeholder: e.g., Lido wstETH
+    validations:
+      required: true
+
+  - type: input
+    id: report-link
+    attributes:
+      label: Report Link
+      description: Link to the report on the site or GitHub.
+      placeholder: https://risk.yearn.farm/report/lido-wsteth
+    validations:
+      required: false
+
+  - type: input
+    id: last-assessment-date
+    attributes:
+      label: Last Assessment Date
+      description: The Assessment Date currently recorded in the report.
+      placeholder: e.g., February 12, 2026
+    validations:
+      required: false
+
+  - type: textarea
+    id: changes-since
+    attributes:
+      label: Changes Since Last Assessment
+      description: |
+        Note any known changes since the last assessment that may affect the score
+        (audits, exploits, governance changes, integrations, TVL shifts, team changes, etc.).
+      placeholder: |
+        - New audit by ChainSecurity (March 2026)
+        - Migrated from EOA admin to 4/7 multisig
+        - Added Symbiotic restaking integration
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context relevant to the reassessment.
+      validations:
+        required: false

--- a/.github/workflows/reassessment-scan.yml
+++ b/.github/workflows/reassessment-scan.yml
@@ -1,0 +1,32 @@
+name: Reassessment Scan
+
+on:
+  schedule:
+    - cron: '0 12 * * 6'  # Saturday at 12:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print what would be done without creating issues"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  scan-stale-reports:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history needed for git-last-commit fallback
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Scan for stale reports and open reassessment issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run && 'true' || '' }}
+        run: uv run scripts/check_stale_reports.py

--- a/reports/TEMPLATE.md
+++ b/reports/TEMPLATE.md
@@ -1,10 +1,24 @@
 # Protocol Risk Assessment: [Protocol Name]
 
-- **Assessment Date:** [Date]
+- **Assessment Date:** [Month Day, Year]
 - **Token:** [Token Name]
 - **Chain:** [Chain Name]
 - **Token Address:** [`[Token Address]`]([Token Explorer Link])
 - **Final Score: X/5.0**
+
+<!--
+Assessment Date format:
+  - Use full English month name and four-digit year, e.g. "March 4, 2026".
+  - When a report is reassessed, append the new date in parentheses on the
+    same line, e.g.
+        **Assessment Date:** February 8, 2026 (Updated: March 22, 2026)
+    or, when reassessing in response to an event:
+        **Assessment Date:** April 27, 2026 (reassessment after April 18, 2026 exploit)
+  - The reassessment-scan workflow parses every "Month Day, Year" date on this
+    line and uses the latest one to decide whether the report is stale, so the
+    appended date keeps the staleness clock honest.
+-->
+
 
 ## Overview + Links
 

--- a/reports/report/midas-mhyper.md
+++ b/reports/report/midas-mhyper.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: Midas mHYPER
 
-- **Assessment Date:** February 7, 2026 (updated April 9, 2026)
+- **Assessment Date:** February 7, 2026 (Updated: April 9, 2026)
 - **Token:** mHYPER
 - **Chain:** Ethereum (also deployed on Monad, Plasma, Katana)
 - **Token Address:** [`0x9b5528528656DBC094765E2abB79F293c21191B9`](https://etherscan.io/token/0x9b5528528656dbc094765e2abb79f293c21191b9)

--- a/scripts/check_stale_reports.py
+++ b/scripts/check_stale_reports.py
@@ -187,11 +187,9 @@ def main() -> int:
         return 1
 
     if dry_run:
-        log.info("DRY-RUN enabled — no issues will be created or fetched")
-        existing_titles: set[str] = set()
-    else:
-        existing_titles = open_reassessment_titles()
-        log.info("found %d existing open reassessment issues", len(existing_titles))
+        log.info("DRY-RUN enabled — no issues will be created")
+    existing_titles = open_reassessment_titles()
+    log.info("found %d existing open reassessment issues", len(existing_titles))
 
     stale_count = 0
     skipped_count = 0

--- a/scripts/check_stale_reports.py
+++ b/scripts/check_stale_reports.py
@@ -1,0 +1,217 @@
+"""Scan reports/report/*.md and open reassessment issues for stale reports.
+
+A report is considered stale if its assessment date is more than STALE_DAYS old.
+The assessment date is parsed from the `**Assessment Date:**` line in the report
+header; if that line includes one or more "(updated <date>)" annotations, the
+latest date wins. If no date can be parsed, falls back to the file's last git
+commit date.
+
+Existing open issues with the `reassessment` label and matching title are not
+re-created, so the workflow is safe to run repeatedly.
+"""
+
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPORTS_DIR = Path("reports/report")
+STALE_DAYS = 60
+LABEL = "reassessment"
+TITLE_PREFIX = "Reassessment: "
+
+ASSESSMENT_LINE_RE = re.compile(r"\*\*Assessment Date:\*\*\s*([^\n]+)", re.IGNORECASE)
+DATE_RE = re.compile(
+    r"\b("
+    r"January|February|March|April|May|June|July|August|September|October|November|December"
+    r")\s+(\d{1,2}),\s+(\d{4})\b"
+)
+TITLE_RE = re.compile(r"^#\s+(.+)$", re.MULTILINE)
+SCORE_RE = re.compile(r"\*\*Final Score:?\*\*\s*([\d.]+)\s*/\s*5\.0")
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+log = logging.getLogger("stale-reports")
+
+
+def parse_dates_from_line(line: str) -> list[datetime]:
+    """Return all `Month Day, Year` dates found in the line, in document order."""
+    out = []
+    for month, day, year in DATE_RE.findall(line):
+        try:
+            out.append(
+                datetime.strptime(f"{month} {day} {year}", "%B %d %Y").replace(
+                    tzinfo=timezone.utc
+                )
+            )
+        except ValueError:
+            continue
+    return out
+
+
+def parse_assessment_date(content: str) -> datetime | None:
+    m = ASSESSMENT_LINE_RE.search(content)
+    if not m:
+        return None
+    dates = parse_dates_from_line(m.group(1))
+    return max(dates) if dates else None
+
+
+def git_last_modified(path: Path) -> datetime | None:
+    try:
+        out = subprocess.check_output(
+            ["git", "log", "-1", "--format=%cI", "--", str(path)],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return None
+    if not out:
+        return None
+    return datetime.fromisoformat(out).astimezone(timezone.utc)
+
+
+def parse_report(path: Path) -> dict:
+    content = path.read_text()
+    title_match = TITLE_RE.search(content)
+    title = title_match.group(1).strip() if title_match else path.stem
+    score_match = SCORE_RE.search(content)
+    score = score_match.group(1) if score_match else None
+
+    date = parse_assessment_date(content)
+    source = "report-header"
+    if date is None:
+        date = git_last_modified(path)
+        source = "git-last-commit"
+
+    return {
+        "path": path,
+        "slug": path.stem,
+        "title": title,
+        "score": score,
+        "date": date,
+        "date_source": source,
+    }
+
+
+def open_reassessment_titles() -> set[str]:
+    out = subprocess.check_output(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--label",
+            LABEL,
+            "--state",
+            "open",
+            "--json",
+            "title",
+            "--limit",
+            "500",
+        ],
+        text=True,
+    )
+    return {issue["title"] for issue in json.loads(out)}
+
+
+def repo_slug() -> str | None:
+    return os.environ.get("GITHUB_REPOSITORY")
+
+
+def build_issue_body(report: dict, days: int) -> str:
+    repo = repo_slug()
+    rel = f"reports/report/{report['slug']}.md"
+    if repo:
+        link = f"https://github.com/{repo}/blob/master/{rel}"
+    else:
+        link = rel
+    date_str = report["date"].date().isoformat() if report["date"] else "unknown"
+    score_str = f"{report['score']}/5.0" if report["score"] else "unknown"
+    return (
+        f"The risk assessment **{report['title']}** has not been updated in "
+        f"{days} days and is due for reassessment.\n\n"
+        f"- **Report:** [`{rel}`]({link})\n"
+        f"- **Last Assessment Date:** {date_str} (source: {report['date_source']})\n"
+        f"- **Current Score:** {score_str}\n"
+        f"- **Days Since Last Assessment:** {days}\n"
+        f"- **Threshold:** {STALE_DAYS} days\n\n"
+        "Opened automatically by the `reassessment-scan` workflow. "
+        "Close this issue once the report has been refreshed.\n"
+    )
+
+
+def create_issue(title: str, body: str, dry_run: bool) -> None:
+    cmd = [
+        "gh",
+        "issue",
+        "create",
+        "--title",
+        title,
+        "--body",
+        body,
+        "--label",
+        LABEL,
+    ]
+    if dry_run:
+        log.info("DRY-RUN would run: %s", " ".join(cmd[:3] + [repr(title)]))
+        return
+    subprocess.run(cmd, check=True)
+
+
+def main() -> int:
+    dry_run = os.environ.get("DRY_RUN", "").lower() in ("1", "true", "yes")
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=STALE_DAYS)
+
+    if not REPORTS_DIR.is_dir():
+        log.error("reports directory not found: %s", REPORTS_DIR)
+        return 1
+
+    if dry_run:
+        log.info("DRY-RUN enabled — no issues will be created or fetched")
+        existing_titles: set[str] = set()
+    else:
+        existing_titles = open_reassessment_titles()
+        log.info("found %d existing open reassessment issues", len(existing_titles))
+
+    stale_count = 0
+    skipped_count = 0
+    for path in sorted(REPORTS_DIR.glob("*.md")):
+        report = parse_report(path)
+        if report["date"] is None:
+            log.warning("could not determine date for %s; skipping", path.name)
+            continue
+
+        if report["date"] >= cutoff:
+            continue
+
+        days = (now - report["date"]).days
+        title = f"{TITLE_PREFIX}{report['slug']}"
+
+        if title in existing_titles:
+            log.info("SKIP %s (%d days) — open issue exists", report["slug"], days)
+            skipped_count += 1
+            continue
+
+        log.info(
+            "STALE %s (%d days, source=%s)",
+            report["slug"],
+            days,
+            report["date_source"],
+        )
+        body = build_issue_body(report, days)
+        create_issue(title, body, dry_run=dry_run)
+        stale_count += 1
+
+    log.info(
+        "done: %d new issue(s), %d skipped (already open)",
+        stale_count,
+        skipped_count,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_stale_reports.py
+++ b/scripts/check_stale_reports.py
@@ -16,6 +16,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -31,7 +32,7 @@ DATE_RE = re.compile(
     r")\s+(\d{1,2}),\s+(\d{4})\b"
 )
 TITLE_RE = re.compile(r"^#\s+(.+)$", re.MULTILINE)
-SCORE_RE = re.compile(r"\*\*Final Score:?\*\*\s*([\d.]+)\s*/\s*5\.0")
+SCORE_RE = re.compile(r"\*\*Final Score:\s*([\d.]+)\s*/\s*5\.0\*\*")
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger("stale-reports")
@@ -142,7 +143,7 @@ def build_issue_body(report: dict, days: int) -> str:
     )
 
 
-def create_issue(title: str, body: str, dry_run: bool) -> None:
+def create_issue(title: str, body: str, dry_run: bool) -> bool:
     cmd = [
         "gh",
         "issue",
@@ -156,8 +157,24 @@ def create_issue(title: str, body: str, dry_run: bool) -> None:
     ]
     if dry_run:
         log.info("DRY-RUN would run: %s", " ".join(cmd[:3] + [repr(title)]))
-        return
-    subprocess.run(cmd, check=True)
+        return True
+    for attempt in range(3):
+        try:
+            subprocess.run(cmd, check=True)
+            return True
+        except subprocess.CalledProcessError as exc:
+            if attempt == 2:
+                log.error("failed to create issue %r after 3 attempts: %s", title, exc)
+                return False
+            backoff = 2**attempt
+            log.warning(
+                "issue create failed (attempt %d/3) — retrying in %ds: %s",
+                attempt + 1,
+                backoff,
+                exc,
+            )
+            time.sleep(backoff)
+    return False
 
 
 def main() -> int:
@@ -178,6 +195,7 @@ def main() -> int:
 
     stale_count = 0
     skipped_count = 0
+    failed_count = 0
     for path in sorted(REPORTS_DIR.glob("*.md")):
         report = parse_report(path)
         if report["date"] is None:
@@ -202,15 +220,18 @@ def main() -> int:
             report["date_source"],
         )
         body = build_issue_body(report, days)
-        create_issue(title, body, dry_run=dry_run)
-        stale_count += 1
+        if create_issue(title, body, dry_run=dry_run):
+            stale_count += 1
+        else:
+            failed_count += 1
 
     log.info(
-        "done: %d new issue(s), %d skipped (already open)",
+        "done: %d new issue(s), %d skipped (already open), %d failed",
         stale_count,
         skipped_count,
+        failed_count,
     )
-    return 0
+    return 1 if failed_count else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/reassessment-scan.yml`, scheduled for `0 12 * * 6` (Saturday 12:00 UTC) with a `workflow_dispatch` `dry_run` input
- Adds `scripts/check_stale_reports.py`, which scans `reports/report/*.md`, parses the latest date from the **Assessment Date** header (falling back to `git log -1` if parsing fails), and opens a `Reassessment: <slug>` issue with the `reassessment` label for any report older than 60 days
- Adds `.github/ISSUE_TEMPLATE/reassessment.yml` so the same template can also be filed manually
- Reruns are idempotent: any report that already has an open issue with the same title is skipped
- The `reassessment` label has been created on the repo (color `#fbca04`)

Closes #153

## Notes on the date parser
- Reports often append an `(updated <date>)` or `(reassessment after <date>)` annotation; the parser extracts every `Month Day, Year` from the Assessment Date line and picks the **latest**, so post-event reassessments correctly bump the staleness clock.
- If no header date can be parsed, the script falls back to `git log -1 --format=%cI -- <path>`. The workflow does `actions/checkout@v4` with `fetch-depth: 0` so the full history is available for that fallback.

## Token / permissions
The workflow uses the default `GITHUB_TOKEN` with a `permissions: issues: write` block. No secret needs to be added; if you'd rather use a PAT, swap `secrets.GITHUB_TOKEN` for the secret name in `.github/workflows/reassessment-scan.yml`.

## Dry-run output (today, 2026-04-30)
10 reports flagged: `fluid`, `infinifi`, `kinetiq-khype`, `maple-syrupusdc`, `origin-arm`, `reserve-ethplus`, `spectra-finance`, `stakedhype-sthype`, `strata-srusde`, `unit-ubtc`. (`kerneldao-hgeth` was already reassessed on April 27 and is correctly excluded.)

## Test plan
- [ ] Run the workflow manually via **Run workflow** with `dry_run: true` and confirm the log lists the same stale reports without filing issues
- [ ] Run the workflow manually with `dry_run: false` and confirm one issue is filed per stale report with the `reassessment` label
- [ ] Re-run the workflow and confirm no duplicate issues are filed (skip log lines should appear)
- [ ] Confirm scheduled run fires at the next Saturday 12:00 UTC