### PR TITLE
docs(strata-srusde): reassess 2026-05-19 (score unchanged at 2.8)

### DIFF
--- a/reports/report/strata-srusde.md
+++ b/reports/report/strata-srusde.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: Strata
 
-- **Assessment Date:** February 18, 2026
+- **Assessment Date:** May 19, 2026
 - **Token:** srUSDe (Senior Tranche USDe)
 - **Chain:** Ethereum
 - **Token Address:** [`0x3d7d6fdf07EE548B939A80edbc9B2256d0cdc003`](https://etherscan.io/address/0x3d7d6fdf07EE548B939A80edbc9B2256d0cdc003)
@@ -23,10 +23,12 @@ The senior tranche always earns at minimum the benchmark rate (floored), with up
 
 **Yield source**: Ethena's sUSDe yield (delta-neutral basis trade on ETH/BTC), redistributed via Strata's DYS mechanism.
 
-**Key metrics (Feb 18, 2026):**
-- Protocol TVL: ~$153.6M (DeFiLlama)
-- Peak TVL: ~$326M (December 2025)
+**Key metrics (May 19, 2026):**
+- Protocol TVL: ~$86.8M (DeFiLlama, aggregated across all Strata markets)
+- srUSDe vault TVL (onchain): ~$51.9M USDe; jrUSDe ~$10.0M USDe (Ethena USDe market only)
+- Peak TVL: ~$326M (October 8, 2025) — protocol is now ~73% below ATH
 - Chain: Ethereum only
+- Protocol now operates **five markets** (added since the previous assessment): Ethena USDe (srUSDe), Neutrl NUSD (srNUSD), Midas mHYPER (srmHYPER), Midas mM1-USD (srmM1-USD), Saturn USDat (srUSDat). srUSDe is the original and largest market; the others share governance and the same access-control contract but each has its own CDO/Strategy/Accounting/AprPairFeed contracts.
 
 **Yearn use cases per issue #47:**
 1. Deposit into senior vault srUSDe as part of a strategy
@@ -83,16 +85,16 @@ The senior tranche always earns at minimum the benchmark rate (floored), with up
 | StrataCDO | [`0xcAb791D0D44eBaC17378fF2AF6356c012F15c9e6`](https://etherscan.io/address/0xcAb791D0D44eBaC17378fF2AF6356c012F15c9e6) |
 | ERC20Cooldown | [`0xeD6c7b379F73DF0618406d263b13b2386E398166`](https://etherscan.io/address/0xeD6c7b379F73DF0618406d263b13b2386E398166) |
 
-### On-Chain Verification (Etherscan, Feb 18, 2026)
+### On-Chain Verification (Etherscan, May 19, 2026)
 
 All core contracts are **verified on Etherscan**:
 
 | Contract | Etherscan Name | Verified | Proxy |
 |----------|---------------|----------|-------|
-| srUSDe | TransparentUpgradeableProxy → Tranche (impl) | Yes | Yes |
+| srUSDe | TransparentUpgradeableProxy → Tranche (impl `0xe894055ca1c73648927e225f3ca38ed48e30210b`) | Yes | Yes |
 | jrUSDe | TransparentUpgradeableProxy | Yes | Yes |
-| StrataCDO | TransparentUpgradeableProxy → StrataCDO (impl) | Yes | Yes |
-| sUSDeStrategy | TransparentUpgradeableProxy | Yes | Yes |
+| StrataCDO | TransparentUpgradeableProxy → StrataCDO (impl `0xb3d4f2c2123f8c3ca85ae7a6d48aa2ef049c79ba`) | Yes | Yes |
+| sUSDeStrategy | TransparentUpgradeableProxy → sUSDeStrategy (impl `0x2b9796606c8480312a572742c00f606ef4adb107`) | Yes | Yes |
 | Accounting | TransparentUpgradeableProxy | Yes | Yes |
 | AccessControlManager | AccessControlManager | Yes | No |
 | Admin Multisig | GnosisSafeProxy | Yes | Yes |
@@ -101,11 +103,11 @@ All core contracts are **verified on Etherscan**:
 | 24h Timelock | StrataMasterChef (OZ TimelockController) | Yes | No |
 | Guardian | EOA (not a contract) | N/A | N/A |
 
-**Note**: Both timelocks are registered on Etherscan as `StrataMasterChef` but contain standard OpenZeppelin TimelockController functions (`schedule`, `execute`, `cancel`, `getMinDelay`). Delays verified onchain: 48h = 172,800 seconds, 24h = 86,400 seconds.
+**Note**: Both timelocks are registered on Etherscan as `StrataMasterChef` but contain standard OpenZeppelin TimelockController functions (`schedule`, `execute`, `cancel`, `getMinDelay`). Delays verified onchain (May 19, 2026): 48h = 172,800 seconds, 24h = 86,400 seconds. Implementation contracts for srUSDe, StrataCDO, and sUSDeStrategy are unchanged since November 2025 — no upgrade has been pushed in the past ~6 months.
 
 ## Audits and Due Diligence Disclosures
 
-Strata has completed an extensive, multi-phased audit process with 3 reputable firms across at least 7 distinct audit engagements:
+Strata has completed an extensive, multi-phased audit process with 3 reputable firms across at least 8 distinct audit engagements (one new Quantstamp engagement added since the previous assessment).
 
 ### Audit History
 
@@ -115,13 +117,16 @@ Strata has completed an extensive, multi-phased audit process with 3 reputable f
 | 2 | **Guardian Audits** | Oct 10, 2025 | Protocol v1 (Tranches) | 1 | 5 | 14 | 5 | 8 | [PDF](https://github.com/GuardianAudits/Audits/blob/main/Strata/Strata_Tranches_report.pdf) |
 | 3 | **Quantstamp** | ~Q4 2025 | Protocol v1 (Tranches) | - | - | - | - | - | [Certificate](https://certificate.quantstamp.com/full/strata-tranches/3c3a4037-2a92-468c-a4f3-5ea498e7b539/index.html) |
 | 4 | **Quantstamp** | ~Q4 2025 | Redemption Fee (Update to Tranches) | - | - | - | - | - | [Certificate](https://certificate.quantstamp.com/full/strata-update-to-tranches/d7a903b7-80cf-42db-8433-79186fdd8be2/index.html) |
-| 5 | **Cyfrin** | Jan 23, 2026 | Shares Cooldown mechanism | 0 | 0 | 6 | 3 | 10 | [PDF](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2026-01-23-cyfrin-strata-shares-cooldown-v2.0.pdf) |
-| 6 | **Cyfrin** | Jun 11, 2025 | Pre-Deposit Vaults | 1 | 1 | 3 | 16 | 9 | [PDF](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-06-11-cyfrin-strata-predeposit-v2.1.pdf) |
-| 7 | **Quantstamp** | ~2025 | Pre-Deposit Vaults | - | - | - | - | - | [Papermark](https://www.papermark.com/view/cmgm9op9b0003l404g395i6a5) |
+| 5 | **Cyfrin** | Jan 23, 2026 | Coverage-aware redemption / Shares Cooldown mechanism | 0 | 0 | 6 | 3 | 10 | [PDF](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2026-01-23-cyfrin-strata-shares-cooldown-v2.0.pdf) |
+| 6 | **Quantstamp** | ~Q1 2026 (new) | Discrete accounting mechanism | - | - | - | - | - | [Certificate](https://certificate.quantstamp.com/full/strata-discrete-accounting/02318e87-e35f-4e96-81ad-192253203d55/index.html) |
+| 7 | **Cyfrin** | Jun 11, 2025 | Pre-Deposit Vaults | 1 | 1 | 3 | 16 | 9 | [PDF](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-06-11-cyfrin-strata-predeposit-v2.1.pdf) |
+| 8 | **Quantstamp** | ~2025 | Pre-Deposit Vaults | - | - | - | - | - | [Papermark](https://www.papermark.com/view/cmgm9op9b0003l404g395i6a5) |
 
 *Quantstamp reports hosted on JS-rendered platforms; finding counts require browser access. Dashes indicate data not programmatically extractable.*
 
 **Total findings across Cyfrin + Guardian reports: 3 Critical, 8 High, 29 Medium, 29 Low (all resolved).**
+
+**New since previous assessment**: Quantstamp audit of the "Discrete accounting mechanism" (engagement #6, published certificate but exact date and finding counts not programmatically extractable). No new audits cover the recently deployed Neutrl/Midas/Saturn markets — those use the same codebase as srUSDe per protocol docs.
 
 Notable Critical/High findings (all resolved):
 - **C: Withdrawers of sUSDe always incur a loss** (Cyfrin #1) -- Inverted parameters in `Tranche::_withdraw` caused users to receive significantly less than entitled
@@ -148,31 +153,40 @@ The architecture is moderately complex:
 
 ## Historical Track Record
 
-- **Time in Production**: srUSDe proxy deployed October 2, 2025 (block [23492392](https://etherscan.io/tx/0x857c511cb166160e9b9acdb8ef47d9306ad5bcef1a311e845b4a2d4b90ea1f6b)). In production for **~4.5 months** as of February 2026. Pre-deposit vaults with TVL existed from July 2025 (~7 months with TVL).
-- **GitHub Repository**: Created September 16, 2025. Public, Solidity-based, actively maintained (last update Feb 17, 2026).
-- **TVL History**:
+- **Time in Production**: srUSDe proxy deployed October 2, 2025 (block [23492392](https://etherscan.io/tx/0x857c511cb166160e9b9acdb8ef47d9306ad5bcef1a311e845b4a2d4b90ea1f6b)). In production for **~7.5 months** as of May 19, 2026. Pre-deposit vaults with TVL existed from July 2025 (~10 months with TVL).
+- **GitHub Repository**: Created September 16, 2025. Public, Solidity-based; last public push **Feb 25, 2026** (~3 months ago). Active development continues on private branches (`strat/morpho`, `strat/neutrl`, `strat/superstate`, `release/performance-fee`) which are not yet merged to public master.
+- **TVL History** (DeFiLlama, protocol-wide totals):
 
 | Period | TVL | Notes |
 |--------|-----|-------|
 | Jul 2025 | ~$18M | Pre-deposit vaults / soft launch |
 | Aug 2025 | $18M - $53M | Steady growth |
-| Sep 2025 | $53M - $105M | Rapid growth |
-| Oct 13, 2025 | ~$110M | Official launch on Ethena USDe |
-| Nov 2025 | $110M - $258M | Strong growth phase |
-| Dec 5-8, 2025 | **~$326M** | **Peak TVL** |
-| Dec 20-31, 2025 | $326M → $262M | Moderate decline |
-| Jan 8-14, 2026 | $230M → $147M | **Sharp drop** (~$83M outflow in ~1 week) |
-| Jan 17, 2026 | **~$122M** | **Deepest drawdown** (62.6% below peak) |
-| Feb 1-10, 2026 | $152M → $233M | Recovery |
-| Feb 18, 2026 | ~$153M | Current (53% below ATH) |
+| Sep 2025 | $53M - $172M | Rapid growth |
+| **Oct 8, 2025** | **~$326M** | **Peak TVL (ATH)** |
+| Oct 13, 2025 | ~$110M (srUSDe market only) | Official launch on Ethena USDe |
+| Nov - Dec 2025 | $214M - $221M | Consolidation |
+| Jan 1, 2026 | $226M | Stable |
+| Jan 8-17, 2026 | $230M → $122M | **First sharp drawdown** (~$108M outflow in ~10 days; -62.6% from peak) |
+| Feb 1-18, 2026 | $132M → $153M | Recovery |
+| Mar 1-31, 2026 | $172M → $258M | Strong recovery |
+| **Apr 2-4, 2026** | **$242M → $114M** | **Second sharp drawdown** (-53% in 2 days) |
+| Apr 11-22, 2026 | $137M → $128M | Partial recovery, then renewed decline |
+| **Apr 23-25, 2026** | **$119M → $84M** | **Third sharp drawdown** (-29% in 2 days) |
+| May 1-19, 2026 | $82M → $87M | Current range, stable but near multi-month lows |
+| **May 19, 2026** | **~$86.8M** | **Current** (~73% below ATH) |
 
-- **TVL Volatility**: The protocol has experienced significant TVL swings. The sharp January drop (from ~$262M to ~$147M in one week) suggests **large depositor concentration risk**. The TVL remains volatile with multiple >20% swings.
-- **Incidents**: No reported security incidents, exploits, or hacks found.
-- **Exchange Rate (onchain verified Feb 18, 2026)**:
-  - `convertToAssets(1e18)` = 1.013728 USDe per srUSDe
-  - `totalAssets()` = 113,838,466 USDe
-  - `totalSupply()` = 112,296,907 srUSDe
-  - As an ERC-4626 vault, the exchange rate should only increase (denominated in underlying). The current 1.37% appreciation over ~4.5 months implies ~3.7% annualized yield to the senior tranche.
+- **TVL Volatility**: The protocol has now experienced **three distinct large drawdown events** (Jan, early Apr, late Apr 2026), each shedding 25-55% of TVL within days. Current TVL sits ~73% below the October 2025 peak. The repeated boom-bust pattern is consistent with **large depositor concentration** and is likely driven in part by points-program farming behavior.
+- **Incidents**: No reported security incidents, exploits, or hacks found in this assessment window (Feb 18 - May 19, 2026).
+- **Governance Activity (Feb 18 - May 19, 2026)**:
+  - 48h Timelock: 14 `CallScheduled` and 14 `CallExecuted` events. Most activity clustered around Feb 23, Apr 8, and May 3 — corresponding to deployments of the new Neutrl, Midas mHYPER/mM1-USD, and Saturn USDat markets (none affect the srUSDe contracts directly).
+  - 24h Timelock: 0 events in this window (and 0 since deployment in October 2025). See onchain finding in *Centralization & Control Risks* below.
+- **Exchange Rate (onchain verified May 19, 2026)**:
+  - `convertToAssets(1e18)` = **1.021541647465871857 USDe per srUSDe** (up from 1.013728 on Feb 18, 2026)
+  - `totalAssets()` = **51,909,893 USDe** (down from 113,838,466 on Feb 18)
+  - `totalSupply()` = **50,815,249 srUSDe** (down from 112,296,907 on Feb 18)
+  - Senior tranche underlying assets dropped ~54% over the 90-day window, mirroring the protocol-wide TVL decline.
+  - Exchange-rate growth: 1.021541 / 1.013728 = +0.77% over 90 days → **~3.1% annualized yield** to the senior tranche over this window (down from the ~3.7% implied at the previous assessment, but in line with the dynamic-yield-split mechanism floored at the Aave benchmark rate).
+  - jrUSDe (junior tranche): `totalAssets()` = ~10,035,113 USDe; `totalSupply()` = ~9,556,172 jrUSDe. Senior:Junior asset ratio is ~5.17:1; total system collateral (senior + junior) / senior = ~119.3%, well above the 105% coverage circuit breaker.
 
 ## Funds Management
 
@@ -234,30 +248,35 @@ The architecture is moderately complex:
 
 ### Governance
 
-Strata uses a layered Role-Based Access Control (RBAC) system with clear separation between operational, administrative, and owner functions:
+Strata uses a layered Role-Based Access Control (RBAC) system in the **AccessControlManager** ([`0x1d19E18ECaC4ef332a0d5d6Aa3a0f0f772605f60`](https://etherscan.io/address/0x1d19E18ECaC4ef332a0d5d6Aa3a0f0f772605f60)). The table below was **validated onchain on May 19, 2026** by hashing each role string with `keccak256` and querying `hasRole(role, address)` against every known principal. Note the corrections vs. the protocol documentation and the previous assessment (both contained errors for PAUSER_ROLE and RESERVE_MANAGER_ROLE).
 
-| Role | Callable By | Description | Key Functions |
-|------|-------------|-------------|---------------|
-| PAUSER_ROLE | Admin Multisig (3/4) | Pause/resume deposits and redemptions | `setActionStates`, `setJrtShortfallPausePrice` |
-| UPDATER_FEED_ROLE | Operational Multisig (2/3) | Trigger APR refresh and recalculation | `onAprChanged`, `updateRoundData` |
-| UPDATER_STRAT_CONFIG_ROLE | 24h Timelock | Update strategy risk parameters and cooldowns | `setRiskParameters`, `setCooldowns` |
-| RESERVE_MANAGER_ROLE | Admin Multisig (3/4) | Redistribute reserves or withdraw to treasury | `reduceReserve`, `distributeReserve`, `setReserveTreasury` |
-| PROPOSER_CONFIG_ROLE | Admin Multisig (3/4) | Propose exit-fee configuration changes | `scheduleExitFeeChange` |
-| OWNER_ROLE | 48h Timelock | High-level protocol configuration | `setAprPairFeed`, `setReserveBps`, `setFeeRetentionBps`, `setMinimumJrtSrtRatio`, `setImplementations`, `setProvider` |
+| Role | Onchain Holder(s) | Description | Key Functions |
+|------|-------------------|-------------|---------------|
+| DEFAULT_ADMIN_ROLE (`0x0000…`) | 48h Timelock + 24h Timelock | AccessControlManager super-admin (can grant/revoke any role) | `grantRole`, `revokeRole`, `grantCall`, `revokeCall` |
+| PAUSER_ROLE | **Operational Multisig (2/3)** *(docs/prior report incorrectly state Admin Multisig)* | Pause/resume deposits and redemptions | `StrataCDO::setActionStates`, `StrataCDO::setJrtShortfallPausePrice` |
+| UPDATER_FEED_ROLE | Operational Multisig (2/3) | Trigger APR refresh and recalculation | `Accounting::onAprChanged`, `AprPairFeed::updateRoundData` |
+| UPDATER_CDO_APR_ROLE | AprPairFeed contract + EOA [`0x1f3aab5b…`](https://etherscan.io/address/0x1f3aab5b7c5ea8c4ce629b14edb09d68b90a3c57) | Push APR updates into the CDO | `Accounting::onAprChanged` (internal-only path) |
+| UPDATER_STRAT_CONFIG_ROLE | **48h Timelock + 24h Timelock** *(prior report listed 24h only)* | Update strategy risk parameters and cooldowns | `Accounting::setRiskParameters`, `sUSDeStrategy::setCooldowns` |
+| RESERVE_MANAGER_ROLE | **24h Timelock only** *(prior report incorrectly listed Admin Multisig)* | Redistribute reserves or withdraw to treasury | `StrataCDO::reduceReserve`, `StrataCDO::distributeReserve`, `StrataCDO::setReserveTreasury` |
+| PROPOSER_CONFIG_ROLE | Admin Multisig (3/4) | Propose exit-fee configuration changes | `TwoStepConfigManager::scheduleExitFeeChange` |
+| DEPOSITOR_CONFIG_ROLE | Operational Multisig (2/3) | Configure the `TrancheDepositor` accepted-token whitelist and routing | `TrancheDepositor::*` config |
+| COOLDOWN_WORKER_ROLE | sUSDeStrategy + 24h Timelock + EOA [`0x99fe6bb5…`](https://etherscan.io/address/0x99fe6bb58b52d54991c0b6ef2595839e835f1a20) | Finalize cooldown unstakes on behalf of the strategy | `ERC20Cooldown`/`UnstakeCooldown` worker hooks |
+| Ownable `owner()` *(not a role in ACM)* | 48h Timelock | High-level protocol configuration on Ownable contracts (StrataCDO, srUSDe, jrUSDe, Accounting, sUSDeStrategy all return 48h Timelock as `owner()`) | `Accounting::setAprPairFeed`, `setReserveBps`, `setFeeRetentionBps`, `setMinimumJrtSrtRatio[Buffer]`, `UnstakCooldown::setImplementations`, `AprPairFeed::setProvider`/`setRoundStaleAfter` |
 
-**Multisig Details:**
-- **Admin Multisig**: 3-of-4 Gnosis Safe. All signers use cold wallets. Keys held by internal team members and founding core contributors. At least 3 signers must validate transaction hashes match
-- **Operational Multisig**: 2-of-3 Gnosis Safe. All keys held by internal team members
-- **Timelocks**: 48h for owner-level changes (proxy upgrades, core config), 24h for strategy config changes
-- **Guardian**: Patrick Collins (Co-Founder & CEO of Cyfrin, well-known security researcher). Can cancel timelock transactions before execution. Monitors queued transactions using Hypernative and custom tools
+**Multisig Details (onchain verified May 19, 2026):**
+- **Admin Multisig** ([`0xA27cA929…`](https://etherscan.io/address/0xA27cA9292268ee0f0258B749f1D5740c9Bb68B50)): 3-of-4 Gnosis Safe (`getThreshold() = 3`). Owners: `0x791fB932…`, `0x296400D8…`, `0xd796E125…`, `0x206cFf3D…`. Threshold and owner set unchanged since the previous assessment.
+- **Operational Multisig** ([`0x4be3749a…`](https://etherscan.io/address/0x4be3749a0F6557b8fd98F3967e859DbD7C694eF4)): 2-of-3 Gnosis Safe (`getThreshold() = 2`). Owners: `0x296400D8…`, `0xd796E125…`, `0xacE53036…`. Two of three signers (`0x296400D8…`, `0xd796E125…`) also sit on the Admin Multisig — the two safes are not fully independent. Unchanged since previous assessment.
+- **48h Timelock** ([`0xb2A3CF69…`](https://etherscan.io/address/0xb2A3CF69C97AFD4dE7882E5fEE120e4efC77B706)): `getMinDelay() = 172,800`. Roles (verified via `hasRole`): PROPOSER → Admin Multisig; CANCELLER → Admin Multisig + Guardian; EXECUTOR is **open** (zero-address holds the role, so anyone can execute after the delay). 53 historical `CallExecuted` events.
+- **24h Timelock** ([`0x4f2682b7…`](https://etherscan.io/address/0x4f2682b78F37910704fB1AFF29358A1da07E022d)): `getMinDelay() = 86,400`. PROPOSER → Admin Multisig; CANCELLER → Admin Multisig (Guardian is **not** assigned CANCELLER on the 24h timelock); EXECUTOR is **unset** (executor list at deployment was empty per constructor calldata; the zero-address sentinel was not granted, no other principal has been granted since). As a consequence, **0 `CallExecuted` events** in the contract's ~7-month lifetime — see finding below.
+- **Guardian** ([`0x277D26a4…`](https://etherscan.io/address/0x277D26a45Add5775F21256159F089769892CEa5B)): Patrick Collins (Co-Founder & CEO of Cyfrin). Externally-owned account. Holds CANCELLER_ROLE on the 48h Timelock; does **not** hold CANCELLER on the 24h Timelock and does **not** hold any role in the AccessControlManager.
 
 **Key concerns:**
-- Admin Multisig is only 3-of-4 (relatively low threshold)
-- Operational Multisig is only 2-of-3 (low threshold)
-- All multisig keys held by internal team -- no external/independent signers
-- Admin Multisig can pause the protocol immediately (no timelock on pause)
-- RESERVE_MANAGER_ROLE (Admin Multisig) can transfer reserves to treasury -- potential extraction vector if compromised
-- No onchain governance yet (planned for future)
+- Admin Multisig is only 3-of-4 (relatively low threshold) and Operational Multisig is only 2-of-3 (low threshold). Two signers overlap between the two safes, reducing key-set independence.
+- All multisig keys held by internal team -- no external/independent signers.
+- **Pause is faster and lower-threshold than previously thought**: Operational Multisig (2/3, internal-only) can pause the protocol immediately with no timelock. This is good for emergency response but means a 2-of-3 internal-key compromise can halt user activity.
+- **Reserve management is timelocked, not multisig-callable** (correcting the prior report): `RESERVE_MANAGER_ROLE` sits on the 24h Timelock, which must be triggered by an Admin Multisig (3/4) proposal with a 24-hour delay. This materially **reduces** the "reserve extraction" risk that the previous assessment flagged as critical.
+- **24h Timelock is currently inoperative**: no executor was granted at deployment (verified by inspecting both `hasRole(EXECUTOR_ROLE, …)` for all principals including the zero address, and the deployment-tx constructor calldata which shows `executors = []`). Combined with the on-chain fact of 0 `CallExecuted` events since October 2025, this means `RESERVE_MANAGER_ROLE` and the 24h path of `UPDATER_STRAT_CONFIG_ROLE` cannot currently fire. For srUSDe this is largely benign because the 48h Timelock holds the same `UPDATER_STRAT_CONFIG_ROLE` and the same Ownable `owner()` powers, so strategy configuration can still be updated via the 48h path; reserve treasury withdrawals, however, are blocked outright until an executor is granted (which itself requires a proposal that no one can execute — likely a redeploy or migration would be needed to fix this). Worth flagging to the team.
+- No onchain governance yet (planned for future).
 
 ### Programmability
 
@@ -277,19 +296,21 @@ Strata uses a layered Role-Based Access Control (RBAC) system with clear separat
 | **Hypernative** | Monitoring & alerting | **Medium** | 24/7 contract monitoring. Not critical for operations but important for security |
 | **Ethereum L1** | Settlement layer | **High** | All contracts deployed on Ethereum mainnet only |
 
-**Key dependency risk**: Strata has a **single critical yield source dependency** on Ethena/sUSDe. The benchmark rate relies on a **single data source** (Aave v3 Core). No documented fallback mechanisms if Ethena or Aave dependencies fail. The AprPairFeed has a `setRoundStaleAfter` parameter suggesting some staleness detection.
+**Key dependency risk**: For srUSDe specifically, Strata has a **single critical yield source dependency** on Ethena/sUSDe. The benchmark rate relies on a **single data source** (Aave v3 Core). No documented fallback mechanisms if Ethena or Aave dependencies fail. The AprPairFeed has a `setRoundStaleAfter` parameter suggesting some staleness detection.
+
+**Note on protocol-wide surface area** (new since previous assessment): Strata expanded from a single market to **five live markets** between Feb and May 2026: Ethena USDe (srUSDe — unchanged), Neutrl NUSD, Midas mHYPER, Midas mM1-USD, and Saturn USDat. Each market has its own CDO/Strategy/Accounting/AprPairFeed/AccessControlManager stack but shares the same multisig and timelock governance. This diversifies the protocol's yield mix away from sole reliance on Ethena, but materially increases overall protocol surface area — none of the new markets have undergone the same depth of audit coverage as the original srUSDe codebase, and operational mistakes on any market (e.g. an oracle mis-configuration on the Midas markets) could indirectly affect team focus / incident-response bandwidth for srUSDe. The srUSDe contracts themselves are unchanged.
 
 ## Operational Risk
 
 - **Team Transparency**: Founding team is **not publicly named** in documentation. Operational team members are not publicly identified. The only publicly named individual is **Patrick Collins** (Cyfrin CEO), who serves as Guardian (security oversight role, not management). Team is classified as **partially anonymous** -- known anons at best
-- **Documentation**: Good quality. Comprehensive docs at docs.strata.markets covering mechanism, technical architecture, contracts, roles, and risks. Actively maintained (last updated Feb 14, 2026)
+- **Documentation**: Comprehensive docs at docs.strata.markets covering mechanism, technical architecture, contracts, roles, and risks; updated to cover the four new markets (Neutrl/Midas/Saturn). However, parts of the docs are now **out-of-date with onchain state** — notably, the docs claim `PAUSER_ROLE` is held by the Admin Multisig, but onchain it is held by the Operational Multisig. Yearn should treat onchain `hasRole` results as authoritative
 - **Legal Structure**: **Frontera Labs, Inc.**, a Delaware (USA) corporation, operates the Interface (front-end) only. The company explicitly disclaims ownership or control of the protocol smart contracts. Protocol contracts are licensed under BUSL-1.1. A planned transition to a **Cayman Islands foundation** is referenced in the [Terms of Service](https://docs.strata.markets/resources/terms-of-service) (last updated Nov 28, 2025). US users are geo-blocked. Contact: legal@strata.markets
 - **Incident Response**: Not formally documented, but the protocol has multiple layers of defense:
   - 24/7 monitoring via Hypernative
-  - Guardian (Patrick Collins) can cancel timelock transactions
-  - Admin Multisig can pause the protocol immediately
-- **Open Source**: Contracts are public on [GitHub](https://github.com/Strata-Money/contracts-tranches)
-- **Points Program**: Strata runs a "Strata Points Program" (likely incentive/airdrop mechanism). The TVL volatility may be partially explained by points farming behavior
+  - Guardian (Patrick Collins) can cancel timelock transactions on the 48h Timelock
+  - Operational Multisig (2/3) can pause the protocol immediately (no timelock)
+- **Open Source**: Contracts are public on [GitHub](https://github.com/Strata-Money/contracts-tranches). Public branch last pushed Feb 25, 2026; active development is on unmerged feature branches (`strat/morpho`, `strat/neutrl`, `strat/superstate`, `release/performance-fee`)
+- **Points Program**: Strata runs a "Strata Points Program" (incentive/airdrop mechanism). Repeated TVL boom-bust cycles in Jan/Apr 2026 are consistent with points-program farming behavior
 
 ## Monitoring
 
@@ -352,26 +373,29 @@ Strata uses a layered Role-Based Access Control (RBAC) system with clear separat
 
 ### Key Strengths
 
-- **Structured risk tranching**: srUSDe benefits from junior tranche (jrUSDe) first-loss protection, providing additional security beyond just the underlying yield source
-- **Multi-layered governance**: 48h timelock for owner changes, 24h timelock for strategy config, two-step exit-fee changes, independent Guardian (Patrick Collins/Cyfrin) with veto power
-- **Onchain transparency**: Exchange rate is programmatic (ERC-4626), accounting is fully onchain, and the codebase is open-source
-- **Multiple reputable audits**: 7+ audit engagements across Cyfrin, Quantstamp, and Guardian Audits
+- **Structured risk tranching**: srUSDe benefits from junior tranche (jrUSDe) first-loss protection. Current senior:junior asset ratio ~5.17:1; total-system collateralization ~119.3% of senior assets, well above the 105% circuit-breaker
+- **Multi-layered governance**: 48h timelock for owner changes (verified active with 53 executions), two-step exit-fee changes, independent Guardian (Patrick Collins/Cyfrin) with CANCELLER role on the 48h timelock
+- **Onchain transparency**: Exchange rate is programmatic (ERC-4626), accounting is fully onchain, and the codebase is open-source. Implementation contracts unchanged since November 2025 (no recent upgrades)
+- **Multiple reputable audits**: 8 audit engagements across Cyfrin, Quantstamp, and Guardian Audits (one new Quantstamp engagement on the discrete-accounting mechanism since the previous assessment)
 - **Active monitoring**: 24/7 monitoring via Hypernative with Guardian oversight
+- **Reserve extraction is timelocked** (corrected from prior assessment): `RESERVE_MANAGER_ROLE` is held by the 24h Timelock, not the Admin Multisig — and the 24h Timelock currently has no executor, so reserve withdrawal to treasury is presently blocked outright
 
 ### Key Risks
 
-- **Short track record**: Only ~4 months in production since official launch (October 2025). Very young protocol
-- **Single critical dependency on Ethena**: All funds flow into Ethena's sUSDe. An Ethena exploit or USDe depeg would directly impact srUSDe holders
-- **Significant TVL volatility**: 62.6% drawdown from peak ($326M → $122M), suggesting large depositor concentration and/or points farming instability
-- **Low multisig thresholds**: Admin Multisig is 3-of-4 with all internal signers (no independent/external signers). Operational Multisig is 2-of-3
-- **No bug bounty program found**: Notable absence for a protocol managing >$150M TVL
+- **Persistent TVL volatility**: protocol now exhibits **three sharp drawdown events** (Jan 8-17, Apr 2-4, Apr 23-25, 2026), each shedding 25-55% of TVL within days. Current TVL ($86.8M) is ~73% below the October 2025 peak ($326M) — worse than the 62.6% reported in Feb. The repeated boom-bust pattern is consistent with large-depositor and points-program concentration
+- **Single critical dependency on Ethena (for srUSDe)**: All srUSDe-market funds flow into Ethena's sUSDe. An Ethena exploit or USDe depeg would directly impact srUSDe holders
+- **Low multisig thresholds with overlapping signers**: Admin Multisig is 3-of-4, Operational Multisig is 2-of-3, and two of the three Operational signers also sit on the Admin Safe. All keys are internal-team-only
+- **Pause is callable by a 2/3 internal-team multisig** (Operational), correcting the previous report's claim that pause was an Admin Multisig (3/4) function
+- **No bug bounty program found**: Notable absence for a protocol managing tens of millions in TVL
 - **Withdrawal delays**: Redemptions subject to cooldown periods tied to Ethena's sUSDe unstaking (~7 days)
 - **Anonymous team**: Founding team not publicly identified. Patrick Collins (Guardian) is the only doxxed individual, in a security oversight role
+- **Rapid multi-market expansion**: protocol grew from 1 market to 5 markets (Neutrl, Midas mHYPER, Midas mM1-USD, Saturn USDat) between Feb and May 2026, with no audits found covering the new markets. While srUSDe contracts are unchanged, broader operational and governance bandwidth is now stretched across five integrations
+- **Stalled public repo**: Public GitHub last pushed Feb 25, 2026 — active development is happening on unmerged branches (`strat/morpho`, `strat/neutrl`, `strat/superstate`, `release/performance-fee`)
 
 ### Critical Risks
 
-- **Junior tranche depletion**: If the junior tranche is fully depleted (e.g., prolonged negative yield or extreme outflows), senior tranche **may incur principal losses**. The 105% coverage circuit breaker provides some protection but is not a guarantee
-- **Reserve extraction risk**: The Admin Multisig (3/4, internal team only) holds RESERVE_MANAGER_ROLE and can transfer reserves to treasury. If compromised, this could be an extraction vector
+- **Junior tranche depletion**: If the junior tranche is fully depleted (e.g., prolonged negative yield or extreme outflows), senior tranche **may incur principal losses**. The 105% coverage circuit breaker provides some protection but is not a guarantee. Current jrUSDe `totalAssets` is ~$10M against ~$51.9M senior assets — adequate but the buffer has shrunk in absolute terms vs. the previous assessment
+- **24h Timelock has no executor and has never executed a single call** since deployment in October 2025 — verified by `hasRole` queries against every known principal (including the zero-address sentinel) and by inspection of the deployment-tx constructor calldata which shows an empty `executors[]` array. Several roles that the protocol documentation routes through the 24h Timelock (RESERVE_MANAGER, UPDATER_STRAT_CONFIG, COOLDOWN_WORKER) cannot fire on that path. For srUSDe most of these functions are reachable via the 48h Timelock or other principals, but it is an unexplained governance misconfiguration that the team should address
 - **Proxy upgrade risk**: Core contracts are upgradeable with 48h timelock. While the Guardian can cancel, this requires active monitoring
 
 ---
@@ -395,95 +419,99 @@ Strata uses a layered Role-Based Access Control (RBAC) system with clear separat
 
 #### Category 1: Audits & Historical Track Record (Weight: 20%)
 
-- **Audits**: 3 audit firms (Cyfrin, Quantstamp, Guardian) across 7+ engagements covering core contracts, redemption mechanism, and pre-deposit vaults. Good coverage.
-- **Bug Bounty**: No active bug bounty program found. Significant gap.
-- **Time in Production**: ~4 months since official launch (October 2025). Very young.
-- **TVL**: ~$153M current, peaked at ~$326M. Has shown significant volatility (62.6% drawdown).
-- **Incidents**: None reported.
+- **Audits**: 3 audit firms (Cyfrin, Quantstamp, Guardian) across **8 engagements** (one new Quantstamp on the discrete-accounting mechanism since Feb). Good coverage of the srUSDe codebase; new Neutrl/Midas/Saturn markets are **not separately audited** in publicly available reports.
+- **Bug Bounty**: Still no active bug bounty program found. Unchanged gap.
+- **Time in Production**: **~7.5 months** since official launch (October 2025). Still young but maturing.
+- **TVL**: ~$86.8M current (down from $153M at the previous assessment); peaked at ~$326M. Three distinct sharp drawdown events now on record (Jan, early Apr, late Apr 2026), giving a peak-to-current decline of ~73%.
+- **Incidents**: None reported in the Feb–May 2026 window.
 
-**Score: 3.0/5** -- Strong audit coverage from reputable firms across multiple phases. However, the very short production history (~4 months), absence of a bug bounty program, and significant TVL volatility weigh heavily. Between score 2 (2+ audits, 1-2 years, TVL >$50M) and score 3 (1 audit, 6-12 months) -- the strong audit suite is offset by the very short track record. Conservative assessment leans toward 3.
+**Score: 3.0/5** -- Audit coverage and time-in-production both modestly improved vs. the Feb assessment, but the protocol now has *three* sharp-drawdown events on its public record (vs. one previously) and TVL sits at ~$87M, the lowest level since the August 2025 ramp. Maintained at 3.0 — the additional audit and three extra months of operation offset the worsened TVL volatility and broader protocol surface area.
 
 #### Category 2: Centralization & Control Risks (Weight: 30%)
 
 **Subcategory A: Governance**
 
-- 3-of-4 Admin Multisig with cold wallets, all internal team signers
-- 2-of-3 Operational Multisig, all internal team signers
-- 48h timelock for owner-level changes (proxy upgrades, core config)
-- 24h timelock for strategy config changes
-- Independent Guardian (Patrick Collins/Cyfrin) can cancel timelock transactions
-- Pause function available immediately via Admin Multisig (no timelock)
+- 3-of-4 Admin Multisig with cold wallets, all internal team signers (unchanged)
+- 2-of-3 Operational Multisig, all internal team signers; two of three owners are also Admin signers (key-set overlap)
+- 48h timelock for Ownable owner-level changes (proxy upgrades, core config) — active (53 historical executions)
+- 24h timelock for strategy config / reserve management — **inoperative**: no executor configured, 0 historical executions over ~7 months
+- Independent Guardian (Patrick Collins/Cyfrin) holds CANCELLER_ROLE on the 48h Timelock only
+- Pause callable by Operational Multisig (2/3, internal-team) with no timelock — *corrected from previous assessment*
+- Reserve withdrawal to treasury is timelocked (24h) and currently unreachable — *also corrected from previous assessment*
 - No external/independent signers on either multisig
 
-**Governance Score: 3.0** -- The timelocked governance with Guardian veto is a good design. However, the 3/4 admin threshold is low, operational multisig is only 2/3, and all signers are internal team only. The Guardian adds meaningful independent oversight but cannot initiate changes, only cancel.
+**Governance Score: 3.0** -- Two findings move in opposite directions vs. the prior assessment: (a) Reserve management is materially less risky than previously described (timelocked, currently blocked); (b) Pause is callable by a 2/3 internal multisig rather than the 3/4 Admin Multisig. The 24h timelock misconfiguration adds operational concern but does not currently widen attack surface. Net: held at 3.0.
 
 **Subcategory B: Programmability**
 
-- srUSDe exchange rate: fully onchain ERC-4626
+- srUSDe exchange rate: fully onchain ERC-4626 (verified `convertToAssets(1e18) = 1.021541…`)
 - Yield distribution (DYS): mostly programmatic using AprPairFeed from Aave
-- Risk-premium parameters (x, y, k): set by team initially, planned transition to independent risk managers
+- Risk-premium parameters (x, y, k): set by team initially, planned transition to independent risk managers (not yet implemented)
 - APR updates: triggered manually by Operational Multisig (but computation is onchain)
 - Accounting: fully onchain
+- Implementation contracts unchanged since November 2025 (no recent upgrade activity on the srUSDe stack)
 
-**Programmability Score: 2.5** -- Most critical functions are onchain and programmatic. The APR update trigger and risk-premium parameter setting introduce some manual dependency. The planned transition to independent risk managers is positive but not yet implemented.
+**Programmability Score: 2.5** -- Unchanged. Most critical functions are onchain and programmatic; manual APR triggers and team-controlled risk parameters keep this above 2.0.
 
 **Subcategory C: External Dependencies**
 
-- **Critical**: Ethena sUSDe (single yield source, all funds deposited there)
+- **Critical**: Ethena sUSDe (single yield source for the srUSDe market, all funds deposited there)
 - **High**: Aave v3 Core (single benchmark rate source)
 - **High**: Gnosis Safe (multisig infrastructure)
+- New since prior assessment: protocol-wide exposure to **Neutrl, Midas, and Saturn** as yield sources for sister markets — these don't affect srUSDe collateral directly but stretch team operational bandwidth
 - No documented fallback mechanisms if critical dependencies fail
 
-**Dependencies Score: 4.0** -- Single critical dependency on Ethena with no fallback. Aave as single benchmark rate source. Failure of Ethena would break core functionality and potentially result in principal losses.
+**Dependencies Score: 4.0** -- Unchanged. For srUSDe specifically, Ethena remains the single critical dependency with no fallback.
 
 **Centralization Score = (3.0 + 2.5 + 4.0) / 3 = 3.17**
 
-**Score: 3.2/5** -- Reasonable governance structure with timelocks and Guardian oversight, but constrained by low multisig thresholds, internal-only signers, critical Ethena dependency, and team-controlled risk parameters.
+**Score: 3.2/5** -- Held at 3.2. Corrected reserve-extraction risk is offset by a lower pause threshold and the 24h-timelock misconfiguration. Multi-market expansion increases the protocol-wide complexity but doesn't directly degrade srUSDe-specific governance.
 
 #### Category 3: Funds Management (Weight: 30%)
 
 **Subcategory A: Collateralization**
 
-- srUSDe backed by sUSDe staked in Ethena's vault (onchain verifiable)
-- Over-collateralized by junior tranche (first-loss capital)
+- srUSDe backed by sUSDe staked in Ethena's vault (onchain verifiable; sUSDeStrategy holds ~50.4M sUSDe per `balanceOf` query on May 19, 2026)
+- Over-collateralized by junior tranche (first-loss capital). Senior:Junior asset ratio ~5.17:1; total-system collateralization ~119.3% of senior assets — above the 105% circuit breaker but tighter than the protocol's idealized targets
 - 105% coverage circuit breaker provides protection
 - Underlying collateral is USDe (Ethena's synthetic dollar -- backed by delta-neutral ETH/BTC strategy with CEX counterparty exposure)
-- Reserve mechanism exists (configurable by admin, can be withdrawn to treasury)
+- Reserve mechanism exists (configurable via timelock; treasury withdrawal currently blocked by the 24h-timelock executor gap)
 
-**Collateralization Score: 2.5** -- Onchain backing verifiable through ERC-4626 and strategy. Junior tranche first-loss protection is a strength. But the underlying asset is Ethena's USDe (itself a synthetic dollar with CEX counterparty risk), and the reserve extraction vector is a concern.
+**Collateralization Score: 2.5** -- Unchanged. Onchain backing remains verifiable. Reserve-extraction concern is reduced vs. the prior assessment (timelocked, currently unreachable) but Ethena synthetic-dollar dependency is the dominant risk.
 
 **Subcategory B: Provability**
 
-- Exchange rate: programmatic onchain (ERC-4626)
+- Exchange rate: programmatic onchain (ERC-4626), `convertToAssets(1e18) = 1.021541647465871857` on May 19, 2026
 - Strategy holdings: verifiable onchain (sUSDe balance in strategy contract)
 - Accounting: fully onchain with transparent TVL tracking
 - Underlying USDe collateral: relies on Ethena's proof of reserves (third-party verified)
 - Risk-premium parameters: set by team, visible onchain once set
 
-**Provability Score: 2.0** -- srUSDe layer is fully onchain verifiable. Underlying USDe/sUSDe provability depends on Ethena (which has third-party verification). Good transparency overall.
+**Provability Score: 2.0** -- Unchanged.
 
 **Funds Management Score = (2.5 + 2.0) / 2 = 2.25**
 
-**Score: 2.25/5** -- Good onchain provability and transparency. Senior tranche benefits from junior first-loss protection. Underlying Ethena dependency and reserve extraction risk prevent a lower score.
+**Score: 2.25/5** -- Unchanged. Onchain provability remains strong; the Ethena dependency continues to dominate funds-management risk.
 
 #### Category 4: Liquidity Risk (Weight: 15%)
 
-- **Exit mechanism**: Cooldown-based redemption (~7 days via Ethena sUSDe unstaking). Not instant
-- **DEX liquidity**: Negligible -- ~$135K total across Uniswap V4 pools with <$500/day volume. No Curve or Balancer pools. Pendle PT markets (~$21.9M) are the most liquid but trade PTs, not raw srUSDe
+- **Exit mechanism**: Cooldown-based redemption (~7 days via Ethena sUSDe unstaking). Not instant. Unchanged.
+- **DEX liquidity**: Still negligible relative to vault TVL. srUSDe is not the primary trading instrument; secondary market venues are Pendle (PT-srUSDe) and Morpho (srUSDe collateral)
 - **Withdrawal restrictions**: 105% coverage circuit breaker can temporarily halt operations
 - **Same-value redemption**: srUSDe redeems for USDe (stablecoin-denominated), minimal price change risk
 - **Use case context**: For the Morpho use case (srUSDe as collateral for USDC loans), the collateral/loan price change should be minimal
 
-**Score: 3.0/5** -- Redemptions are available but not instant (~7 day cooldown). Limited or no DEX liquidity for secondary market exits. The same-value (stablecoin-denominated) redemption is a plus, and the Morpho collateral use case has minimal price impact risk. Between score 2 (direct redemption with minor delays) and score 4 (withdrawal queues/restrictions) -- the 7-day cooldown and limited secondary market push this toward 3.
+**Score: 3.0/5** -- Unchanged. Redemptions remain available but not instant.
 
 #### Category 5: Operational Risk (Weight: 5%)
 
 - **Team**: Partially anonymous. Founding team not publicly identified. Patrick Collins (Guardian) is the only doxxed individual, in a security oversight role
-- **Documentation**: Good quality, comprehensive, actively maintained
+- **Documentation**: Comprehensive at docs.strata.markets; the public docs page now also covers the four new markets (Neutrl, Midas mHYPER, Midas mM1-USD, Saturn USDat). However, parts of the docs are out-of-date with respect to onchain state (e.g. PAUSER_ROLE is documented as Admin Multisig but is in fact held by the Operational Multisig)
+- **Public GitHub activity**: Last push Feb 25, 2026 (~3 months stale); active development is on unmerged branches that are not visible from the master view
 - **Legal Structure**: Frontera Labs, Inc. (Delaware) operates the front-end. Protocol contracts are autonomous and licensed under BUSL-1.1. Planned transition to Cayman Islands foundation. US users geo-blocked
 - **Incident Response**: Not formally documented. 24/7 Hypernative monitoring + Guardian veto capability provide de facto incident response
 
-**Score: 2.5/5** -- Adequate documentation, clear legal entity (Delaware corporation), and US compliance via geo-blocking. Anonymous team and no formal incident response plan are concerns, but Patrick Collins's involvement adds credibility.
+**Score: 2.5/5** -- Held at 2.5. Strengths (legal clarity, monitoring) and weaknesses (anonymous team, doc drift, stalled public repo) roughly balance.
 
 ### Final Score Calculation
 
@@ -514,27 +542,29 @@ Final Score = (Centralization × 0.30) + (Funds Mgmt × 0.30) + (Audits × 0.20)
 
 Strata's srUSDe is a well-designed risk-tranching product with good audit coverage from reputable firms, multi-layered governance with independent Guardian oversight, and fully onchain accounting and exchange rate computation. The junior tranche first-loss protection adds meaningful risk mitigation beyond the underlying yield source.
 
-However, the protocol is very young (~4 months), has a critical single dependency on Ethena's sUSDe, exhibited significant TVL volatility (62.6% drawdown), has no bug bounty program, an anonymous team, and withdrawal delays tied to Ethena's cooldown period.
+The protocol is now ~7.5 months in production and has accumulated a longer (mostly clean) operational track record, but TVL volatility has worsened, not improved — there are now three sharp drawdown events on the public record, and current TVL ($86.8M) sits ~73% below the October 2025 peak. The protocol has also expanded rapidly to five live markets in three months, none of the new markets are separately audited, and an onchain governance check exposed a 24h-timelock executor misconfiguration that has gone unfixed for 7 months. Critical dependencies (Ethena, Aave) remain unchanged.
 
 **For the intended Yearn use cases:**
-1. **Direct srUSDe deposit**: Medium risk. The 7-day withdrawal cooldown and Ethena dependency are the primary concerns.
+1. **Direct srUSDe deposit**: Medium risk. The 7-day withdrawal cooldown and Ethena dependency are the primary concerns. The repeated TVL boom-bust pattern is worth watching for incident triggers (though no exploits have been observed).
 2. **srUSDe as Morpho collateral (srUSDe/USDC)**: Lower effective risk for the specific use case since srUSDe is stablecoin-denominated and price changes should be minimal, but liquidation could be slow due to cooldown periods.
 
 **Key conditions for exposure:**
-- Monitor srUSDe exchange rate for any decreases (should only increase)
-- Monitor senior coverage ratio (alert below 105%)
-- Monitor 48h and 24h timelocks for any scheduled changes
+- Monitor srUSDe exchange rate for any decreases (should only increase — currently 1.021541 USDe/srUSDe)
+- Monitor senior coverage ratio (alert below 105%; currently ~119.3%)
+- Monitor 48h Timelock for any scheduled changes (the 24h Timelock has not fired since deployment)
 - Monitor USDe peg stability
 - Track TVL for concentration risk signals (large outflows)
 - Verify bug bounty program status with the team
+- Verify with the team whether the 24h-timelock executor configuration is intentional or a bug requiring remediation
 
 ---
 
 ## Reassessment Triggers
 
-- **Time-based**: Reassess in 3 months (May 2026) given the protocol's youth
-- **TVL-based**: Reassess if TVL changes by more than 50%
+- **Time-based**: Reassess in 60 days (per reassessment-scan threshold) or sooner if any of the below trigger
+- **TVL-based**: Reassess if TVL changes by more than 50% (from current ~$87M)
 - **Incident-based**: Reassess after any exploit, governance change, collateral modification, or Ethena incident
 - **Dependency-based**: Reassess if Ethena modifies sUSDe mechanics, cooldown periods, or undergoes significant changes
 - **Bug bounty**: Reassess if/when a bug bounty program is launched (should improve Audits score)
-- **Governance-based**: Reassess when onchain governance is activated or when risk-premium parameters transition to independent managers
+- **Governance-based**: Reassess when onchain governance is activated, when risk-premium parameters transition to independent managers, or when the 24h-Timelock executor misconfiguration is resolved
+- **Market expansion**: Reassess if the new Neutrl/Midas/Saturn markets receive separate audits or if any of them experience an incident (operational spillover risk to srUSDe)

--- a/reports/report/strata-srusde.md
+++ b/reports/report/strata-srusde.md
@@ -149,7 +149,7 @@ The architecture is moderately complex:
 
 ### Bug Bounty
 
-**No active bug bounty program found.** Exhaustive search across Immunefi, Code4rena, Sherlock, HackerOne, Safe Harbor, and the protocol's own documentation and GitHub yielded no bug bounty listing, responsible disclosure policy, or security contact for vulnerability reporting. The [security documentation](https://docs.strata.markets/technical-documentation/security) covers audits, multisigs, and monitoring but does not mention a bug bounty. This is a notable gap for a protocol with >$150M TVL.
+**No active bug bounty program found.** Exhaustive search across Immunefi, Code4rena, Sherlock, HackerOne, Safe Harbor, and the protocol's own documentation and GitHub yielded no bug bounty listing, responsible disclosure policy, or security contact for vulnerability reporting. The [security documentation](https://docs.strata.markets/technical-documentation/security) covers audits, multisigs, and monitoring but does not mention a bug bounty. This is a notable gap for a protocol with tens of millions in TVL (~$86.8M as of May 19, 2026).
 
 ## Historical Track Record
 
@@ -213,7 +213,7 @@ The architecture is moderately complex:
 - **Senior coverage ratio**: When it falls below **105%**, the protocol may temporarily halt senior minting and junior redemptions to protect the senior tranche
 - **Underlying collateral**: USDe is Ethena's synthetic dollar backed by a delta-neutral strategy (ETH/BTC spot + short perpetual futures). Ethena maintains proof of reserves via third-party verification
 - **Risk hierarchy**: Senior tranche (srUSDe) is principal-protected in the base asset and paid first. The junior tranche absorbs losses before any impact to senior holders. However, if the junior tranche is **fully depleted**, the senior tranche **may incur principal losses**
-- **Reserve mechanism**: Part of strategy gains can be allocated to a protocol reserve (configurable via `setReserveBps`), which can be redistributed to tranche TVL or withdrawn to treasury
+- **Reserve mechanism**: Part of strategy gains can be allocated to a protocol reserve (configurable via `setReserveBps`). The reserve *could* in principle be redistributed to tranche TVL or withdrawn to treasury via `distributeReserve`, `reduceReserve`, and `setReserveTreasury` — however, all three functions require `RESERVE_MANAGER_ROLE`, which onchain is held only by the 24h Timelock. The 24h Timelock currently has no executor configured (see Centralization section), so **none of these reserve-management paths can currently fire**. The reserve buffer is therefore effectively frozen at its current allocation and cannot be relied upon as adjustable senior-tranche support until the executor configuration is fixed.
 
 ### Provability
 
@@ -228,8 +228,8 @@ The architecture is moderately complex:
 
 1. **Redeem from srUSDe vault**: Initiate withdrawal → cooldown period (tied to Ethena's sUSDe cooldown, currently ~7 days) → finalize. Permissionless but not instant
 2. **DEX swap**: Extremely thin onchain DEX liquidity. Total across all Uniswap V4 pools: ~$135K. Largest pool is srUSDe/USDe at ~$81K with only $425 in 24h volume. **No Curve or Balancer pools exist.** CoinGecko does not list srUSDe
-3. **Pendle markets**: PT-srUSDe-02APR2026 pool holds ~$21.9M TVL with ~$128K weekly volume. Primary venue for srUSDe trading, but these are fixed-yield PT tokens, not raw srUSDe
-4. **Morpho markets**: PT-srUSDe-2APR2026/USDC market has ~$14.6M supply and 82.4% utilization. A raw srUSDe/USDe market exists on Morpho but is empty ($0 supply/$0 borrow)
+3. **Pendle markets**: The PT-srUSDe-02APR2026 pool referenced in the previous report **expired April 2, 2026** (onchain `isExpired() = true`, `expiry() = 1775088000`). The successor market PT-srUSDe-25JUN2026 ([market `0xfc82267a9e065aaf407f64dadd49bfbdc9511fb1`](https://etherscan.io/address/0xfc82267a9e065aaf407f64dadd49bfbdc9511fb1), [PT `0x619D75E3b790eBC21c289f2805Bb7177A7D732E2`](https://etherscan.io/address/0x619D75E3b790eBC21c289f2805Bb7177A7D732E2)) is live with **~$11.2M LP liquidity** as of May 19, 2026 (Pendle API). This trades the fixed-yield PT, not raw srUSDe
+4. **Morpho markets**: PT-srUSDe-25JUN2026/USDC market exists but is **near-empty** (~$4.7K supply, 88% utilization on minuscule borrow per Morpho Blue API on May 19, 2026). A raw srUSDe/USDe market exists on Morpho with $0 supply/$0 borrow. The previously-cited ~$14.6M PT-srUSDe-2APR2026/USDC market is no longer active (PT expired)
 
 ### Withdrawal Restrictions
 
@@ -240,8 +240,8 @@ The architecture is moderately complex:
 ### Liquidity Assessment
 
 - **Primary liquidity**: The main exit path is through the cooldown-based redemption mechanism (not instant)
-- **Secondary market**: DEX liquidity is negligible (~$135K total across Uniswap V4 pools). Pendle PT-srUSDe markets (~$21.9M) are the most liquid venue but trade fixed-yield PTs, not raw srUSDe. Morpho lending markets hold ~$14.6M in PT-srUSDe collateral
-- **Large holder impact**: Given the TVL volatility (62.6% drawdown from peak), large holders can exit but it takes time due to cooldowns
+- **Secondary market**: DEX liquidity remains negligible. Pendle is the most liquid venue with the **active** PT-srUSDe-25JUN2026 market holding ~$11.2M LP liquidity (down from the ~$21.9M cited at the previous assessment for the now-expired April PT). Morpho PT-srUSDe-25JUN2026/USDC market has effectively no supply (~$4.7K). Raw srUSDe markets remain empty
+- **Large holder impact**: Given the TVL volatility (~73% drawdown from peak), large holders can exit but it takes time due to cooldowns and the now-thinner secondary market
 - **Same-value redemption**: srUSDe redeems for USDe (stablecoin-denominated), so price impact risk is minimal for the Morpho use case
 
 ## Centralization & Control Risks
@@ -409,7 +409,7 @@ Strata uses a layered Role-Based Access Control (RBAC) system in the **AccessCon
 
 ### Critical Risk Gates
 
-- [x] **No audit** -- Protocol audited by 3 reputable firms (Cyfrin, Quantstamp, Guardian) across 7+ engagements. **PASS**
+- [x] **No audit** -- Protocol audited by 3 reputable firms (Cyfrin, Quantstamp, Guardian) across 8 engagements. **PASS**
 - [x] **Unverifiable reserves** -- srUSDe exchange rate is programmatic onchain (ERC-4626). Underlying sUSDe holdings verifiable onchain. **PASS**
 - [x] **Total centralization** -- 3-of-4 Gnosis Safe multisig with 48h timelock and independent Guardian. Not a single EOA. **PASS**
 
@@ -475,9 +475,9 @@ Strata uses a layered Role-Based Access Control (RBAC) system in the **AccessCon
 - Over-collateralized by junior tranche (first-loss capital). Senior:Junior asset ratio ~5.17:1; total-system collateralization ~119.3% of senior assets — above the 105% circuit breaker but tighter than the protocol's idealized targets
 - 105% coverage circuit breaker provides protection
 - Underlying collateral is USDe (Ethena's synthetic dollar -- backed by delta-neutral ETH/BTC strategy with CEX counterparty exposure)
-- Reserve mechanism exists (configurable via timelock; treasury withdrawal currently blocked by the 24h-timelock executor gap)
+- Reserve mechanism exists in code (`setReserveBps` allocates a portion of strategy gains to reserve), but **all reserve-management paths are currently unreachable**: `RESERVE_MANAGER_ROLE` is held only by the 24h Timelock, which has no executor configured (see Centralization section). `distributeReserve`, `reduceReserve`, and `setReserveTreasury` therefore cannot fire on the current setup, so the reserve cannot be relied upon as adjustable senior-tranche support (it also can't be extracted to treasury — net mixed for users).
 
-**Collateralization Score: 2.5** -- Unchanged. Onchain backing remains verifiable. Reserve-extraction concern is reduced vs. the prior assessment (timelocked, currently unreachable) but Ethena synthetic-dollar dependency is the dominant risk.
+**Collateralization Score: 2.5** -- Unchanged. Onchain backing remains verifiable. Reserve cannot be redistributed *or* extracted under current configuration, removing both the extraction risk and the reserve-as-support upside vs. the prior assessment. Ethena synthetic-dollar dependency remains the dominant risk.
 
 **Subcategory B: Provability**
 


### PR DESCRIPTION
## Summary

Refresh srUSDe risk report (closes #163) with onchain validation via `RPC_1`.

- **Role-table corrections** (verified via `hasRole` on AccessControlManager `0x1d19E18ECaC4ef332a0d5d6Aa3a0f0f772605f60`):
  - `PAUSER_ROLE` → **Operational Multisig (2/3)**, not Admin Multisig (3/4) as previously documented
  - `RESERVE_MANAGER_ROLE` → **24h Timelock only**, not Admin Multisig — removes the "reserve extraction" critical risk the prior report flagged
  - `UPDATER_STRAT_CONFIG_ROLE` → **both 48h + 24h Timelocks** (prior report listed 24h only)
- **24h Timelock has no executor** configured (empty `executors[]` in deployment calldata) and 0 `CallExecuted` events in ~7 months — roles routed through it can't fire on that path. Flagged for team follow-up
- TVL refresh: $153.6M → **$86.8M** (~73% below the $326M Oct 2025 peak; two additional sharp drawdowns in Apr 2026)
- Exchange rate: `convertToAssets(1e18)` = 1.013728 → **1.021541 USDe/srUSDe** (~3.1% annualized over 90 days)
- New Quantstamp audit on the discrete-accounting mechanism
- Protocol expanded to **5 live markets** (added Neutrl NUSD, Midas mHYPER, Midas mM1-USD, Saturn USDat) — srUSDe contracts unchanged
- Final score **unchanged at 2.8** (corrected reserve risk offset by lower pause threshold + worse TVL volatility + multi-market surface area)

## Test plan

- [x] Spot-check role-membership table against onchain `hasRole` queries — re-verified 2026-05-19: Admin(3/4)→PROPOSER_CONFIG; Op(2/3)→PAUSER + UPDATER_FEED + DEPOSITOR_CONFIG; 48hTL→DEFAULT_ADMIN + UPDATER_STRAT_CONFIG; 24hTL→DEFAULT_ADMIN + UPDATER_STRAT_CONFIG + RESERVE_MANAGER; Ownable `owner()` of StrataCDO/srUSDe/Accounting/sUSDeStrategy all = 48h Timelock
- [x] Verify exchange-rate / `totalAssets` / `totalSupply` numbers via `cast call` — `convertToAssets(1e18) = 1.021550…` (ticked up vs the 1.021541… captured in the report, expected since rate accrues continuously); `totalAssets ≈ 51.91M`; `totalSupply ≈ 50.81M srUSDe`; jrUSDe `totalAssets ≈ 10.05M`; 48h delay = 172800s; 24h delay = 86400s; Safe thresholds 3 and 2
- [x] Confirm TVL history aligns with DeFiLlama — peak $326.4M on 2025-10-08; current $86.9M on 2026-05-19 (73.4% drawdown); Apr drawdown points: $242M→$195M→$115M (Apr 2-4) and $119M→$90M→$84M (Apr 23-25)
- [x] Sanity-check new audit link (Quantstamp discrete-accounting certificate) — HTTP 200 on `certificate.quantstamp.com/full/strata-discrete-accounting/02318e87-…`; Cyfrin/Guardian PDF links also resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
