### PR TITLE
fix: stop caching transient Cloudflare 5xx/4xx in lychee

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -14,6 +14,11 @@ no_progress = true
 # GitBook hosts, DefiLlama, app frontends, etc.) without per-host allowlisting.
 accept = ['200..=299', '403', '429']
 
+# Don't cache transient errors. Cloudflare-fronted hosts occasionally return 5xx
+# or 429 to bots; caching those poisons subsequent daily runs until max_cache_age
+# expires. Re-checking each day yields the steady-state 200/403.
+cache_exclude_status = ['429', '500..=599']
+
 # TEMPLATE.md contains literal `URL` placeholders in markdown link syntax.
 # reports/old/ is archived/legacy material that we don't actively maintain.
 exclude_path = ["reports/TEMPLATE.md", "reports/old"]
@@ -24,10 +29,17 @@ exclude_path = ["reports/TEMPLATE.md", "reports/old"]
 # - Twitter/X often produces connection errors / soft-blocks
 # - LinkedIn requires auth (returns 999/other non-403 codes)
 # - trust-security.xyz returns 405 on HEAD requests
+# - defillama.com/protocol/ Cloudflare intermittently returns 500 to crawlers;
+#   slugs are validated separately via api.llama.fi in scripts/check_defillama_links.py
+# - maple.finance/syrup Cloudflare returns 404 to bots on this subpath despite
+#   the page existing (verified via Wayback); no other maple.finance subpath
+#   exhibits this so the exclude is kept narrow
 exclude = [
     '^https?://(www\.)?rekt\.news',
     '^https?://(blue-api|api)\.morpho\.org/graphql',
     '^https?://(www\.)?(twitter|x)\.com',
     '^https?://(www\.)?linkedin\.com',
     '^https?://(www\.)?trust-security\.xyz',
+    '^https?://(www\.)?defillama\.com/protocol/',
+    '^https?://(www\.)?maple\.finance/syrup',
 ]


### PR DESCRIPTION
Closes #185.

## Summary

Issue #185 reported 10 broken links from the daily lychee run: 9 `defillama.com/protocol/<slug>` returning 500 and `maple.finance/syrup` returning 404. All are false positives — verified the slugs are valid via `api.llama.fi` (existing sidecar) and `maple.finance/syrup` exists via Wayback (Jan 2026 snapshot title: "SYRUP Token"). Cloudflare's bot-protection on these hosts returns variable codes (403/404/500) which lychee cached as failures and replayed on subsequent daily runs.

## Changes (`lychee.toml`)

- `cache_exclude_status = ['429', '500..=599']` so transient server errors and rate-limits aren't cached.
- Exclude `defillama.com/protocol/` — same rationale as the existing `rekt.news` exclude; slugs are already validated by `scripts/check_defillama_links.py` against the unprotected `api.llama.fi`.
- Exclude `maple.finance/syrup` specifically. Cloudflare returns 404 to bots on this subpath while the page exists. Kept narrow so other `maple.finance` paths still get checked.

## Test plan

- [x] `lychee './reports/**/*.md'` locally — 0 errors (was 10), 67 excluded (was 25, +42 for added excludes).
- [x] `uv run scripts/check_defillama_links.py reports` — all 22 unique slugs still validated.
- [ ] After merge: confirm the next daily run (09:00 UTC) closes / no longer reopens #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)