### PR TITLE
feat(graph): backfill dependency graphs for 30 reports

### DIFF
--- a/reports/graph/3jane-usd3.yaml
+++ b/reports/graph/3jane-usd3.yaml
@@ -1,0 +1,189 @@
+slug: 3jane-usd3
+title: 3Jane (USD3) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Strategy
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: USD3
+    label: USD3 (Senior Tranche)
+    address: "0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc"
+    category: vault
+    note: ERC-4626 senior tranche; TransparentUpgradeableProxy
+  - id: sUSD3
+    label: sUSD3 (Junior / First-Loss)
+    address: "0xf689555121e529Ff0463e191F9Bd9d1E496164a7"
+    category: vault
+    note: Staked USD3; absorbs losses first; 1-month lock
+
+  # === Protocol infra ===
+  - id: morpho-credit
+    label: MorphoCredit (Lending Engine)
+    address: "0xDe6e08ac208088cc62812Ba30608D852c6B0EcBc"
+    category: infra
+    note: Morpho Blue fork with credit-based markets
+  - id: credit-line
+    label: CreditLine (Borrower Approval)
+    address: "0x26389b03298BA5DA0664FfD6bF78cF3A7820c6A9"
+    category: infra
+    note: Approves credit lines, posts minimum repayments
+  - id: protocol-config
+    label: ProtocolConfig
+    address: "0x6b276A2A7dd8b629adBA8A06AD6573d01C84f34E"
+    category: infra
+    note: Pause, debt cap, tranche ratios, IRM bounds
+  - id: irm
+    label: AdaptiveCurveIRM
+    address: "0x1d434D2899f81F3C3fdf52C814A6E23318f9C7Df"
+    category: infra
+    note: Interest rate model proxy
+  - id: helper
+    label: Helper (Borrower Interactions)
+    address: "0x82736F81A56935c8429ADdbDa4aEBec737444505"
+    category: infra
+
+  # === Governance ===
+  - id: multisig
+    label: Multisig (3-of-5 Safe)
+    address: "0x33333333bd7045f1a601a1e289d7ab21036fb5ef"
+    category: governance
+    note: PROPOSER + EXECUTOR + CANCELLER on Timelock
+  - id: timelock
+    label: TimelockController (24h)
+    address: "0x1dCcD4628d48a50C1A7adEA3848bcC869f08f8C2"
+    category: governance
+    note: Owner of all core contracts
+  - id: emergency-controller
+    label: EmergencyController
+    category: governance
+    note: EMERGENCY_AUTHORIZED_ROLE; bypasses timelock for binary pause / debt-cap=0
+
+  # === Strategies / Capital deployment ===
+  - id: aave-strategy
+    label: Aave V3 Idle Reserves
+    category: strategy
+    note: Baseline yield on idle USDC; Phase 1 "risk-off" mode
+  - id: unsecured-loans
+    label: Unsecured Credit Lines
+    category: strategy
+    note: ~$7.2M borrowed (44% utilization); base rate + risk premium
+
+  # === External dependencies ===
+  - id: aave-v3-usdc
+    label: Aave V3 USDC Market
+    category: dependency
+    note: Blue-chip lending venue for idle reserves
+  - id: borrowers
+    label: Approved Borrowers
+    category: dependency
+    note: Offchain-underwritten credit lines (3CA algorithm)
+  - id: zk-tls
+    label: zkTLS / Reclaim Protocol
+    category: dependency
+    note: Zero-knowledge proofs of offchain bank/credit data
+  - id: eigenlayer-avs
+    label: EigenLayer AVS
+    category: dependency
+    note: Verifies zkTLS proofs; early-stage infra
+  - id: insurance-fund
+    label: Insurance Fund ($1M USDC)
+    category: dependency
+    note: Second-loss buffer after sUSD3
+
+edges:
+  # === Governance flow ===
+  - from: multisig
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR + CANCELLER
+  - from: timelock
+    to: morpho-credit
+    kind: controls
+    label: owner (24h delay)
+  - from: timelock
+    to: USD3
+    kind: controls
+    label: proxy admin (24h delay)
+  - from: timelock
+    to: protocol-config
+    kind: controls
+    label: owner (24h delay)
+  - from: timelock
+    to: credit-line
+    kind: controls
+    label: owner
+  - from: emergency-controller
+    to: morpho-credit
+    kind: holds-role
+    label: EMERGENCY_AUTHORIZED_ROLE (bypass timelock)
+
+  # === Internal vault flow ===
+  - from: sUSD3
+    to: USD3
+    kind: deposits-into
+    label: "stake (85/15 yield split)"
+  - from: USD3
+    to: morpho-credit
+    kind: deposits-into
+    label: USDC supply
+
+  # === Allocation: lending pool into strategies ===
+  - from: morpho-credit
+    to: aave-strategy
+    kind: allocates-to
+    label: "idle reserves (~56%)"
+  - from: morpho-credit
+    to: unsecured-loans
+    kind: allocates-to
+    label: "~44% utilization"
+
+  # === Credit underwriting wiring ===
+  - from: credit-line
+    to: morpho-credit
+    kind: manages
+    label: approves credit lines
+  - from: protocol-config
+    to: morpho-credit
+    kind: manages
+    label: pause / debt cap / tranche ratios
+  - from: irm
+    to: morpho-credit
+    kind: manages
+    label: borrow rate model
+  - from: helper
+    to: morpho-credit
+    kind: routes-through
+    label: borrower entry point
+
+  # === Strategy → external dependencies ===
+  - from: aave-strategy
+    to: aave-v3-usdc
+    kind: deposits-into
+    label: "USDC supply"
+  - from: unsecured-loans
+    to: borrowers
+    kind: deposits-into
+    label: "uncollateralized loans"
+  - from: borrowers
+    to: zk-tls
+    kind: routes-through
+    label: bank / credit-score proofs
+  - from: zk-tls
+    to: eigenlayer-avs
+    kind: routes-through
+    label: ZK proof verification
+  - from: USD3
+    to: insurance-fund
+    kind: routes-through
+    label: $1M loss buffer

--- a/reports/graph/aave-sgho.yaml
+++ b/reports/graph/aave-sgho.yaml
@@ -1,0 +1,159 @@
+slug: aave-sgho
+title: Aave (sGho) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Strategy / Module
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: sGho
+    label: sGho (GHO Savings Vault)
+    address: "0xE1753F2e00940cC31213dd92013cF019DFE4ca1d"
+    category: vault
+    note: ERC-4626, TransparentUpgradeableProxy
+  - id: gho
+    label: GHO (Aave Stablecoin)
+    address: "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f"
+    category: vault
+    note: ERC-20, upgradeable
+
+  # === Strategy / module legs ===
+  - id: gsm-usdc
+    label: GSM USDC (Gsm4626)
+    address: "0x3A3868898305f04beC7FEa77BecFf04C13444112"
+    category: strategy
+    note: waEthUSDC ↔ GHO at 1:1
+  - id: gho-reserve
+    label: GHO Reserve (GSM Facilitator)
+    address: "0x54C58157DeF387A880AE62332D1445f03adbE7E9"
+    category: strategy
+    note: Pre-minted GHO pool drawn by GSMs
+
+  # === Infra ===
+  - id: sgho-proxy-admin
+    label: sGho ProxyAdmin
+    address: "0xc15700631020eba02317964550365b95a9a28adb"
+    category: infra
+  - id: oracle-swap-freezer
+    label: Oracle Swap Freezer
+    address: "0x6e51936e0ED4256f9dA4794B536B619c88Ff0047"
+    category: infra
+    note: Chainlink-based auto-freeze on USDC depeg
+
+  # === Governance ===
+  - id: aave-executor-l1
+    label: Aave Governance Executor L1
+    address: "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A"
+    category: governance
+    note: On-chain DAO timelock executor
+  - id: sgho-steward
+    label: sGho Steward
+    address: "0x60Bf2DF49F17529Cf956D57848ebEB8a0d0a2757"
+    category: governance
+    note: Decomposes YIELD_MANAGER (rate, supply cap)
+  - id: risk-council
+    label: GHO Risk Council (3-of-4 Safe)
+    address: "0x8513e6F37dBc52De87b166980Fa3F50639694B60"
+    category: governance
+  - id: protocol-guardian
+    label: Aave Protocol Guardian
+    address: "0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30"
+    category: governance
+    note: Emergency pause
+  - id: gho-gsm-steward
+    label: GHO GSM Steward
+    address: "0xD1E856a947CdF56b4f000ee29d34F5808E0A6848"
+    category: governance
+    note: CONFIGURATOR on GSMs (rate-limited)
+
+  # === External dependencies ===
+  - id: dep-waEthUSDC
+    label: waEthUSDC (Wrapped Aave USDC)
+    address: "0xD4fa2D31b7968E448877f69A96DE69f5de8cD23E"
+    category: dependency
+    note: ERC-4626 staticAToken; Aave V3 USDC supply position
+  - id: dep-aave-v3
+    label: Aave V3 USDC Market
+    category: dependency
+    note: Underlying lending market for waEthUSDC
+
+edges:
+  # === Governance flow ===
+  - from: aave-executor-l1
+    to: sgho-proxy-admin
+    kind: controls
+    label: owner
+  - from: sgho-proxy-admin
+    to: sGho
+    kind: manages
+    label: upgradeable proxy
+  - from: aave-executor-l1
+    to: sGho
+    kind: holds-role
+    label: DEFAULT_ADMIN + TOKEN_RESCUER
+  - from: aave-executor-l1
+    to: sgho-steward
+    kind: controls
+    label: DEFAULT_ADMIN
+  - from: sgho-steward
+    to: sGho
+    kind: holds-role
+    label: YIELD_MANAGER
+  - from: risk-council
+    to: sgho-steward
+    kind: holds-role
+    label: FIXED_RATE / SUPPLY_CAP / FLOAT / AMP
+  - from: protocol-guardian
+    to: sGho
+    kind: holds-role
+    label: PAUSE_GUARDIAN
+  - from: aave-executor-l1
+    to: gsm-usdc
+    kind: holds-role
+    label: DEFAULT_ADMIN + CONFIGURATOR + SWAP_FREEZER
+  - from: gho-gsm-steward
+    to: gsm-usdc
+    kind: holds-role
+    label: CONFIGURATOR (rate-limited)
+  - from: oracle-swap-freezer
+    to: gsm-usdc
+    kind: holds-role
+    label: SWAP_FREEZER (auto)
+
+  # === Mint authority on GHO (via GSM Reserve facilitator) ===
+  - from: gho-reserve
+    to: gho
+    kind: mints
+    label: GSM facilitator (pre-minted pool)
+
+  # === Money flow: USDC pipeline → sGho ===
+  - from: sGho
+    to: gsm-usdc
+    kind: routes-through
+    label: "waEthUSDC → GHO"
+  - from: gsm-usdc
+    to: gho-reserve
+    kind: routes-through
+    label: draws GHO
+  - from: gsm-usdc
+    to: dep-waEthUSDC
+    kind: deposits-into
+    label: "waEthUSDC custody"
+  - from: dep-waEthUSDC
+    to: dep-aave-v3
+    kind: deposits-into
+    label: "USDC supply"
+  - from: sGho
+    to: gho
+    kind: deposits-into
+    label: holds GHO (no rehypothecation)

--- a/reports/graph/across-protocol.yaml
+++ b/reports/graph/across-protocol.yaml
@@ -1,0 +1,204 @@
+slug: across-protocol
+title: Across Protocol (V2 LP Tokens) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: LP Token
+  - id: strategy
+    label: Spoke / Strategy
+  - id: governance
+    label: Governance / Multisig
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === LP tokens (user-facing vault layer) ===
+  - id: lp-weth
+    label: Av2-WETH-LP
+    address: "0x28F77208728B0A45cAb24c4868334581Fe86F95B"
+    category: vault
+  - id: lp-usdc
+    label: Av2-USDC-LP
+    address: "0xC9b09405959f63F72725828b5d449488b02be1cA"
+    category: vault
+  - id: lp-usdt
+    label: Av2-USDT-LP
+    address: "0xC2faB88f215f62244d2E32c8a65E8F58DA8415a5"
+    category: vault
+  - id: lp-dai
+    label: Av2-DAI-LP
+    address: "0x4FaBacAC8C41466117D6A38F46d08ddD4948A0cB"
+    category: vault
+  - id: lp-wbtc
+    label: Av2-WBTC-LP
+    address: "0x59C1427c658E97a7d568541DaC780b2E5c8affb4"
+    category: vault
+
+  # === Protocol infra ===
+  - id: hub-pool
+    label: HubPool (immutable, custody)
+    address: "0xc186fA914353c44b2E33eBE05f21846F1048bEda"
+    category: infra
+    note: Non-upgradeable; holds liquidReserves and accounts for utilizedReserves
+  - id: lp-factory
+    label: LpTokenFactory
+    address: "0x7dB69eb9F52eD773E9b03f5068A1ea0275b2fD9d"
+    category: infra
+    note: Deploys per-pool LP tokens; sole minter = HubPool
+  - id: bond-token
+    label: BondToken (ABT)
+    address: "0xee1DC6BCF1Ee967a350e9aC6CaaAA236109002ea"
+    category: infra
+    note: Bond currency; proposer allowlist gated by HubPool Owner
+  - id: config-store
+    label: AcrossConfigStore (LP fee params)
+    address: "0x3B03509645713718B78951126E0A6de6f10043f5"
+    category: infra
+  - id: eth-spoke
+    label: Ethereum SpokePool (UUPS)
+    address: "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5"
+    category: strategy
+    note: Inflight inventory venue; admin = HubPool
+  - id: l2-spokes
+    label: L2 SpokePools (Arbitrum, Optimism, Base, Polygon, zkSync, Linea, Blast, World Chain, ...)
+    category: strategy
+    note: All UUPS, admin via relaySpokePoolAdminFunction
+
+  # === Governance ===
+  - id: hub-owner-safe
+    label: Hub Pool Owner Safe (3-of-5)
+    address: "0xB524735356985D2f267FA010D681f061DfF03715"
+    category: governance
+    note: No timelock; holds setPaused, haircutReserves, relaySpokePoolAdminFunction; also owns BondToken
+
+  # === External dependencies ===
+  - id: uma-oo
+    label: UMA Optimistic Oracle V3
+    address: "0xfb55F43fB9F48F63f9269DB7Dde3BbBe1ebDC0dE"
+    category: dependency
+    note: 30-min liveness, ACROSS-V2 identifier
+  - id: uma-dvm
+    label: UMA DVM (UMA tokenholders)
+    category: dependency
+    note: Final dispute arbiter
+  - id: canonical-bridges
+    label: Canonical L1↔L2 Bridges
+    category: dependency
+    note: Arbitrum / Optimism / Base / Polygon / zkSync / Linea / Blast / World Chain native bridges
+
+edges:
+  # === Governance — multisig has unilateral control over the HubPool ===
+  - from: hub-owner-safe
+    to: hub-pool
+    kind: holds-role
+    label: owner (no timelock; setPaused, haircutReserves, relaySpokePoolAdminFunction)
+  - from: hub-owner-safe
+    to: bond-token
+    kind: holds-role
+    label: owner (setProposer allowlist)
+  - from: hub-owner-safe
+    to: config-store
+    kind: manages
+    label: LP fee rate params
+  - from: hub-owner-safe
+    to: eth-spoke
+    kind: manages
+    label: UUPS upgrade (via HubPool)
+  - from: hub-owner-safe
+    to: l2-spokes
+    kind: manages
+    label: UUPS upgrade (via HubPool)
+
+  # === Deployment ===
+  - from: lp-factory
+    to: lp-weth
+    kind: deploys
+  - from: lp-factory
+    to: lp-usdc
+    kind: deploys
+  - from: lp-factory
+    to: lp-usdt
+    kind: deploys
+  - from: lp-factory
+    to: lp-dai
+    kind: deploys
+  - from: lp-factory
+    to: lp-wbtc
+    kind: deploys
+
+  # === LP token mint authority ===
+  - from: hub-pool
+    to: lp-weth
+    kind: mints
+    label: sole minter (addLiquidity)
+  - from: hub-pool
+    to: lp-usdc
+    kind: mints
+    label: sole minter (addLiquidity)
+  - from: hub-pool
+    to: lp-usdt
+    kind: mints
+    label: sole minter (addLiquidity)
+  - from: hub-pool
+    to: lp-dai
+    kind: mints
+    label: sole minter (addLiquidity)
+  - from: hub-pool
+    to: lp-wbtc
+    kind: mints
+    label: sole minter (addLiquidity)
+
+  # === Capital flow: LP token → HubPool → SpokePool inventory ===
+  - from: lp-weth
+    to: hub-pool
+    kind: deposits-into
+    label: addLiquidity / removeLiquidity
+  - from: lp-usdc
+    to: hub-pool
+    kind: deposits-into
+    label: addLiquidity / removeLiquidity
+  - from: lp-usdt
+    to: hub-pool
+    kind: deposits-into
+    label: addLiquidity / removeLiquidity
+  - from: lp-dai
+    to: hub-pool
+    kind: deposits-into
+    label: addLiquidity / removeLiquidity
+  - from: lp-wbtc
+    to: hub-pool
+    kind: deposits-into
+    label: addLiquidity / removeLiquidity
+  - from: hub-pool
+    to: eth-spoke
+    kind: allocates-to
+    label: utilizedReserves
+  - from: hub-pool
+    to: l2-spokes
+    kind: allocates-to
+    label: utilizedReserves (cross-chain)
+
+  # === Inflight inventory repatriates via canonical bridges ===
+  - from: l2-spokes
+    to: canonical-bridges
+    kind: routes-through
+    label: repatriate to HubPool
+
+  # === Optimistic oracle dependency ===
+  - from: hub-pool
+    to: uma-oo
+    kind: routes-through
+    label: root bundle dispute
+  - from: uma-oo
+    to: uma-dvm
+    kind: routes-through
+    label: escalate on dispute
+
+  # === Bond token tie-in ===
+  - from: hub-pool
+    to: bond-token
+    kind: routes-through
+    label: proposer bond

--- a/reports/graph/apyx-apxusd.yaml
+++ b/reports/graph/apyx-apxusd.yaml
@@ -1,0 +1,187 @@
+slug: apyx-apxusd
+title: Apyx (apxUSD / apyUSD) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: apxUSD
+    label: apxUSD (Dividend-Backed USD)
+    address: "0x98a878B1CD98131b271883b390F68d2c90674665"
+    category: vault
+    note: ERC-20, UUPS Proxy
+  - id: apyUSD
+    label: apyUSD (Yield Vault)
+    address: "0x38eeb52f0771140d10c4e9a9a72349a329fe8a6a"
+    category: vault
+    note: ERC-4626 yield vault, UUPS Proxy
+  - id: unlock-token
+    label: UnlockToken (30-day cooldown)
+    address: "0x93775e2dfa4e716c361a1f53f212c7ae031bf4e6"
+    category: vault
+    note: apyUSD redemption queue
+
+  # === Protocol infra ===
+  - id: access-manager
+    label: AccessManager (OZ v5)
+    address: "0xe167330e2eac88666de253e9607c6d9ae0ca2824"
+    category: infra
+  - id: minter-v0
+    label: MinterV0 (EIP-712)
+    address: "0x2c36e1adfaa80ee0324b04cc814f5207bb7ba76e"
+    category: infra
+    note: MINT_STRAT_ROLE (60s / 4h delays)
+  - id: rate-oracle
+    label: ApxUSDRateOracle
+    address: "0xa2ef2e7bf32248083e514a737259f3785ea8d37d"
+    category: infra
+    note: Admin-set Curve pool oracle (0 delay)
+  - id: yield-distributor
+    label: YieldDistributor
+    address: "0xdbca79adc13a0fa6f921d5cf5b3fae2b8a739c2a"
+    category: infra
+  - id: linear-vest
+    label: LinearVestV0 (~17d vesting)
+    address: "0x0d62b4cc02b4b51ed19ddf41d7a7979cf394c99f"
+    category: infra
+  - id: address-list
+    label: AddressList (Allow/Deny)
+    address: "0x2c271ddf484ac0386d216eb7eb9ff02d4dc0f6aa"
+    category: infra
+  - id: order-delegate
+    label: OrderDelegate
+    address: "0x5c697433e214b1a6d7a2ddd4cdca1505c98f75f1"
+    category: infra
+
+  # === Governance ===
+  - id: admin-safe
+    label: Admin Safe (4-of-6)
+    address: "0xabdd8c8ee69e5f5180eb9352aeffc5ceead65e96"
+    category: governance
+    note: ADMIN_ROLE; 0 exec delay
+  - id: guardian-safe
+    label: Guardian / Upgrader Safe (3-of-6)
+    address: "0xf9862efc1704ac05e687f66e5cd8c130e5663ce2"
+    category: governance
+    note: UPGRADER (3d), PAUSER (0), UNPAUSER (4h), YIELD_OPERATOR (0)
+  - id: ops-safe
+    label: Operations Safe (3-of-5)
+    address: "0x37b0779a66edc491df83e59a56d485835323a555"
+    category: governance
+    note: No AccessManager roles
+
+  # === External dependencies ===
+  - id: dep-preferred-shares
+    label: DAT Preferred Shares (STRC / SATA)
+    category: dependency
+    note: Offchain Nasdaq-listed equities; ~11-12% dividend
+  - id: dep-mpc-custody
+    label: MPC Prime-Brokerage Custody
+    category: dependency
+    note: Third-party prime brokerage accounts; custodians not publicly named
+  - id: dep-curve
+    label: Curve apxUSD/USDC StableSwap-NG
+    address: "0xe1b96555bbeca40e583bbb41a11c68ca4706a414"
+    category: dependency
+    note: Primary exit; ~$29M TVL
+  - id: dep-ccip
+    label: Chainlink CCIP (Base)
+    category: dependency
+    note: Cross-chain expansion to Base
+
+edges:
+  # === Governance flow ===
+  - from: admin-safe
+    to: access-manager
+    kind: holds-role
+    label: ADMIN_ROLE (0 delay)
+  - from: guardian-safe
+    to: access-manager
+    kind: holds-role
+    label: UPGRADER (3d) + PAUSER + UNPAUSER + YIELD_OPERATOR
+  - from: access-manager
+    to: apxUSD
+    kind: manages
+    label: role-gated calls
+  - from: access-manager
+    to: apyUSD
+    kind: manages
+    label: role-gated calls
+  - from: access-manager
+    to: minter-v0
+    kind: manages
+  - from: access-manager
+    to: rate-oracle
+    kind: manages
+    label: setRate (0 delay)
+  - from: access-manager
+    to: yield-distributor
+    kind: manages
+  - from: access-manager
+    to: linear-vest
+    kind: manages
+  - from: access-manager
+    to: address-list
+    kind: manages
+  - from: access-manager
+    to: unlock-token
+    kind: manages
+
+  # === Mint authority on apxUSD ===
+  - from: minter-v0
+    to: apxUSD
+    kind: mints
+    label: MINT_STRAT_ROLE
+  - from: order-delegate
+    to: minter-v0
+    kind: routes-through
+    label: minting delegate
+
+  # === Internal vault flow ===
+  - from: apyUSD
+    to: apxUSD
+    kind: deposits-into
+    label: ERC-4626 stake
+  - from: apyUSD
+    to: unlock-token
+    kind: routes-through
+    label: "30-day cooldown"
+
+  # === Yield distribution ===
+  - from: yield-distributor
+    to: linear-vest
+    kind: routes-through
+    label: ~17d linear
+  - from: linear-vest
+    to: apyUSD
+    kind: deposits-into
+    label: vested apxUSD yield
+
+  # === Oracle wiring ===
+  - from: rate-oracle
+    to: dep-curve
+    kind: routes-through
+    label: pool pricing
+
+  # === Backing & external dependencies ===
+  - from: apxUSD
+    to: dep-preferred-shares
+    kind: deposits-into
+    label: offchain backing
+  - from: dep-preferred-shares
+    to: dep-mpc-custody
+    kind: routes-through
+    label: custody
+  - from: apxUSD
+    to: dep-ccip
+    kind: routes-through
+    label: Base bridge

--- a/reports/graph/buck.yaml
+++ b/reports/graph/buck.yaml
@@ -1,0 +1,222 @@
+slug: buck
+title: BUCK (Bitcoin Dollar SavingsCoin) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Reserve
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: BUCK
+    label: BUCK Token (UUPS Proxy)
+    address: "0xdb13997f4D83EF343845d0bAEb27d1173dF8c224"
+    category: vault
+    note: Yield-bearing ERC-20; ~$1.00 entry price
+
+  # === Protocol infra ===
+  - id: liquidity-window
+    label: Liquidity Window (Mint/Refund)
+    address: "0x6E87adb23ac0e150Ca9F76C33Df2AdCae508548E"
+    category: infra
+    note: Access-gated mint/refund entrypoint
+  - id: policy-manager
+    label: Policy Manager (Band State)
+    address: "0x79f86b9E0ac84C7580575089E453431D77905E36"
+    category: infra
+    note: GREEN/YELLOW/RED band logic; fees + caps
+  - id: oracle-adapter
+    label: Oracle Adapter (non-strict)
+    address: "0xa6c5f4D041192C2019E77f679eA02e9684235Fd9"
+    category: infra
+    note: Falls back to admin-set $1.00; Pyth onchain stale 46+ days
+  - id: rewards-engine
+    label: Rewards Engine
+    address: "0x159c1C0F796a02111334cC280eE001b091a9580C"
+    category: infra
+    note: Distributes monthly STRC dividends as BUCK; upgraded 3x in 8wk
+  - id: collateral-attestation
+    label: Collateral Attestation
+    address: "0x1aEEEf99704258947A9ea77eF021d5e0551c0428"
+    category: infra
+    note: Stores STRC valuation posted by attestor EOA
+  - id: access-registry
+    label: Access Registry (Allowlist)
+    address: "0xbCc6de2423B496cb36C3278dC487EfD9c5C550B6"
+    category: infra
+    note: Merkle allowlist; revoke() denylists addresses
+
+  # === Reserve legs ===
+  - id: liquidity-reserve
+    label: Liquidity Reserve (USDC)
+    address: "0x1A426E3a87368a4851f7443Ff656A054Af872f66"
+    category: strategy
+    note: ~$124K USDC (8% of reserves); 24h queued withdrawals
+  - id: strc-reserve
+    label: STRC Reserve (Offchain Custody)
+    category: strategy
+    note: ~$1.52M STRC (92% of reserves); held in Fireblocks MPC
+
+  # === Governance ===
+  - id: admin-eoa
+    label: Admin / Owner (Single EOA)
+    address: "0x376269214bB78b3D4f31d17600499b439c1aCB4b"
+    category: governance
+    note: Sole owner of all 8 contracts; NO multisig, NO timelock
+  - id: treasury-eoa
+    label: Treasury (EOA)
+    address: "0x5d105791469064cA0764cfaCfc577c286351CFAD"
+    category: governance
+  - id: attestor-eoa
+    label: Attestor (EOA)
+    address: "0x6f31810c8e6bfaf3ba486b4b7ce651b023423fa3"
+    category: governance
+    note: Single EOA posts STRC valuations
+
+  # === External dependencies ===
+  - id: strc
+    label: STRC (Strategy Inc. Preferred)
+    category: dependency
+    note: NASDAQ:STRC; 9% par dividends; sole yield source
+  - id: pyth
+    label: Pyth Oracle (STRC/USD)
+    address: "0x4305fb66699c3b2702d4d05cf36551390a4c69c6"
+    category: dependency
+    note: Pull oracle; onchain price stale since Jan 15, 2026
+  - id: fireblocks
+    label: Fireblocks MPC Custody
+    category: dependency
+    note: Offchain STRC custody; not onchain-verifiable
+  - id: network-firm
+    label: The Network Firm (Attestation)
+    category: dependency
+    note: Monthly AICPA reserve attestation
+  - id: uniswap-pool
+    label: Uniswap V2 BUCK/USDC
+    address: "0xaab3e2a7908f557c2c28cadf7556353c9a08f82e"
+    category: dependency
+    note: ~$61K USDC depth; deployer-supplied liquidity
+  - id: curve-pool
+    label: Curve StableSwap BUCK/USDC
+    address: "0x42cb0274c6492e3991bde2ce75abf8cdf7f11d66"
+    category: dependency
+    note: ~$47K USDC depth; treasury-supplied liquidity
+
+edges:
+  # === Governance: single EOA owns everything ===
+  - from: admin-eoa
+    to: BUCK
+    kind: controls
+    label: owner (Ownable2Step, no timelock)
+  - from: admin-eoa
+    to: liquidity-window
+    kind: controls
+    label: owner — instant upgradeToAndCall
+  - from: admin-eoa
+    to: liquidity-reserve
+    kind: controls
+    label: DEFAULT_ADMIN
+  - from: admin-eoa
+    to: policy-manager
+    kind: controls
+    label: DEFAULT_ADMIN
+  - from: admin-eoa
+    to: rewards-engine
+    kind: controls
+    label: DEFAULT_ADMIN
+  - from: admin-eoa
+    to: collateral-attestation
+    kind: controls
+    label: DEFAULT_ADMIN
+  - from: admin-eoa
+    to: oracle-adapter
+    kind: controls
+    label: owner (sets internal price)
+  - from: admin-eoa
+    to: access-registry
+    kind: controls
+    label: owner — revoke() can freeze any address
+  - from: attestor-eoa
+    to: collateral-attestation
+    kind: holds-role
+    label: posts STRC valuation
+  - from: treasury-eoa
+    to: curve-pool
+    kind: deploys
+    label: deployed pool
+
+  # === Mint authority: who can mint BUCK ===
+  - from: liquidity-window
+    to: BUCK
+    kind: mints
+    label: MINTER (mint/refund)
+  - from: rewards-engine
+    to: BUCK
+    kind: mints
+    label: yield distribution
+
+  # === Internal flow ===
+  - from: BUCK
+    to: liquidity-window
+    kind: routes-through
+    label: mint / refund (access-gated)
+  - from: liquidity-window
+    to: liquidity-reserve
+    kind: deposits-into
+    label: USDC reserve (~8%)
+  - from: liquidity-window
+    to: policy-manager
+    kind: routes-through
+    label: band state / fees
+  - from: liquidity-window
+    to: access-registry
+    kind: routes-through
+    label: allowlist check
+  - from: liquidity-window
+    to: oracle-adapter
+    kind: routes-through
+    label: STRC price gate
+
+  # === Reserve allocation ===
+  - from: BUCK
+    to: liquidity-reserve
+    kind: allocates-to
+    label: "USDC ~8%"
+  - from: BUCK
+    to: strc-reserve
+    kind: allocates-to
+    label: "STRC ~92%"
+
+  # === Reserve → external dependencies ===
+  - from: strc-reserve
+    to: strc
+    kind: deposits-into
+    label: open-market purchase
+  - from: strc-reserve
+    to: fireblocks
+    kind: routes-through
+    label: MPC custody
+  - from: oracle-adapter
+    to: pyth
+    kind: routes-through
+    label: pull-feed (stale)
+  - from: collateral-attestation
+    to: network-firm
+    kind: routes-through
+    label: monthly attestation
+  - from: BUCK
+    to: uniswap-pool
+    kind: routes-through
+    label: secondary DEX exit
+  - from: BUCK
+    to: curve-pool
+    kind: routes-through
+    label: secondary DEX exit

--- a/reports/graph/fluid.yaml
+++ b/reports/graph/fluid.yaml
@@ -1,0 +1,286 @@
+slug: fluid
+title: Fluid Lending Protocol (fTokens) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: fToken / Vault
+  - id: strategy
+    label: Strategy / Market
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === fToken layer (user-facing) ===
+  - id: fUSDC
+    label: fUSDC (~$193M)
+    address: "0x9Fb7b4477576Fe5B32be4C1843aFB1e55F251B33"
+    category: vault
+    note: ERC-4626 USDC lending vault
+  - id: fUSDT
+    label: fUSDT (~$130M)
+    address: "0x5C20B550819128074FD538Edf79791733ccEdd18"
+    category: vault
+  - id: fWETH
+    label: fWETH (~2,533 WETH)
+    address: "0x90551c1795392094FE6D29B758EcCD233cFAa260"
+    category: vault
+  - id: fwstETH
+    label: fwstETH (~1,768 wstETH)
+    address: "0x2411802D8BEA09be0aF8fD8D08314a63e706b29C"
+    category: vault
+  - id: fGHO
+    label: fGHO (~$12M)
+    address: "0x6A29A46E21C730DcA1d8b23d637c101cec605C5B"
+    category: vault
+  - id: fsUSDS
+    label: fsUSDS
+    address: "0x2BBE31d63E6813E3AC858C04dae43FB2a72B0D11"
+    category: vault
+  - id: fUSDtb
+    label: fUSDtb
+    address: "0x15e8c742614b5D8Db4083A41Df1A14F5D2bFB400"
+    category: vault
+
+  # === Core infra ===
+  - id: liquidity-layer
+    label: Liquidity Layer (Infinite Proxy)
+    address: "0x52Aa899454998Be5b000Ad077a46Bbe360F4e497"
+    category: infra
+    note: Holds ALL deposits across lending / vaults / DEX / stETH
+  - id: liquidity-impl
+    label: Liquidity Layer Impl (Mar 31 2026)
+    address: "0xcc331DaF69752Bece3Dc98DBc63EacD5092266a2"
+    category: infra
+    note: Current dummy impl; module-dispatch lives in module slots
+  - id: lending-factory
+    label: LendingFactory
+    address: "0x54B91A0D94cb471F37f949c60F7Fa7935b551D03"
+    category: infra
+    note: Deploys fToken contracts
+  - id: vault-protocol
+    label: Vault Protocol (Borrowers)
+    category: infra
+    note: Tick-based liquidations; generates fToken yield
+  - id: rebalancer
+    label: Rebalancer (fUSDC/fUSDT)
+    address: "0x724d0c9497Fa89B2C6A4585e08380c91a92ab9b6"
+    category: infra
+    note: Deposits underlying as rewards; cannot withdraw
+
+  # === Governance ===
+  - id: fluid-token
+    label: FLUID Governance Token
+    address: "0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb"
+    category: governance
+    note: 100M max supply; 4M quorum, 1M propose
+  - id: governor-bravo
+    label: GovernorBravo (128 proposals)
+    address: "0x0204Cd037B2ec03605CFdFe482D8e257C765fA1B"
+    category: governance
+    note: 1d delay, 2d voting; 120 executed
+  - id: timelock
+    label: Timelock (1-day delay)
+    address: "0x2386DC45AdDed673317eF068992F19421B481F4c"
+    category: governance
+    note: Admin of all core contracts
+  - id: avocado-guardian
+    label: Avocado Guardian (7-of-14)
+    address: "0x4F6F977aCDD1177DCD81aB83074855EcB9C2D49e"
+    category: governance
+    note: Pause Class-0 only; can cancel timelock txns
+
+  # === Top borrow markets driving fToken yield ===
+  - id: borrow-eth
+    label: ETH/LST Borrow Markets
+    category: strategy
+    note: Top Eth-supply collateral group (~45%)
+  - id: borrow-stable-wrappers
+    label: Yield-Bearing Stable Wrappers
+    category: strategy
+    note: SUSDAI / reUSD / sUSDe — wrap-ratio amplification risk
+  - id: borrow-btc
+    label: BTC Borrow Markets
+    category: strategy
+    note: WBTC / cbBTC (~10% of Eth supply)
+  - id: borrow-stables
+    label: Stablecoin Borrow Markets
+    category: strategy
+    note: USDC / USDT / GHO; high utilization (>85%)
+
+  # === External dependencies ===
+  - id: dep-susdai
+    label: SUSDAI (19.9% top supply)
+    category: dependency
+    note: Sky yield-bearing stable wrapper; #1 supply asset
+  - id: dep-reusd
+    label: reUSD (Re Protocol)
+    address: "0x5086bf358635B81D8C47C66d1C8b9E567Db70c72"
+    category: dependency
+    note: Yield-bearing stable wrapper; structurally similar to wstUSR
+  - id: dep-wsteth
+    label: wstETH (Lido)
+    address: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
+    category: dependency
+    note: 16.8% of all-chain supply
+  - id: dep-weeth
+    label: weETH (ether.fi)
+    category: dependency
+    note: 12.9% of all-chain supply
+  - id: dep-wbtc
+    label: WBTC / cbBTC
+    category: dependency
+  - id: dep-chainlink
+    label: Chainlink Oracles
+    category: dependency
+    note: Primary price feeds for liquidations
+  - id: dep-permit2
+    label: Uniswap Permit2
+    address: "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+    category: dependency
+    note: Deposit signatures
+
+edges:
+  # === Governance ===
+  - from: fluid-token
+    to: governor-bravo
+    kind: controls
+    label: token-holder voting
+  - from: governor-bravo
+    to: timelock
+    kind: proposes-on
+    label: queue / execute
+  - from: avocado-guardian
+    to: timelock
+    kind: cancels-on
+    label: cancel queued txns
+  - from: timelock
+    to: liquidity-layer
+    kind: controls
+    label: EIP-1967 admin (upgrade impl)
+  - from: timelock
+    to: lending-factory
+    kind: controls
+    label: owner
+  - from: avocado-guardian
+    to: liquidity-layer
+    kind: holds-role
+    label: pause Class-0
+
+  # === Proxy / deployment wiring ===
+  - from: liquidity-impl
+    to: liquidity-layer
+    kind: manages
+    label: dummy impl (since Mar 31 2026)
+  - from: lending-factory
+    to: fUSDC
+    kind: deploys
+  - from: lending-factory
+    to: fUSDT
+    kind: deploys
+  - from: lending-factory
+    to: fWETH
+    kind: deploys
+  - from: lending-factory
+    to: fwstETH
+    kind: deploys
+  - from: lending-factory
+    to: fGHO
+    kind: deploys
+  - from: lending-factory
+    to: fsUSDS
+    kind: deploys
+  - from: lending-factory
+    to: fUSDtb
+    kind: deploys
+  - from: rebalancer
+    to: fUSDC
+    kind: manages
+    label: deposits as rewards
+  - from: rebalancer
+    to: fUSDT
+    kind: manages
+    label: deposits as rewards
+
+  # === fToken flow: deposits into shared Liquidity Layer ===
+  - from: fUSDC
+    to: liquidity-layer
+    kind: deposits-into
+    label: "USDC supply"
+  - from: fUSDT
+    to: liquidity-layer
+    kind: deposits-into
+    label: "USDT supply"
+  - from: fWETH
+    to: liquidity-layer
+    kind: deposits-into
+    label: "WETH supply"
+  - from: fwstETH
+    to: liquidity-layer
+    kind: deposits-into
+    label: "wstETH supply"
+  - from: fGHO
+    to: liquidity-layer
+    kind: deposits-into
+    label: "GHO supply"
+  - from: fsUSDS
+    to: liquidity-layer
+    kind: deposits-into
+    label: "sUSDS supply"
+  - from: fUSDtb
+    to: liquidity-layer
+    kind: deposits-into
+    label: "USDtb supply"
+
+  # === Yield: Liquidity Layer lends to Vault Protocol borrow markets ===
+  - from: liquidity-layer
+    to: vault-protocol
+    kind: routes-through
+    label: shared borrow pool
+  - from: vault-protocol
+    to: borrow-eth
+    kind: allocates-to
+    label: "~45% Eth supply"
+  - from: vault-protocol
+    to: borrow-stable-wrappers
+    kind: allocates-to
+    label: "~32% (SUSDAI + reUSD)"
+  - from: vault-protocol
+    to: borrow-btc
+    kind: allocates-to
+    label: "~10% Eth supply"
+  - from: vault-protocol
+    to: borrow-stables
+    kind: allocates-to
+    label: "~17% Eth supply"
+
+  # === Borrow markets → collateral / external dependencies ===
+  - from: borrow-stable-wrappers
+    to: dep-susdai
+    kind: deposits-into
+    label: "19.9% top asset"
+  - from: borrow-stable-wrappers
+    to: dep-reusd
+    kind: deposits-into
+    label: "12.7%"
+  - from: borrow-eth
+    to: dep-wsteth
+    kind: deposits-into
+  - from: borrow-eth
+    to: dep-weeth
+    kind: deposits-into
+  - from: borrow-btc
+    to: dep-wbtc
+    kind: deposits-into
+  - from: vault-protocol
+    to: dep-chainlink
+    kind: routes-through
+    label: liquidation oracle
+  - from: liquidity-layer
+    to: dep-permit2
+    kind: routes-through
+    label: deposit signatures

--- a/reports/graph/fx-fxusd.yaml
+++ b/reports/graph/fx-fxusd.yaml
@@ -1,0 +1,249 @@
+slug: fx-fxusd
+title: f(x) Protocol (fxUSD) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Collateral / Pool
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: fxUSD
+    label: fxUSD (Stablecoin)
+    address: "0x085780639CC2cACd35E474e71f4d000e2405d8f6"
+    category: vault
+    note: TransparentUpgradeableProxy; ~$53.9M supply; 156% CR
+  - id: fxSAVE
+    label: fxSAVE (Auto-Compounding Vault)
+    address: "0x7743e50F534a7f9F1791DdE7dCD89F7783Eefc39"
+    category: vault
+    note: ~$30M; wraps fxSP for stability-pool yield
+  - id: fxSP
+    label: fxSP (Stability Pool)
+    address: "0x65C9A641afCEB9C0E6034e558A319488FA0FA3be"
+    category: vault
+    note: Holds fxUSD + USDC for peg defense
+
+  # === Protocol infra ===
+  - id: pool-manager
+    label: PoolManager (Long, Primary Custody)
+    address: "0x250893CA4Ba5d05626C785e8da758026928FCD24"
+    category: infra
+    note: Custodies ALL V2 collateral (~$84M)
+  - id: short-pool-manager
+    label: ShortPoolManager (sPOSITION)
+    address: "0xaCDc0AB51178d0Ae8F70c1EAd7d3cF5421FDd66D"
+    category: infra
+  - id: peg-keeper
+    label: PegKeeper
+    address: "0x50562fe7e870420F5AAe480B7F94EB4ace2fcd70"
+    category: infra
+    note: Buys fxUSD below peg using USDC
+  - id: configuration
+    label: Configuration
+    address: "0x16b334f2644cc00b85DB1A1efF0C2C395e00C28d"
+    category: infra
+    note: Protocol parameter store
+  - id: gateway-router
+    label: GatewayRouter
+    address: "0xA5e2Ec4682a32605b9098Ddd7204fe84Ab932fE4"
+    category: infra
+    note: User-facing router
+  - id: proxy-admin
+    label: ProxyAdmin
+    address: "0x9b54b7703551d9d0ced177a78367560a8b2edda4"
+    category: infra
+    note: Upgrades all proxies; owned by Timelock since Apr 20 2026
+  - id: reserve-pool
+    label: Reserve Pool
+    address: "0xE93F5DD55eC9bdAbbba5eA88E4b4f3C253ee45Ed"
+    category: infra
+    note: 17.43 wstETH + 0.38 WBTC + 1,229 fxUSD
+
+  # === Governance ===
+  - id: operational-multisig
+    label: Operational Multisig (6-of-9)
+    address: "0x26B2ec4E02ebe2F54583af25b647b1D619e67BbF"
+    category: governance
+    note: PROPOSER + EXECUTOR + CANCELLER on Timelock
+  - id: emergency-multisig
+    label: Emergency Multisig (3-of-4)
+    address: "0x28c921adAC4c1072658eB01a28DA06b5F651eF62"
+    category: governance
+    note: Direct pause on xPOSITION/sPOSITION (no timelock)
+  - id: timelock
+    label: TimelockController (3-day)
+    address: "0x68863fb8855b04509a835082478D6E3D0bE4E61a"
+    category: governance
+    note: Owns ProxyAdmin since Apr 20 2026
+  - id: vefxn
+    label: veFXN (Vote Escrow)
+    address: "0xEC6B8A3F3605B083F7044C0F31f2cac0caf1d469"
+    category: governance
+    note: Snapshot voting power (fxn.eth)
+  - id: fxn-token
+    label: FXN Governance Token
+    address: "0x365AccFCa291e7D3914637ABf1F7635dB165Bb09"
+    category: governance
+
+  # === Strategy / collateral legs ===
+  - id: xsteth-pool
+    label: xstETH Pool (wstETH collateral)
+    address: "0x6ecfa38fee8a5277b91efda204c235814f0122e8"
+    category: strategy
+    note: ~4,452 wstETH (~$12.4M) custody in PoolManager
+  - id: xwbtc-pool
+    label: xWBTC Pool (WBTC collateral)
+    address: "0xab709e26fa6b0a30c119d8c55b887ded24952473"
+    category: strategy
+    note: ~902 WBTC (~$71.8M) custody in PoolManager
+
+  # === External dependencies ===
+  - id: dep-wsteth
+    label: wstETH (Lido)
+    category: dependency
+    note: Primary ETH collateral
+  - id: dep-wbtc
+    label: WBTC
+    category: dependency
+    note: BTC collateral
+  - id: dep-chainlink
+    label: Chainlink (ETH/USD, BTC/USD)
+    category: dependency
+    note: Primary price oracle (critical)
+  - id: dep-curve
+    label: Curve (EMA + USDC/fxUSD)
+    address: "0x5018BE882DccE5E3F2f3B0913AE2096B9b3fB61f"
+    category: dependency
+    note: Peg-monitoring EMA + $7.7M DEX pool
+  - id: dep-aave
+    label: Aave (USDC + wstETH yield)
+    category: dependency
+    note: Stability Pool deploys ≤80% USDC to Aave Core
+  - id: dep-uniswap
+    label: Uniswap V3 (TWAP Oracle)
+    category: dependency
+    note: Validation price source
+
+edges:
+  # === Governance flow ===
+  - from: operational-multisig
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR + CANCELLER
+  - from: timelock
+    to: proxy-admin
+    kind: controls
+    label: owner (3d delay)
+  - from: proxy-admin
+    to: fxUSD
+    kind: manages
+    label: TransparentUpgradeableProxy admin
+  - from: proxy-admin
+    to: pool-manager
+    kind: manages
+  - from: proxy-admin
+    to: fxSAVE
+    kind: manages
+  - from: emergency-multisig
+    to: pool-manager
+    kind: holds-role
+    label: pause (no timelock)
+  - from: emergency-multisig
+    to: short-pool-manager
+    kind: holds-role
+    label: pause (no timelock)
+  - from: fxn-token
+    to: vefxn
+    kind: routes-through
+    label: lock for voting power
+  - from: vefxn
+    to: operational-multisig
+    kind: controls
+    label: Snapshot signaling (fxn.eth)
+
+  # === Internal vault flow ===
+  - from: fxSAVE
+    to: fxSP
+    kind: deposits-into
+    label: auto-compounding wrapper
+  - from: fxSP
+    to: fxUSD
+    kind: deposits-into
+    label: peg-defense reserve
+  - from: fxUSD
+    to: peg-keeper
+    kind: routes-through
+    label: Stability-Pool peg defense
+  - from: fxUSD
+    to: gateway-router
+    kind: routes-through
+    label: user mint/redeem entry
+  - from: gateway-router
+    to: pool-manager
+    kind: routes-through
+    label: V2 position entry
+
+  # === Mint authority on fxUSD ===
+  - from: pool-manager
+    to: fxUSD
+    kind: mints
+    label: V2 collateral-backed mint
+  - from: short-pool-manager
+    to: fxUSD
+    kind: mints
+    label: sPOSITION mint
+
+  # === Configuration / reserve wiring ===
+  - from: configuration
+    to: pool-manager
+    kind: manages
+    label: LTV / fees / oracle params
+  - from: reserve-pool
+    to: pool-manager
+    kind: routes-through
+    label: recapitalization buffer
+
+  # === Collateral allocation ===
+  - from: pool-manager
+    to: xsteth-pool
+    kind: allocates-to
+    label: "wstETH ~$12.4M"
+  - from: pool-manager
+    to: xwbtc-pool
+    kind: allocates-to
+    label: "WBTC ~$71.8M"
+
+  # === Strategy → external dependencies ===
+  - from: xsteth-pool
+    to: dep-wsteth
+    kind: deposits-into
+    label: wstETH collateral
+  - from: xwbtc-pool
+    to: dep-wbtc
+    kind: deposits-into
+    label: WBTC collateral
+  - from: fxSP
+    to: dep-aave
+    kind: deposits-into
+    label: USDC ≤80% to Aave Core
+  - from: pool-manager
+    to: dep-chainlink
+    kind: routes-through
+    label: ETH/USD + BTC/USD
+  - from: pool-manager
+    to: dep-uniswap
+    kind: routes-through
+    label: TWAP validation
+  - from: peg-keeper
+    to: dep-curve
+    kind: routes-through
+    label: EMA price + USDC/fxUSD pool

--- a/reports/graph/kerneldao-hgeth.yaml
+++ b/reports/graph/kerneldao-hgeth.yaml
@@ -1,0 +1,229 @@
+slug: kerneldao-hgeth
+title: KernelDAO Kelp Gain (hgETH) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Strategy
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: hgETH
+    label: hgETH (High Growth Vault)
+    address: "0xc824A08dB624942c5E5F330d56530cD1598859fD"
+    category: vault
+    note: ERC-4626 TransparentUpgradeableProxy → GainLendingPool; paused since 2026-04-18
+  - id: gain-adapter
+    label: GainAdapter (rsETH adapter)
+    address: "0xB185D98056419029daE7120EcBeFa0DbC12c283A"
+    category: vault
+    note: Converts ETH/LST deposits → rsETH before vault entry
+
+  # === Protocol infra ===
+  - id: loans-operator
+    label: Loans Operator
+    address: "0x416e26e331Fc0b77386e9dDB5Ed9AdE73F1241F4"
+    category: infra
+    note: Strategy execution / recalls
+  - id: loans-deployer
+    label: Loans Deployer
+    address: "0x9E053AAA3C435e94C1663a428cdC4ea91F23C556"
+    category: infra
+  - id: scheduled-caller
+    label: Scheduled Caller
+    address: "0x06eada250B02A3614AFce04B8cd7025093312159"
+    category: infra
+  - id: fees-collector
+    label: Fees Collector
+    address: "0x2151A97C7819782fD99efF020CdfE0aE838Ad378"
+    category: infra
+    note: Receives minted hgETH shares (1.5% mgmt fee)
+
+  # === Governance ===
+  - id: vault-multisig
+    label: Vault Multisig (3/5)
+    address: "0x66Bee721697BF17D9Eea28c51C828a43ba597B0b"
+    category: governance
+    note: Gnosis Safe; 4 anonymous + 1 Kelp deployer; no timelock
+  - id: proxyadmin-multisig
+    label: ProxyAdmin Multisig (3/5)
+    address: "0xFD96F6854bc73aeBc6dc6E61A372926186010a91"
+    category: governance
+    note: Same 5 signers as vault multisig
+  - id: hgeth-proxyadmin
+    label: hgETH ProxyAdmin
+    address: "0xd355daae366220a0282cd5d2687fbc395395fc40"
+    category: governance
+    note: No timelock between Safe and ProxyAdmin
+  - id: oracle-proxyadmin-multisig
+    label: Oracle ProxyAdmin Multisig (3/5)
+    address: "0x266f15c63d5D3dE038F2E05D1fA397d92BCB013E"
+    category: governance
+    note: Different 5 signers from vault multisig
+
+  # === Strategy legs (12+ active venues, top categories) ===
+  - id: strat-aave
+    label: Aave Leverage Farming
+    category: strategy
+    note: Leveraged USDe / ETH looper
+  - id: strat-pendle
+    label: Pendle Fixed-Yield
+    category: strategy
+  - id: strat-morpho
+    label: Morpho Lending
+    category: strategy
+  - id: strat-euler
+    label: Euler Lending
+    category: strategy
+  - id: strat-compound
+    label: Compound Lending
+    category: strategy
+  - id: strat-usual
+    label: Usual / Elixir
+    category: strategy
+
+  # === External dependencies ===
+  - id: rsETH
+    label: rsETH (Kelp LRT)
+    address: "0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7"
+    category: dependency
+    note: Liquid restaked ETH; peg stressed post-2026-04-18 bridge exploit
+  - id: eigenlayer
+    label: EigenLayer Restaking
+    category: dependency
+    note: Underlying restaking infra for rsETH
+  - id: upshift
+    label: Upshift Finance Infra
+    category: dependency
+    note: Vault infrastructure (August subaccounts, policy engine)
+  - id: ultrayield
+    label: UltraYield Curator (Edge Capital)
+    category: dependency
+    note: Allocation curator across 12+ venues
+  - id: morpho-hgeth-weth
+    label: Morpho hgETH/WETH (91.5% LLTV)
+    address: "0x56dbc0f2784cd959e57fcc9cd83c3b7a24ee678c"
+    category: dependency
+    note: Yearn use-case market; 99.5% utilized, oracle un-adjusted
+  - id: hgeth-usd-oracle
+    label: hgETH/USD EOMultiFeedAdapter
+    address: "0x70cf192d6b76d57a46aafc9285ced110034eb013"
+    category: dependency
+    note: Upgradeable Morpho oracle feed proxy
+  - id: nexus-mutual
+    label: Nexus Mutual (Embedded Cover)
+    category: dependency
+    note: ~$30M+ cover; excludes liquidation losses + bridge failures
+
+edges:
+  # === Governance ===
+  - from: vault-multisig
+    to: hgETH
+    kind: holds-role
+    label: owner() (pause/unpause)
+  - from: proxyadmin-multisig
+    to: hgeth-proxyadmin
+    kind: controls
+    label: owner (no timelock)
+  - from: hgeth-proxyadmin
+    to: hgETH
+    kind: manages
+    label: upgradeable proxy
+  - from: oracle-proxyadmin-multisig
+    to: hgeth-usd-oracle
+    kind: manages
+    label: oracle upgrade authority
+
+  # === Internal infra wiring ===
+  - from: loans-operator
+    to: hgETH
+    kind: holds-role
+    label: loansOperator
+  - from: loans-deployer
+    to: hgETH
+    kind: holds-role
+    label: loansDeployerAddress
+  - from: scheduled-caller
+    to: hgETH
+    kind: holds-role
+    label: scheduledCaller
+
+  # === Vault → rsETH conversion ===
+  - from: hgETH
+    to: gain-adapter
+    kind: routes-through
+    label: ETH/LST → rsETH
+  - from: gain-adapter
+    to: rsETH
+    kind: deposits-into
+    label: convert to rsETH
+
+  # === Strategy allocation (paused, but structural) ===
+  - from: hgETH
+    to: strat-aave
+    kind: allocates-to
+    label: leveraged USDe/ETH
+  - from: hgETH
+    to: strat-pendle
+    kind: allocates-to
+    label: fixed-yield
+  - from: hgETH
+    to: strat-morpho
+    kind: allocates-to
+    label: lending
+  - from: hgETH
+    to: strat-euler
+    kind: allocates-to
+    label: lending
+  - from: hgETH
+    to: strat-compound
+    kind: allocates-to
+    label: lending
+  - from: hgETH
+    to: strat-usual
+    kind: allocates-to
+    label: stablecoin
+
+  # === Curation / infra dependencies ===
+  - from: ultrayield
+    to: hgETH
+    kind: manages
+    label: curator
+  - from: upshift
+    to: hgETH
+    kind: manages
+    label: vault infra (August subaccounts)
+
+  # === Strategies → external dependencies ===
+  - from: rsETH
+    to: eigenlayer
+    kind: deposits-into
+    label: restaking
+  - from: hgETH
+    to: morpho-hgeth-weth
+    kind: routes-through
+    label: 91.5% LLTV collateral market
+  - from: hgeth-usd-oracle
+    to: morpho-hgeth-weth
+    kind: manages
+    label: BASE_FEED_1
+
+  # === Fees ===
+  - from: hgETH
+    to: fees-collector
+    kind: routes-fees-to
+    label: 1.5% mgmt + 20% perf
+
+  # === Insurance ===
+  - from: nexus-mutual
+    to: hgETH
+    kind: manages
+    label: embedded cover (~$30M)

--- a/reports/graph/kinetiq-khype.yaml
+++ b/reports/graph/kinetiq-khype.yaml
@@ -1,0 +1,186 @@
+slug: kinetiq-khype
+title: Kinetiq (kHYPE) — Contract Dependency Graph
+chain: hyperevm
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Validator Delegation
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: kHYPE
+    label: kHYPE (LST)
+    address: "0xfd739d4e423301ce9385c1fb8850539d657c296d"
+    category: vault
+    note: ERC-20 upgradeable proxy; exchange-rate model
+  - id: staking-pool
+    label: StakingPool (Diamond/Router)
+    address: "0x393D0B87Ed38fc779FD9611144aE649BA6082109"
+    category: vault
+    note: Minter/Burner of kHYPE; StakingManagerRouter (7 facets)
+  - id: instant-unstake-pool
+    label: InstantUnstakePool
+    address: "0x665b67793594fc5C251a3C95cbEb4B6245Cd2123"
+    category: vault
+    note: Instant-unstake liquidity pool (~42K HYPE)
+
+  # === Protocol infra ===
+  - id: staking-accountant
+    label: StakingAccountant
+    address: "0x9209648Ec9D448EF57116B73A2f081835643dc7A"
+    category: infra
+    note: kHYPE↔HYPE exchange-rate aggregator
+  - id: validator-manager
+    label: ValidatorManager
+    address: "0x4b797A93DfC3D18Cf98B7322a2b142FA8007508f"
+    category: infra
+    note: Delegation engine
+  - id: oracle-manager
+    label: OracleManager
+    address: "0x192826e470bd65FDC2CB472eDd834D096233049b"
+    category: infra
+    note: Validator performance oracle
+  - id: reward-tracker
+    label: RewardShareTracker
+    address: "0xE5FbA07C7b3CfbC29633f3D3Ab38b36007F35983"
+    category: infra
+  - id: pauser-registry
+    label: PauserRegistry
+    address: "0x752E76ea71960Da08644614E626c9F9Ff5a50547"
+    category: infra
+  - id: facet-registry
+    label: FacetRegistry (7 facets)
+    address: "0x4841eCC9Ffb18aEA197E4d1dd1633cEA5e834225"
+    category: infra
+    note: Diamond facet registry
+  - id: operator-eoa
+    label: Operator EOA (Bot)
+    address: "0x23A4604cDFe8e9e2e9Cf7C10D7492B0F3f4B4038"
+    category: infra
+    note: Kinetiq automated keeper; holds OPERATOR
+
+  # === Governance ===
+  - id: multisig
+    label: Governance Multisig (4/8)
+    address: "0x18A82c968b992D28D4D812920eB7b4305306f8F1"
+    category: governance
+    note: Gnosis Safe v1.3.0; pseudonymous signers; no timelock
+  - id: treasury-multisig
+    label: Treasury Multisig (4/7)
+    address: "0x64bD77698Ab7C3Fd0a1F54497b228ED7a02098E3"
+    category: governance
+  - id: khype-proxyadmin
+    label: kHYPE ProxyAdmin
+    address: "0x9c1e8db004d8158a52e83ffdc63e37eabea8304c"
+    category: governance
+  - id: staking-pool-proxyadmin
+    label: StakingPool ProxyAdmin
+    address: "0x8194aa9eca9225f96a690072b22a9ad0dd064f64"
+    category: governance
+  - id: pauser-proxyadmin
+    label: PauserRegistry ProxyAdmin
+    address: "0xd26c2c4a8bd4f78c64212318424ed794be120ea6"
+    category: governance
+
+  # === External dependencies (validators / Hyperliquid L1) ===
+  - id: hyperliquid-l1
+    label: Hyperliquid L1 Validators (15)
+    category: dependency
+    note: Delegations spread across 15 validators; 0% to Hyper Foundation
+
+edges:
+  # === Governance ===
+  - from: multisig
+    to: khype-proxyadmin
+    kind: controls
+    label: owner (no timelock)
+  - from: multisig
+    to: staking-pool-proxyadmin
+    kind: controls
+    label: owner (no timelock)
+  - from: multisig
+    to: pauser-proxyadmin
+    kind: controls
+    label: owner (no timelock)
+  - from: khype-proxyadmin
+    to: kHYPE
+    kind: manages
+    label: upgradeable proxy
+  - from: staking-pool-proxyadmin
+    to: staking-pool
+    kind: manages
+    label: upgradeable proxy
+  - from: pauser-proxyadmin
+    to: pauser-registry
+    kind: manages
+    label: upgradeable proxy
+  - from: multisig
+    to: kHYPE
+    kind: holds-role
+    label: DEFAULT_ADMIN
+  - from: multisig
+    to: staking-pool
+    kind: holds-role
+    label: DEFAULT_ADMIN + MANAGER
+  - from: multisig
+    to: pauser-registry
+    kind: holds-role
+    label: DEFAULT_ADMIN + PAUSER
+  - from: multisig
+    to: staking-accountant
+    kind: holds-role
+    label: MANAGER
+  - from: operator-eoa
+    to: staking-pool
+    kind: holds-role
+    label: OPERATOR (EOA)
+
+  # === Mint authority on kHYPE ===
+  - from: staking-pool
+    to: kHYPE
+    kind: mints
+    label: MINTER + BURNER
+
+  # === Internal vault / infra wiring ===
+  - from: facet-registry
+    to: staking-pool
+    kind: manages
+    label: 7 facets
+  - from: staking-accountant
+    to: kHYPE
+    kind: manages
+    label: exchange-rate aggregator
+  - from: validator-manager
+    to: staking-pool
+    kind: manages
+    label: delegation engine
+  - from: oracle-manager
+    to: validator-manager
+    kind: manages
+    label: validator performance
+  - from: reward-tracker
+    to: staking-pool
+    kind: manages
+    label: reward distribution
+
+  # === Flow: user HYPE → StakingPool → validators ===
+  - from: kHYPE
+    to: staking-pool
+    kind: allocates-to
+    label: "100%"
+  - from: staking-pool
+    to: instant-unstake-pool
+    kind: routes-through
+    label: instant-unstake leg
+  - from: staking-pool
+    to: hyperliquid-l1
+    kind: deposits-into
+    label: "HYPE → validators (15)"

--- a/reports/graph/maple-syrupusdc.yaml
+++ b/reports/graph/maple-syrupusdc.yaml
@@ -1,0 +1,215 @@
+slug: maple-syrupusdc
+title: Maple (syrupUSDC) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Strategy / Loan Manager
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: syrupUSDC
+    label: syrupUSDC Pool (ERC-4626)
+    address: "0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b"
+    category: vault
+
+  # === Protocol infra ===
+  - id: pool-manager
+    label: PoolManager
+    address: "0x7aD5fFa5fdF509E30186F4609c2f6269f4B6158F"
+    category: infra
+  - id: syrup-router
+    label: SyrupRouter (Deposit Gateway)
+    address: "0x134cCaaA4F1e4552eC8aEcb9E4A2360dDcF8df76"
+    category: infra
+  - id: withdrawal-queue
+    label: WithdrawalManagerQueue (FIFO)
+    address: "0x1bc47a0Dd0FdaB96E9eF982fdf1F34DC6207cfE3"
+    category: infra
+  - id: permission-manager
+    label: PoolPermissionManager
+    address: "0xBe10aDcE8B6E3E02Db384E7FaDA5395DD113D8b3"
+    category: infra
+    note: Deposit allowlist
+  - id: pool-delegate-cover
+    label: PoolDelegateCover (First-loss)
+    address: "0x9e62FE15d0E99cE2b30CE0D256e9Ab7b6893AfF5"
+    category: infra
+  - id: maple-globals
+    label: MapleGlobals (v301)
+    address: "0x804a6F5F667170F545Bf14e5DDB48C70B788390C"
+    category: infra
+    note: 7d default timelock + 2d window
+
+  # === Strategy / loan-manager legs ===
+  - id: open-term-lm
+    label: OpenTermLoanManager (~$1.34B AUM)
+    address: "0x6ACEb4cAbA81Fa6a8065059f3A944fb066A10fAc"
+    category: strategy
+  - id: fixed-term-lm
+    label: FixedTermLoanManager ($0 AUM)
+    address: "0x4A1c3F0D9aD0b3f9dA085bEBfc22dEA54263371b"
+    category: strategy
+    note: Migrated to open-term
+  - id: aave-strategy
+    label: AaveStrategy (dormant)
+    address: "0x560B3A85Af1cEF113BB60105d0Cf21e1d05F91d4"
+    category: strategy
+    note: 10 wei AUM as of May 2026
+  - id: sky-strategy
+    label: SkyStrategy (dormant)
+    address: "0x859C9980931fa0A63765fD8EF2e29918Af5b038C"
+    category: strategy
+    note: 10 wei AUM as of May 2026
+  - id: pool-delegate
+    label: Pool Delegate (Maple Direct EOA)
+    address: "0xC1e18FFD8825FfB286D177DDEbeba345EC70B49f"
+    category: strategy
+    note: Loan origination, impairments
+
+  # === Governance ===
+  - id: governor-timelock
+    label: Governor Timelock (24h)
+    address: "0x2eFFf88747EB5a3FF00d4d8d0f0800E306C0426b"
+    category: governance
+  - id: dao-multisig
+    label: DAO Multisig (4-of-7)
+    address: "0xd6d4Bcde6c816F17889f1Dd3000aF0261B03a196"
+    category: governance
+    note: PROPOSER + ROLE_ADMIN
+  - id: security-admin
+    label: Security Admin (3-of-6)
+    address: "0x6b1A78C1943b03086F7Ee53360f9b0672bD60818"
+    category: governance
+    note: CANCELLER + emergency pause
+  - id: ops-admin
+    label: Operational Admin (3-of-5)
+    address: "0xCe1cE7c7F436DCc4E28Bc8bf86115514d3DC34E8"
+    category: governance
+    note: EXECUTOR on Timelock
+
+  # === External dependencies ===
+  - id: dep-borrowers
+    label: Institutional Borrowers
+    category: dependency
+    note: Overcollateralized loans (BTC/ETH/USTB/etc.)
+  - id: dep-chainlink
+    label: Chainlink Oracles
+    category: dependency
+    note: Collateral pricing for liquidations
+  - id: dep-aave-v3
+    label: Aave V3 (idle deployment)
+    category: dependency
+    note: AaveStrategy target (currently dormant)
+  - id: dep-sky
+    label: Sky / MakerDAO (idle deployment)
+    category: dependency
+    note: SkyStrategy target (currently dormant)
+  - id: dep-ccip
+    label: Chainlink CCIP
+    category: dependency
+    note: Cross-chain syrupUSDC (Base/Arbitrum/Solana)
+
+edges:
+  # === Governance flow ===
+  - from: dao-multisig
+    to: governor-timelock
+    kind: proposes-on
+    label: PROPOSER + ROLE_ADMIN
+  - from: ops-admin
+    to: governor-timelock
+    kind: holds-role
+    label: EXECUTOR
+  - from: security-admin
+    to: governor-timelock
+    kind: cancels-on
+    label: CANCELLER
+  - from: governor-timelock
+    to: maple-globals
+    kind: controls
+    label: governor() (24h + 7d global)
+  - from: maple-globals
+    to: pool-manager
+    kind: manages
+    label: protocol params
+  - from: security-admin
+    to: syrupUSDC
+    kind: holds-role
+    label: emergency pause
+
+  # === Internal pool flow ===
+  - from: syrup-router
+    to: syrupUSDC
+    kind: routes-through
+    label: USDC deposit
+  - from: pool-manager
+    to: syrupUSDC
+    kind: manages
+    label: pool admin
+  - from: syrupUSDC
+    to: withdrawal-queue
+    kind: routes-through
+    label: FIFO redemption
+  - from: permission-manager
+    to: syrupUSDC
+    kind: manages
+    label: deposit allowlist
+  - from: pool-delegate-cover
+    to: syrupUSDC
+    kind: routes-fees-to
+    label: first-loss cover
+
+  # === Allocation: syrupUSDC → loan managers / strategies ===
+  - from: syrupUSDC
+    to: open-term-lm
+    kind: allocates-to
+    label: "~97% (OTLM)"
+  - from: syrupUSDC
+    to: fixed-term-lm
+    kind: allocates-to
+    label: "0% (migrated)"
+  - from: syrupUSDC
+    to: aave-strategy
+    kind: allocates-to
+    label: "dormant"
+  - from: syrupUSDC
+    to: sky-strategy
+    kind: allocates-to
+    label: "dormant"
+
+  # === Loan origination ===
+  - from: pool-delegate
+    to: open-term-lm
+    kind: manages
+    label: loan origination + impairments
+  - from: pool-delegate
+    to: fixed-term-lm
+    kind: manages
+
+  # === Strategy / loan-manager → external ===
+  - from: open-term-lm
+    to: dep-borrowers
+    kind: deposits-into
+    label: overcollateralized loans
+  - from: open-term-lm
+    to: dep-chainlink
+    kind: routes-through
+    label: collateral pricing
+  - from: aave-strategy
+    to: dep-aave-v3
+    kind: deposits-into
+  - from: sky-strategy
+    to: dep-sky
+    kind: deposits-into
+  - from: syrupUSDC
+    to: dep-ccip
+    kind: routes-through
+    label: cross-chain wrapper

--- a/reports/graph/mezo-musd.yaml
+++ b/reports/graph/mezo-musd.yaml
@@ -1,0 +1,226 @@
+slug: mezo-musd
+title: Mezo (MUSD) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: CDP / Pool
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: MUSD
+    label: MUSD (Ethereum)
+    address: "0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186"
+    category: vault
+    note: Bridged from Mezo via Wormhole NTT; ~1.72M on Ethereum
+  - id: musd-mezo
+    label: MUSD (Native — Mezo Chain)
+    category: vault
+    note: Mezo L1 (chain id 31612); ~$19.85M TVL
+
+  # === Protocol infra ===
+  - id: ntt-manager
+    label: NTT Manager (Wormhole Bridge)
+    address: "0x5293158bf7a81ED05418DA497a80F7e6Dbf4477E"
+    category: infra
+    note: Burn/mint mode; only active minter on Ethereum
+  - id: wormhole-transceiver
+    label: Wormhole Transceiver
+    address: "0x76ddB3f1dDe02391Ef0A28664499B74C29d18d3E"
+    category: infra
+    note: ERC1967Proxy
+  - id: active-pool
+    label: ActivePool (Mezo)
+    category: infra
+    note: Holds active trove BTC collateral
+  - id: default-pool
+    label: DefaultPool (Mezo)
+    category: infra
+    note: Holds redistributed collateral
+  - id: trove-manager
+    label: TroveManager (Mezo)
+    category: infra
+    note: CDP accounting (Liquity V1 fork)
+  - id: borrower-ops
+    label: BorrowerOperations (Mezo)
+    category: infra
+    note: Open / adjust / close troves
+  - id: stability-pool
+    label: StabilityPool (Mezo)
+    category: infra
+    note: First-loss buffer; 100M PCV bootstrap loan
+  - id: interest-rate-manager
+    label: InterestRateManager (Mezo)
+    category: infra
+    note: Governance-set fixed rates (1-5% APR)
+  - id: price-feed
+    label: PriceFeed (Mezo)
+    category: infra
+    note: Consumes Skip Connect precompile (60s staleness)
+
+  # === Governance ===
+  - id: mezo-multisig
+    label: Mezo Multisig (5-of-9 Safe)
+    address: "0x98D8899c3030741925BE630C710A98B57F397C7a"
+    category: governance
+    note: Owner of MUSD token + bridge; NO timelock; anon signers
+  - id: ntt-pauser
+    label: NTT Pauser Multisig (2-of-4)
+    address: "0x40C7b9612B394212394EA860cACd0e176CA4Ae5B"
+    category: governance
+    note: Low-threshold emergency bridge pause
+  - id: mezo-validators
+    label: Mezo Validator Set
+    category: governance
+    note: veBTC/veMEZO governance on Mezo L1
+
+  # === CDP / Strategy ===
+  - id: trove-cdps
+    label: BTC-Collateralized Troves
+    category: strategy
+    note: Liquity-style CDPs; MCR 110% / CCR 150%
+
+  # === External dependencies ===
+  - id: dep-tbtc
+    label: tBTC (Threshold Network)
+    category: dependency
+    note: Sole collateral asset; decentralized BTC bridge
+  - id: dep-wormhole
+    label: Wormhole Guardian Network
+    category: dependency
+    note: 19 guardians, 13/19 threshold
+  - id: dep-skip-connect
+    label: Skip Connect (BTC/USD Oracle)
+    category: dependency
+    note: Cosmos vote-extension oracle; 9 CEX feeds
+  - id: dep-mezo-chain
+    label: Mezo L1 (Cosmos SDK)
+    category: dependency
+    note: New EVM L1; chain id 31612
+  - id: dep-curve-pool
+    label: Curve MUSD/crv2pool
+    address: "0xB5571E76693ba60110B5811DD650FFefce1C955f"
+    category: dependency
+    note: ~$1.14M; 74% MUSD imbalance
+  - id: dep-uni-pool
+    label: Uniswap V3 MUSD/USDC
+    address: "0x748C05B80d07de9692d976bd3173F301356aB945"
+    category: dependency
+    note: ~$645K; 61% MUSD imbalance
+
+edges:
+  # === Governance: Ethereum side ===
+  - from: mezo-multisig
+    to: MUSD
+    kind: controls
+    label: owner — set mintList / burnList
+  - from: mezo-multisig
+    to: ntt-manager
+    kind: controls
+    label: owner — proxy upgrade
+  - from: mezo-multisig
+    to: wormhole-transceiver
+    kind: controls
+    label: owner
+  - from: ntt-pauser
+    to: ntt-manager
+    kind: holds-role
+    label: pause bridge (2/4)
+
+  # === Governance: Mezo side ===
+  - from: mezo-validators
+    to: interest-rate-manager
+    kind: controls
+    label: veBTC/veMEZO rate-setting
+  - from: mezo-validators
+    to: dep-mezo-chain
+    kind: controls
+    label: consensus / validator set
+
+  # === Mint authority on Ethereum MUSD ===
+  - from: ntt-manager
+    to: MUSD
+    kind: mints
+    label: bridge mint/burn (only active minter)
+
+  # === Bridge flow: Mezo native ↔ Ethereum ===
+  - from: musd-mezo
+    to: ntt-manager
+    kind: routes-through
+    label: Wormhole NTT (burn on Mezo)
+  - from: ntt-manager
+    to: MUSD
+    kind: routes-through
+    label: mint on Ethereum
+  - from: ntt-manager
+    to: wormhole-transceiver
+    kind: routes-through
+    label: cross-chain message
+
+  # === Mezo-side CDP flow ===
+  - from: musd-mezo
+    to: trove-cdps
+    kind: allocates-to
+    label: "100% BTC-backed CDPs"
+  - from: trove-cdps
+    to: active-pool
+    kind: deposits-into
+    label: collateral custody
+  - from: trove-cdps
+    to: default-pool
+    kind: deposits-into
+    label: redistributed debt
+  - from: borrower-ops
+    to: trove-manager
+    kind: manages
+    label: open / adjust / close
+  - from: trove-manager
+    to: active-pool
+    kind: manages
+    label: CDP accounting
+  - from: stability-pool
+    to: musd-mezo
+    kind: routes-through
+    label: liquidation absorption + 100M PCV
+  - from: interest-rate-manager
+    to: trove-manager
+    kind: manages
+    label: fixed rate per loan
+  - from: price-feed
+    to: trove-manager
+    kind: routes-through
+    label: BTC/USD for liquidation
+
+  # === External dependencies ===
+  - from: active-pool
+    to: dep-tbtc
+    kind: deposits-into
+    label: BTC via tBTC bridge
+  - from: wormhole-transceiver
+    to: dep-wormhole
+    kind: routes-through
+    label: guardian signatures
+  - from: price-feed
+    to: dep-skip-connect
+    kind: routes-through
+    label: precompile (Chainlink-compatible)
+  - from: musd-mezo
+    to: dep-mezo-chain
+    kind: routes-through
+    label: hosted on Mezo L1
+  - from: MUSD
+    to: dep-curve-pool
+    kind: routes-through
+    label: secondary DEX exit
+  - from: MUSD
+    to: dep-uni-pool
+    kind: routes-through
+    label: secondary DEX exit

--- a/reports/graph/midas-mhyper.yaml
+++ b/reports/graph/midas-mhyper.yaml
@@ -1,0 +1,290 @@
+slug: midas-mhyper
+title: Midas (mHYPER) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Strategy Venue
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: mHYPER
+    label: mHYPER (LYT)
+    address: "0x9b5528528656DBC094765E2abB79F293c21191B9"
+    category: vault
+    note: Subordinated debt instrument; TransparentUpgradeableProxy
+  - id: deposit-vault
+    label: DepositVault
+    address: "0x6Be2f55816efd0d91f52720f096006d63c366e98"
+    category: vault
+    note: User-facing mint entry (USDC → mHYPER)
+  - id: redemption-vault
+    label: RedemptionVaultWithSwapper
+    address: "0xbA9FD2850965053Ffab368Df8AA7eD2486f11024"
+    category: vault
+    note: Instant + standard redemption
+
+  # === Protocol infra ===
+  - id: access-control
+    label: MidasAccessControl
+    address: "0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B"
+    category: infra
+    note: Role-based permission system
+  - id: oracle
+    label: CustomAggregatorFeed (NAV)
+    address: "0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68"
+    category: infra
+    note: Admin-set NAV oracle (2x/week)
+  - id: data-feed
+    label: mHYPER DataFeed
+    address: "0x92004DCC5359eD67f287F32d12715A37916deCdE"
+    category: infra
+    note: Feeds price data to vaults
+  - id: oft-adapter
+    label: LayerZero OFT Adapter
+    address: "0x148c86390a4ae6f7a02df5903bc0a89e8b4581a0"
+    category: infra
+    note: Cross-chain bridge; holds MINT + BURN
+  - id: mint-burn-eoa
+    label: Mint/Burn Operator EOA
+    address: "0x5683de280d0c3967fba2f04d707fa1ef5a044e25"
+    category: infra
+    note: Fordefi MPC; holds MINT/BURN/PAUSE/BLACKLIST/GREENLIST
+  - id: oracle-updater-eoa
+    label: Oracle Updater EOA
+    address: "0xd1e01471f3e1002d4eec1b39b7dbd7aff952a99f"
+    category: infra
+    note: Single EOA, no timelock on price updates
+  - id: tokens-receiver
+    label: Tokens Receiver
+    address: "0xF356c5e9F69DaDB332Bb098C7Ed960Db1d3376DD"
+    category: infra
+
+  # === Governance ===
+  - id: admin-safe
+    label: Admin Safe (1/3)
+    address: "0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89"
+    category: governance
+    note: Gnosis Safe; DEFAULT_ADMIN + Timelock proposer/executor
+  - id: admin-eoa-fordefi
+    label: DEFAULT_ADMIN EOA (Fordefi MPC)
+    address: "0xd4195cf4df289a4748c1a7b6ddbe770e27ba1227"
+    category: governance
+    note: Bypasses timelock for role grants
+  - id: admin-eoa-fireblocks
+    label: DEFAULT_ADMIN EOA (Fireblocks MPC)
+    address: "0x875c06a295c41c27840b9c9dfda7f3d819d8bc6a"
+    category: governance
+    note: Bypasses timelock for role grants
+  - id: timelock
+    label: MidasTimelockController (48h)
+    address: "0xE3EEe3e0D2398799C884a47FC40C029C8e241852"
+    category: governance
+    note: OZ TimelockController; gates proxy upgrades only
+  - id: proxy-admin
+    label: ProxyAdmin (shared)
+    address: "0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC"
+    category: governance
+
+  # === Strategy venues ===
+  - id: strat-fluid
+    label: Fluid (28.7%)
+    category: strategy
+  - id: strat-aave
+    label: Aave Leveraged USDe (21.6%)
+    category: strategy
+  - id: strat-kamino
+    label: Kamino (Solana) (19.3%)
+    category: strategy
+  - id: strat-morpho
+    label: Morpho Vaults (15.0%)
+    category: strategy
+  - id: strat-pendle
+    label: Pendle (14.7%)
+    category: strategy
+  - id: strat-hyperliquid
+    label: Hyperliquid Basis (<0.1%)
+    category: strategy
+
+  # === Attestation Engine (March 2026) ===
+  - id: keystone-forwarder
+    label: KeystoneForwarder (Chainlink DON)
+    address: "0x0b93082D9b3C7C97fAcd250082899BAcf3af3885"
+    category: infra
+  - id: save-cre-receiver
+    label: SaveCreReceiverProxy
+    address: "0xC50102b6598924Aa8deB201c757bFb9a3dBdB9b6"
+    category: infra
+  - id: save-registry
+    label: MidasSaveRegistryWithClaim
+    address: "0x2D6e9F608807436DE5D9603B00Abe3FEd1Bc809d"
+    category: infra
+    note: Onchain proof / attestation registry
+
+  # === External dependencies ===
+  - id: hyperithm
+    label: Hyperithm (Strategy Manager)
+    category: dependency
+    note: Offchain fund manager; AUM $300M+
+  - id: fordefi
+    label: Fordefi MPC Custody
+    category: dependency
+    note: Tri-party MPC custody (Midas + Hyperithm + Independent)
+  - id: llamarisk-canary
+    label: LlamaRisk + Canary (Verifiers)
+    category: dependency
+    note: Attestation Engine third-party verifiers
+  - id: vlayer
+    label: vlayer (Notarization)
+    category: dependency
+
+edges:
+  # === Governance ===
+  - from: admin-safe
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR (1/3)
+  - from: timelock
+    to: proxy-admin
+    kind: controls
+    label: owner (48h delay)
+  - from: proxy-admin
+    to: mHYPER
+    kind: manages
+    label: upgradeable proxy
+  - from: proxy-admin
+    to: deposit-vault
+    kind: manages
+  - from: proxy-admin
+    to: redemption-vault
+    kind: manages
+  - from: proxy-admin
+    to: oracle
+    kind: manages
+  - from: proxy-admin
+    to: access-control
+    kind: manages
+  - from: admin-safe
+    to: access-control
+    kind: holds-role
+    label: DEFAULT_ADMIN (no timelock)
+  - from: admin-eoa-fordefi
+    to: access-control
+    kind: holds-role
+    label: DEFAULT_ADMIN (no timelock)
+  - from: admin-eoa-fireblocks
+    to: access-control
+    kind: holds-role
+    label: DEFAULT_ADMIN (no timelock)
+  - from: access-control
+    to: mHYPER
+    kind: manages
+    label: gates mint/burn/pause/blacklist
+  - from: oracle-updater-eoa
+    to: oracle
+    kind: holds-role
+    label: NAV updater (no timelock)
+
+  # === Mint authority on mHYPER ===
+  - from: deposit-vault
+    to: mHYPER
+    kind: mints
+    label: M_HYPER_MINT_OPERATOR_ROLE
+  - from: mint-burn-eoa
+    to: mHYPER
+    kind: mints
+    label: MINT + BURN (no collateral check)
+  - from: oft-adapter
+    to: mHYPER
+    kind: mints
+    label: cross-chain MINT + BURN
+
+  # === Internal flow ===
+  - from: deposit-vault
+    to: mHYPER
+    kind: routes-through
+    label: USDC → mHYPER
+  - from: redemption-vault
+    to: mHYPER
+    kind: routes-through
+    label: mHYPER → USDC
+  - from: oracle
+    to: data-feed
+    kind: manages
+    label: NAV price feed
+  - from: data-feed
+    to: deposit-vault
+    kind: manages
+    label: price at deposit
+  - from: data-feed
+    to: redemption-vault
+    kind: manages
+    label: price at redeem
+
+  # === Capital flow: vault → custody → strategies ===
+  - from: mHYPER
+    to: fordefi
+    kind: routes-through
+    label: tri-party MPC custody
+  - from: fordefi
+    to: hyperithm
+    kind: routes-through
+    label: offchain strategy execution
+  - from: hyperithm
+    to: strat-fluid
+    kind: allocates-to
+    label: "28.7%"
+  - from: hyperithm
+    to: strat-aave
+    kind: allocates-to
+    label: "21.6%"
+  - from: hyperithm
+    to: strat-kamino
+    kind: allocates-to
+    label: "19.3%"
+  - from: hyperithm
+    to: strat-morpho
+    kind: allocates-to
+    label: "15.0%"
+  - from: hyperithm
+    to: strat-pendle
+    kind: allocates-to
+    label: "14.7%"
+  - from: hyperithm
+    to: strat-hyperliquid
+    kind: allocates-to
+    label: "<0.1%"
+
+  # === Attestation Engine (NAV verification pipeline) ===
+  - from: keystone-forwarder
+    to: save-cre-receiver
+    kind: routes-through
+    label: onReport()
+  - from: save-cre-receiver
+    to: save-registry
+    kind: routes-through
+    label: setAttestation()
+  - from: save-registry
+    to: oracle
+    kind: manages
+    label: NAV hash anchor
+  - from: llamarisk-canary
+    to: keystone-forwarder
+    kind: routes-through
+    label: verifier signatures
+  - from: vlayer
+    to: keystone-forwarder
+    kind: routes-through
+    label: cryptographic notarization
+  - from: tokens-receiver
+    to: deposit-vault
+    kind: routes-through
+    label: USDC receiver

--- a/reports/graph/origin-arm.yaml
+++ b/reports/graph/origin-arm.yaml
@@ -1,0 +1,150 @@
+slug: origin-arm
+title: Origin ARM (ARM-WETH-stETH) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Strategy / Market
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: arm
+    label: ARM-WETH-stETH (LidoARM Proxy)
+    address: "0x85B78AcA6Deae198fBF201c82DAF6Ca21942acc6"
+    category: vault
+    note: EIP-1967 proxy; ERC-4626 LP token
+  - id: arm-impl
+    label: ARM Implementation (LidoARM)
+    address: "0xC0297a0E39031F09406F0987C9D9D41c5dfbc3df"
+    category: vault
+  - id: fee-collector
+    label: Fee Collector (Safe 1/3)
+    address: "0xBB077E716A5f1F1B63ed5244eBFf5214E50fec8c"
+    category: vault
+
+  # === Governance ===
+  - id: xogn
+    label: xOGN Governance Token
+    address: "0x63898b3b6Ef3d39332082178656E9862bee45C57"
+    category: governance
+    note: Staked OGN — proposes via Origin DeFi Governance
+  - id: origin-gov
+    label: Origin DeFi Governance
+    address: "0x1D3fBD4d129Ddd2372EA85c5Fa00b2682081c9EC"
+    category: governance
+    note: PROPOSER + EXECUTOR + CANCELLER on Timelock
+  - id: timelock
+    label: Timelock Controller (48h)
+    address: "0x35918cDE7233F2dD33fA41ae3Cb6aE0e42E0e69F"
+    category: governance
+    note: Self-administered TIMELOCK_ADMIN_ROLE
+  - id: gov-multisig
+    label: GOV Multisig (5/8, cancel-only)
+    address: "0xbe2AB3d3d8F6a32b96414ebbd865dBD276d3d899"
+    category: governance
+
+  # === Protocol infra ===
+  - id: operator
+    label: Operator EOA (price setter)
+    address: "0x39878253374355DBcc15C86458F084fb6f2d6DE7"
+    category: infra
+    note: No timelock; sets traderate0/1, bounded by crossPrice
+  - id: morpho-wrapper
+    label: MorphoMarket Wrapper
+    address: "0xB7CeFE4CB483Be80C2963D3D9Edb991e69ff39cf"
+    category: infra
+    note: Abstract4626MarketWrapper; owner = Timelock
+  - id: harvester
+    label: Harvester Safe (MORPHO rewards)
+    address: "0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971"
+    category: infra
+
+  # === Strategy / external markets ===
+  - id: lido-wq
+    label: Lido Withdrawal Queue
+    address: "0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1"
+    category: dependency
+    note: Core yield mechanism — stETH 1:1 redemption
+  - id: morpho-vault
+    label: WETH ARM Morpho Vault (Yearn-curated)
+    address: "0x3Dfe70B05657949A5dB340754aD664810ac63b21"
+    category: dependency
+    note: MetaMorpho v1.1; idle WETH lending
+
+  # === Secondary liquidity ===
+  - id: curve-pool
+    label: Curve OETH / ARM-WETH-stETH
+    address: "0x95753095f15870acc0cb0ed224478ea61aeb0b8e"
+    category: dependency
+    note: ~$222K TVL secondary exit venue
+
+edges:
+  # === Governance flow: xOGN → Origin Gov → Timelock → ARM ===
+  - from: xogn
+    to: origin-gov
+    kind: controls
+    label: voting token
+  - from: origin-gov
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR + CANCELLER
+  - from: gov-multisig
+    to: timelock
+    kind: cancels-on
+    label: CANCELLER only
+  - from: timelock
+    to: arm
+    kind: controls
+    label: owner (upgrade, setCrossPrice, setFee, setOperator)
+  - from: timelock
+    to: morpho-wrapper
+    kind: controls
+    label: owner
+
+  # === Operator role on vault (no timelock) ===
+  - from: operator
+    to: arm
+    kind: holds-role
+    label: operator (setPrices, requestLidoWithdrawals, setActiveMarket)
+
+  # === Vault internal wiring ===
+  - from: arm-impl
+    to: arm
+    kind: manages
+    label: EIP-1967 implementation
+  - from: arm
+    to: fee-collector
+    kind: routes-fees-to
+    label: 20% performance fee
+
+  # === Capital flow: ARM → strategies → external dependencies ===
+  - from: arm
+    to: lido-wq
+    kind: deposits-into
+    label: ~99% (request → claim 1-3d)
+  - from: arm
+    to: morpho-wrapper
+    kind: allocates-to
+    label: idle WETH buffer
+  - from: morpho-wrapper
+    to: morpho-vault
+    kind: deposits-into
+    label: WETH supply
+  - from: morpho-vault
+    to: harvester
+    kind: routes-fees-to
+    label: MORPHO rewards
+
+  # === Secondary liquidity ===
+  - from: arm
+    to: curve-pool
+    kind: routes-through
+    label: secondary DEX exit

--- a/reports/graph/paxos-usdg.yaml
+++ b/reports/graph/paxos-usdg.yaml
@@ -1,0 +1,132 @@
+slug: paxos-usdg
+title: Paxos (USDG) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Token
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Token layer ===
+  - id: usdg
+    label: USDG (Global Dollar)
+    address: "0xe343167631d89B6Ffc58B88d6b7fB0228795491D"
+    category: vault
+    note: ERC1967 / UUPS Proxy
+
+  # === Internal infra ===
+  - id: supply-control
+    label: SupplyControl
+    address: "0x9a7164112029b81c07636AB7b59fA813E0883BBF"
+    category: infra
+    note: UUPS Proxy; rate-limited mint controller registry
+  - id: sc1
+    label: Supply Controller 1 (500M cap)
+    address: "0xf845a0A05Cbd91Ac15C3E59D126DE5dFbC2aAbb7"
+    category: infra
+    note: EOA; ~138,888 USDG/sec refill
+  - id: sc2
+    label: Supply Controller 2 (1B cap)
+    address: "0x2fb074FA59c9294c71246825C1c9A0c7782d41a4"
+    category: infra
+    note: EOA; ~277,778 USDG/sec refill
+  - id: oft-wrapper
+    label: OFTWrapper (LayerZero V2)
+    address: "0x147BdE4F997f0d4C7544ED0C55eAcf1E5E6bf9c4"
+    category: infra
+    note: SC3; 45M cap; whitelist only
+
+  # === Governance ===
+  - id: token-timelock
+    label: Token Admin Timelock (3h)
+    address: "0x9036566eAa5F83E0b9E1161C6c602b0Adf997654"
+    category: governance
+    note: OpenZeppelin TimelockController
+  - id: default-admin-multisig
+    label: DEFAULT_ADMIN Multisig (7 owners)
+    address: "0x137Dcd97872dE27a4d3bf36A4643c5e18FA40713"
+    category: governance
+    note: SimpleMultiSig; proposer/executor on Timelock
+  - id: ops-multisig
+    label: Operational Multisig (3-of-7)
+    address: "0x0644Bd0248d5F89e4F6E845a91D15c23591e5D33"
+    category: governance
+    note: PAUSE / ASSET_PROTECTION / SUPPLY_CONTROLLER_MANAGER
+  - id: supply-control-admin
+    label: SupplyControl Admin (EOA)
+    address: "0x3Af3e85f4f97De7AD0f000B724Fb77fE5ffc024B"
+    category: governance
+    note: DEFAULT_ADMIN + SUPPLY_CONTROLLER_MANAGER on SupplyControl
+
+  # === External dependencies ===
+  - id: dep-paxos-custody
+    label: Paxos Reserves (Offchain)
+    category: dependency
+    note: T-Bills + cash at segregated custodians; MAS-supervised
+  - id: dep-layerzero
+    label: LayerZero V2 OFT
+    category: dependency
+    note: Cross-chain bridge to Solana / X Layer / Ink
+
+edges:
+  # === Governance flow ===
+  - from: default-admin-multisig
+    to: token-timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR
+  - from: token-timelock
+    to: usdg
+    kind: controls
+    label: DEFAULT_ADMIN + owner (3h delay)
+  - from: ops-multisig
+    to: usdg
+    kind: holds-role
+    label: PAUSE + ASSET_PROTECTION + SUPPLY_CONTROLLER_MANAGER
+  - from: supply-control-admin
+    to: supply-control
+    kind: holds-role
+    label: DEFAULT_ADMIN + SUPPLY_CONTROLLER_MANAGER
+
+  # === Mint authority on USDG ===
+  - from: sc1
+    to: usdg
+    kind: mints
+    label: SUPPLY_CONTROLLER (500M cap)
+  - from: sc2
+    to: usdg
+    kind: mints
+    label: SUPPLY_CONTROLLER (1B cap)
+  - from: oft-wrapper
+    to: usdg
+    kind: mints
+    label: SUPPLY_CONTROLLER (45M; bridge)
+
+  # === Supply controller registry ===
+  - from: supply-control
+    to: sc1
+    kind: manages
+    label: rate-limited
+  - from: supply-control
+    to: sc2
+    kind: manages
+    label: rate-limited
+  - from: supply-control
+    to: oft-wrapper
+    kind: manages
+    label: rate-limited
+
+  # === External dependencies (off-chain backing + bridge) ===
+  - from: usdg
+    to: dep-paxos-custody
+    kind: deposits-into
+    label: "1:1 fiat reserves (offchain)"
+  - from: oft-wrapper
+    to: dep-layerzero
+    kind: routes-through
+    label: cross-chain transfer

--- a/reports/graph/re-reusd.yaml
+++ b/reports/graph/re-reusd.yaml
@@ -1,0 +1,297 @@
+slug: re-reusd
+title: Re Protocol (reUSD) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Capital Deployment
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: reusd
+    label: reUSD (Deposit Token)
+    address: "0x5086bf358635B81D8C47C66d1C8b9E567Db70c72"
+    category: vault
+    note: ERC-20 price-appreciation token; UUPS upgradeable
+  - id: icl
+    label: Insurance Capital Layer (ICL)
+    address: "0x4691C475bE804Fa85f91c2D6D0aDf03114de3093"
+    category: vault
+    note: Backed deposit/mint entrypoint; UUPS proxy
+
+  # === Internal infra ===
+  - id: share-price-calc
+    label: Share Price Calculator
+    address: "0xd1D104a7515989ac82F1AFDa15a23650411b05B8"
+    category: infra
+    note: Stores reUSD share price; setSharePrice gated by PRICE_SETTER_ROLE
+  - id: nav-consumer
+    label: NAV Consumer (Chainlink Functions)
+    address: "0x84d4eaeb10f9e57b67622f667c6c13e22fa4b2b6"
+    category: infra
+    note: 10% deviation cap; daily 23:45 UTC update
+  - id: instant-redeem
+    label: Instant Redemption (impl.)
+    address: "0xa31DeeBB3680A3007120e74bcBdf4dF36F042a40"
+    category: infra
+    note: 6 bps fee; 20%/day, 10%/wallet caps; sUSDe payout
+  - id: instant-redeem-interaction
+    label: Instant Redemption Interaction
+    address: "0x8aEb9453EF22Cb38abC7a3Af9c208F65C1BfE31e"
+    category: infra
+    note: User-facing entrypoint; KYC-gated
+  - id: redeem-vault
+    label: Daily Instant Redemption Vault
+    address: "0x5C454f5526e41fBE917b63475CD8CA7E4631B147"
+    category: infra
+    note: Onchain liquidity buffer (~$7.6M sUSDe)
+  - id: minter-burner
+    label: ShareTokenMinterBurner (LZ wrapper)
+    address: "0x0dFb42aa18CEeD719617cd554304F6cA412A6b18"
+    category: infra
+    note: Cross-chain mint/burn for LayerZero OFT
+  - id: oft-adapter
+    label: ReMintBurnAdapter (LayerZero OFT)
+    address: "0x2BB4046022B9161f3F84Ad8E35cac1d5946e0e85"
+    category: infra
+    note: 2.5M reUSD/24h cap per peer chain
+  - id: price-router
+    label: PriceRouter
+    address: "0xFe76cF5eD606593fB7764f33627B8D7E0f9Fab66"
+    category: infra
+  - id: kyc-registry
+    label: KYC Registry
+    address: "0x82F1806AEab5Ecb9a485eb041d5Ed4940b123995"
+    category: infra
+  - id: access-manager
+    label: AccessManager (OZ v5)
+    address: "0x3f0DA1C363e34802C6f12F9C27276dC0e6696FD8"
+    category: infra
+    note: Authority for Instant Redemption
+
+  # === Governance ===
+  - id: gov-safe
+    label: Governance Safe (3-of-5)
+    address: "0x8EEc10616802Ef639ca55C98Ac856553FadeFbAd"
+    category: governance
+    note: DEFAULT_ADMIN + UPGRADER on reUSD/ICL; PROPOSER + CANCELLER on Timelock
+  - id: timelock
+    label: Timelock Controller (48h)
+    address: "0x69dDEa332723cF5407151aAF68B9b076557FCA93"
+    category: governance
+  - id: oracle-admin
+    label: Oracle Admin EOA (MPC 3/5)
+    address: "0x6C15B25E9750Dccb698C1a4023f34015bFe57649"
+    category: governance
+    note: Holds PRICE_SETTER_ROLE; owns minter-burner + OFT adapter; no timelock
+  - id: access-admin
+    label: Access Admin EOA (MPC 5/8)
+    address: "0x80a62B72dF1136aCBc57141FB67Aa46812fECAFc"
+    category: governance
+  - id: custodian-mgr
+    label: Custodian Manager EOA (MPC 3/5)
+    address: "0x9b6d7f2de2E4569297C7e88531E47679cEbE6eC9"
+    category: governance
+    note: CUSTODIAN_MANAGER_ROLE on ICL
+
+  # === Capital deployment legs (~92% of reserves sit at plain EOAs) ===
+  - id: icl-custodial
+    label: ICL Custodial Wallet (EOA, ~$24.4M)
+    address: "0x295F67Fdb21255A3Db82964445628a706FBe689E"
+    category: strategy
+    note: Fireblocks MPC (claimed); plain EOA onchain
+  - id: redeem-custodian
+    label: Redemption Reserves Custodian (EOA, ~$65.4M sUSDe)
+    address: "0x9eA38e09F41A9DE53972a68268BA0Dcc6d2fAdf8"
+    category: strategy
+    note: Fireblocks MPC (claimed); plain EOA onchain
+
+  # === External dependencies ===
+  - id: ethena-susde
+    label: Ethena sUSDe (basis-trade)
+    category: dependency
+    note: ~90% of onchain reserves; 7-day cooldown
+  - id: section114
+    label: §114 Reinsurance Trust
+    category: dependency
+    note: Offchain U.S.-domiciled trust; cash + T-Bills
+  - id: cayman-reinsurer
+    label: Cayman Reinsurer (CIMA Class B(iii))
+    category: dependency
+    note: Issues Surplus Notes to ICL
+  - id: chainlink-functions
+    label: Chainlink Functions + Automation
+    category: dependency
+    note: DON fun-ethereum-mainnet-1, sub 85
+  - id: chainlink-susde
+    label: Chainlink sUSDe/USD aggregator
+    address: "0xFF3BC18cCBd5999CE63E788A1c250a88626aD099"
+    category: dependency
+  - id: tnf-aup
+    label: The Network Firm (offchain AUP)
+    category: dependency
+    note: Daily attestation of §114 trust balances
+  - id: fireblocks
+    label: Fireblocks Custody (MPC, offchain)
+    category: dependency
+    note: Claimed N-of-M signing for reserve EOAs
+
+edges:
+  # === Governance flow ===
+  - from: gov-safe
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + CANCELLER
+  - from: gov-safe
+    to: reusd
+    kind: holds-role
+    label: DEFAULT_ADMIN + UPGRADER
+  - from: gov-safe
+    to: icl
+    kind: holds-role
+    label: DEFAULT_ADMIN + UPGRADER
+  - from: timelock
+    to: reusd
+    kind: manages
+    label: 48h-delayed upgrades / role changes
+  - from: timelock
+    to: icl
+    kind: manages
+    label: 48h-delayed upgrades / role changes
+  - from: access-admin
+    to: access-manager
+    kind: controls
+    label: admin (grantRole / labelRole)
+  - from: access-manager
+    to: instant-redeem
+    kind: manages
+    label: authority()
+  - from: custodian-mgr
+    to: icl
+    kind: holds-role
+    label: CUSTODIAN_MANAGER_ROLE
+  - from: oracle-admin
+    to: share-price-calc
+    kind: holds-role
+    label: PRICE_SETTER_ROLE (bypasses NAV Consumer)
+  - from: oracle-admin
+    to: nav-consumer
+    kind: holds-role
+    label: DEFAULT_ADMIN + EMERGENCY_UPDATER
+
+  # === Mint authority on reUSD ===
+  - from: icl
+    to: reusd
+    kind: mints
+    label: MINTER_ROLE (backed path)
+  - from: instant-redeem
+    to: reusd
+    kind: mints
+    label: MINTER_ROLE (burn on redeem)
+  - from: minter-burner
+    to: reusd
+    kind: mints
+    label: MINTER_ROLE (OFT cross-chain)
+  - from: oracle-admin
+    to: minter-burner
+    kind: controls
+    label: owner
+  - from: oracle-admin
+    to: oft-adapter
+    kind: controls
+    label: owner
+  - from: oft-adapter
+    to: minter-burner
+    kind: routes-through
+    label: LayerZero adapter
+
+  # === Price path ===
+  - from: chainlink-functions
+    to: nav-consumer
+    kind: routes-through
+    label: offchain NAV
+  - from: nav-consumer
+    to: share-price-calc
+    kind: manages
+    label: setSharePrice (audited path)
+  - from: share-price-calc
+    to: price-router
+    kind: routes-through
+  - from: chainlink-susde
+    to: price-router
+    kind: routes-through
+    label: sUSDe/USD
+
+  # === Capital flow: user → ICL → custodial reserves ===
+  - from: reusd
+    to: icl
+    kind: deposits-into
+    label: USDC deposit → mint reUSD
+  - from: icl
+    to: icl-custodial
+    kind: allocates-to
+    label: ~24%
+  - from: icl
+    to: redeem-custodian
+    kind: allocates-to
+    label: ~65%
+  - from: icl
+    to: redeem-vault
+    kind: allocates-to
+    label: ~8% (instant buffer)
+  - from: icl-custodial
+    to: ethena-susde
+    kind: deposits-into
+    label: sUSDe staking
+  - from: redeem-custodian
+    to: ethena-susde
+    kind: deposits-into
+    label: sUSDe staking
+  - from: redeem-vault
+    to: ethena-susde
+    kind: deposits-into
+    label: sUSDe payout token
+
+  # === Offchain ===
+  - from: icl-custodial
+    to: section114
+    kind: deposits-into
+    label: §114 Trust collateral
+  - from: section114
+    to: cayman-reinsurer
+    kind: routes-through
+    label: surplus notes
+  - from: section114
+    to: tnf-aup
+    kind: routes-fees-to
+    label: daily attestation
+  - from: icl-custodial
+    to: fireblocks
+    kind: routes-through
+    label: MPC custody (offchain)
+  - from: redeem-custodian
+    to: fireblocks
+    kind: routes-through
+    label: MPC custody (offchain)
+
+  # === Redemption flow ===
+  - from: instant-redeem-interaction
+    to: instant-redeem
+    kind: routes-through
+    label: delegate
+  - from: instant-redeem
+    to: redeem-vault
+    kind: routes-through
+    label: source liquidity
+  - from: instant-redeem-interaction
+    to: kyc-registry
+    kind: routes-through
+    label: KYC check

--- a/reports/graph/reserve-ethplus.yaml
+++ b/reports/graph/reserve-ethplus.yaml
@@ -1,0 +1,216 @@
+slug: reserve-ethplus
+title: Reserve Protocol (ETH+) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Collateral Strategy
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: ethplus
+    label: ETH+ (RToken)
+    address: "0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8"
+    category: vault
+    note: ERC-1967 proxy; basket-of-LSTs
+  - id: strsr
+    label: stRSR (RSR overcollateralization)
+    address: "0xffa151Ad0A0e2e40F39f9e5E9F87cF9E45e819dd"
+    category: vault
+    note: First-loss buffer (~$1.4M / 2.9% OC)
+
+  # === Internal infra ===
+  - id: main
+    label: Main (AccessController)
+    address: "0xb6A7d481719E97e142114e905E86a39a2Fa0dfD2"
+    category: infra
+    note: Access controller for all roles; version 4.2.0
+  - id: backing-mgr
+    label: BackingManager (holds collateral)
+    address: "0x608e1e01EF072c15E5Da7235ce793f4d24eCa67B"
+    category: infra
+  - id: basket-handler
+    label: BasketHandler
+    category: infra
+    note: Defines basket weights; fullyCollateralized check
+
+  # === Governance ===
+  - id: governor
+    label: Governor Anastasius v1
+    address: "0xa8a608b9b558235e7f87d7024cc05e6f47d62022"
+    category: governance
+    note: OZ Governor; 2d delay + 3d vote; stRSR voting token
+  - id: timelock
+    label: Timelock Controller (3d)
+    address: "0xd7985a7c617febc4a833b5f70cfa79b40c313ad2"
+    category: governance
+    note: OWNER on Main
+  - id: guardian
+    label: Guardian Safe (3-of-6)
+    address: "0xd5fe2780eb882d1da78f2136b81c2a4395488c98"
+    category: governance
+    note: PAUSER + SHORT/LONG_FREEZER + Timelock CANCELLER
+  - id: deployer-eoa
+    label: Deployer EOA (residual PAUSER)
+    address: "0xe3e34fa93575af41bef3476236e1a3cdb3f60b85"
+    category: governance
+    note: PAUSER role since 2023 deployment; not revoked
+
+  # === Collateral strategies (LST plugins) ===
+  - id: wsteth
+    label: wstETH (50%)
+    category: strategy
+    note: Lido collateral plugin
+  - id: weeth
+    label: weETH (22%)
+    category: strategy
+    note: Ether.fi collateral plugin
+  - id: sfrxeth
+    label: sfrxETH (10%)
+    category: strategy
+    note: Frax collateral plugin
+  - id: reth
+    label: rETH (10%)
+    category: strategy
+    note: Rocket Pool collateral plugin
+  - id: ethx
+    label: ETHx (8%)
+    category: strategy
+    note: Stader collateral plugin
+
+  # === External dependencies ===
+  - id: lido
+    label: Lido (stETH)
+    category: dependency
+  - id: etherfi
+    label: Ether.fi (eETH)
+    category: dependency
+  - id: frax
+    label: Frax (frxETH)
+    category: dependency
+  - id: rocketpool
+    label: Rocket Pool
+    category: dependency
+  - id: stader
+    label: Stader
+    category: dependency
+  - id: chainlink
+    label: Chainlink price feeds
+    category: dependency
+    note: Per-collateral plugins; vetted alternates where unavailable
+
+edges:
+  # === Governance flow ===
+  - from: governor
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR (~8d total)
+  - from: guardian
+    to: timelock
+    kind: cancels-on
+    label: CANCELLER
+  - from: timelock
+    to: main
+    kind: holds-role
+    label: OWNER
+  - from: guardian
+    to: main
+    kind: holds-role
+    label: PAUSER + SHORT_FREEZER + LONG_FREEZER
+  - from: deployer-eoa
+    to: main
+    kind: holds-role
+    label: PAUSER (residual)
+  - from: main
+    to: ethplus
+    kind: manages
+    label: upgrades, basket, throttles
+  - from: main
+    to: strsr
+    kind: manages
+    label: upgrades, params
+  - from: main
+    to: backing-mgr
+    kind: manages
+  - from: main
+    to: basket-handler
+    kind: manages
+
+  # === Capital flow: ETH+ → BackingManager → LST plugins → LST issuers ===
+  - from: ethplus
+    to: backing-mgr
+    kind: deposits-into
+    label: issue/redeem basket
+  - from: backing-mgr
+    to: wsteth
+    kind: allocates-to
+    label: "50.0%"
+  - from: backing-mgr
+    to: weeth
+    kind: allocates-to
+    label: "22.0%"
+  - from: backing-mgr
+    to: sfrxeth
+    kind: allocates-to
+    label: "10.0%"
+  - from: backing-mgr
+    to: reth
+    kind: allocates-to
+    label: "10.0%"
+  - from: backing-mgr
+    to: ethx
+    kind: allocates-to
+    label: "8.0%"
+  - from: basket-handler
+    to: backing-mgr
+    kind: manages
+    label: basket weights
+
+  # === LST → underlying staking protocol ===
+  - from: wsteth
+    to: lido
+    kind: deposits-into
+  - from: weeth
+    to: etherfi
+    kind: deposits-into
+  - from: sfrxeth
+    to: frax
+    kind: deposits-into
+  - from: reth
+    to: rocketpool
+    kind: deposits-into
+  - from: ethx
+    to: stader
+    kind: deposits-into
+
+  # === Oracle dependency ===
+  - from: wsteth
+    to: chainlink
+    kind: routes-through
+    label: ETH/USD feed
+  - from: weeth
+    to: chainlink
+    kind: routes-through
+    label: ETH/USD feed
+  - from: reth
+    to: chainlink
+    kind: routes-through
+    label: ETH/USD feed
+  - from: ethx
+    to: chainlink
+    kind: routes-through
+    label: ETH/USD feed
+
+  # === RSR overcollateralization buffer ===
+  - from: strsr
+    to: ethplus
+    kind: routes-through
+    label: first-loss capital

--- a/reports/graph/resolv-rlp.yaml
+++ b/reports/graph/resolv-rlp.yaml
@@ -1,0 +1,251 @@
+slug: resolv-rlp
+title: Resolv RLP — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Strategy / Custody Leg
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: RLP
+    label: RLP (Liquidity Pool)
+    address: "0x4956b52aE2fF65D74CA2d61207523288e4528f96"
+    category: vault
+    note: Junior/insurance tranche; first-loss capital
+  - id: USR
+    label: USR (Stablecoin)
+    address: "0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110"
+    category: vault
+    note: Senior tranche; protected by RLP
+
+  # === Internal infra ===
+  - id: rlp-requests-manager
+    label: RLP Requests Manager
+    address: "0x10f4d4EAd6Bcd4de7849898403d88528e3Dfc872"
+    category: infra
+    note: Mint/burn entry; epoch-based batch burn
+  - id: rlp-counter
+    label: RLP Counter
+    address: "0xc7ab90c2ea9271efb31f5fa2843eeb4b331eafa0"
+    category: infra
+    note: Offchain price storage (24h cycle)
+  - id: usr-counter
+    label: USR Counter (TheCounter)
+    address: "0xa27a69Ae180e202fDe5D38189a3F24Fe24E55861"
+    category: infra
+    note: completeSwap() exploited 2026-03-22 — ~80M USR unbacked mint
+  - id: whitelist
+    label: Whitelist
+    address: "0x5943026E21E3936538620ba27e01525bBA311255"
+    category: infra
+    note: Gates mint/redeem to allowlisted wallets
+  - id: reward-distributor
+    label: RewardDistributor
+    address: "0xbE23BB6D817C08E7EC4Cd0adB0E23156189c1bA9"
+    category: infra
+  - id: fee-collector
+    label: Fee Collector
+    address: "0x6E02e225329E32c854178d7c865cF70fE1617f02"
+    category: infra
+  - id: treasury
+    label: Treasury (onchain wallet)
+    address: "0xacb7027f271b03b502d65feba617a0d817d62b8e"
+    category: infra
+
+  # === Governance ===
+  - id: multisig
+    label: Gnosis Safe (3-of-5)
+    address: "0xd6889f307be1b83bb355d5da7d4478fb0d2af547"
+    category: governance
+    note: DEFAULT_ADMIN_ROLE on all core contracts; 5 anonymous EOAs
+  - id: timelock
+    label: TimelockController (3-day)
+    address: "0x290d9544669c9c7a64f6899a0a3b28d563f6ebee"
+    category: governance
+    note: Owns all ProxyAdmins; upgrades only
+
+  # === Strategy / custody legs ===
+  - id: fireblocks-deribit
+    label: Fireblocks (Deribit) Wallet
+    address: "0x22062B644aADD7e7Bb11e58C37BC1b022f4Ec3aC"
+    category: strategy
+    note: Margin for Deribit hedging futures
+  - id: fireblocks-bybit
+    label: Fireblocks (Bybit) Wallet
+    address: "0x2a144e059cd8a8200298976ce55e8938f33b1d3b"
+    category: strategy
+    note: Margin for Bybit hedging futures
+  - id: ceffu-binance
+    label: Ceffu (Binance) Custody
+    category: strategy
+    note: Omnibus wallet; margin for Binance perps
+  - id: defi-allocations
+    label: DeFi / RWA Allocations
+    category: strategy
+    note: Aave v3, Lido, EtherFi, Superstate USCC
+
+  # === External dependencies (hedging venues) ===
+  - id: dep-binance
+    label: Binance (Perp Futures)
+    category: dependency
+    note: Short perp leg of delta-neutral hedge
+  - id: dep-deribit
+    label: Deribit (Perp Futures)
+    category: dependency
+  - id: dep-bybit
+    label: Bybit (Perp Futures)
+    category: dependency
+  - id: dep-hyperliquid
+    label: Hyperliquid (Perp DEX)
+    category: dependency
+  - id: dep-aave
+    label: Aave v3 (ETH Borrowing)
+    category: dependency
+  - id: dep-lido
+    label: Lido (stETH)
+    category: dependency
+  - id: dep-etherfi
+    label: EtherFi (weETH)
+    category: dependency
+  - id: dep-uscc
+    label: Superstate USCC + Aave Horizon RWA
+    category: dependency
+
+edges:
+  # === Governance ===
+  - from: multisig
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR (sole)
+  - from: timelock
+    to: RLP
+    kind: manages
+    label: ProxyAdmin owner (upgrades, 3d)
+  - from: timelock
+    to: USR
+    kind: manages
+    label: ProxyAdmin owner (upgrades, 3d)
+  - from: multisig
+    to: RLP
+    kind: holds-role
+    label: DEFAULT_ADMIN_ROLE (no delay)
+  - from: multisig
+    to: USR
+    kind: holds-role
+    label: DEFAULT_ADMIN_ROLE (no delay)
+  - from: multisig
+    to: rlp-requests-manager
+    kind: holds-role
+    label: DEFAULT_ADMIN_ROLE
+  - from: multisig
+    to: rlp-counter
+    kind: holds-role
+    label: SERVICE_ROLE (offchain price)
+  - from: multisig
+    to: whitelist
+    kind: manages
+    label: RDAL controls allowlist
+  - from: multisig
+    to: usr-counter
+    kind: holds-role
+    label: DEFAULT_ADMIN_ROLE
+  - from: multisig
+    to: reward-distributor
+    kind: holds-role
+    label: DEFAULT_ADMIN_ROLE
+
+  # === Mint authority on USR (RLP losses cascade through USR collateral) ===
+  - from: usr-counter
+    to: USR
+    kind: mints
+    label: SERVICE_ROLE (exploited)
+  - from: rlp-requests-manager
+    to: RLP
+    kind: mints
+    label: completeMint (backend)
+
+  # === User flow into RLP ===
+  - from: rlp-requests-manager
+    to: RLP
+    kind: routes-through
+    label: requestMint → completeMint
+  - from: rlp-counter
+    to: rlp-requests-manager
+    kind: routes-through
+    label: 24h price feed (offchain)
+  - from: whitelist
+    to: rlp-requests-manager
+    kind: manages
+    label: allowlist check
+  - from: RLP
+    to: fee-collector
+    kind: routes-fees-to
+
+  # === RLP first-loss absorbs USR strategy losses ===
+  - from: RLP
+    to: USR
+    kind: routes-through
+    label: first-loss tranche over USR collateral
+
+  # === USR collateral pool → strategy/custody legs ===
+  - from: USR
+    to: fireblocks-deribit
+    kind: allocates-to
+    label: "Deribit margin"
+  - from: USR
+    to: fireblocks-bybit
+    kind: allocates-to
+    label: "Bybit margin"
+  - from: USR
+    to: ceffu-binance
+    kind: allocates-to
+    label: "Binance margin"
+  - from: USR
+    to: defi-allocations
+    kind: allocates-to
+    label: "DeFi + RWA"
+  - from: USR
+    to: treasury
+    kind: routes-through
+    label: onchain custody
+
+  # === Custody legs → hedging venues ===
+  - from: fireblocks-deribit
+    to: dep-deribit
+    kind: deposits-into
+    label: short perps
+  - from: fireblocks-bybit
+    to: dep-bybit
+    kind: deposits-into
+    label: short perps
+  - from: ceffu-binance
+    to: dep-binance
+    kind: deposits-into
+    label: short perps
+  - from: treasury
+    to: dep-hyperliquid
+    kind: deposits-into
+    label: short perps (DEX)
+
+  # === DeFi allocations → individual venues ===
+  - from: defi-allocations
+    to: dep-aave
+    kind: deposits-into
+  - from: defi-allocations
+    to: dep-lido
+    kind: deposits-into
+  - from: defi-allocations
+    to: dep-etherfi
+    kind: deposits-into
+  - from: defi-allocations
+    to: dep-uscc
+    kind: deposits-into

--- a/reports/graph/resolv-wstusr.yaml
+++ b/reports/graph/resolv-wstusr.yaml
@@ -1,0 +1,282 @@
+slug: resolv-wstusr
+title: Resolv wstUSR — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Strategy / Custody Leg
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: wstUSR
+    label: wstUSR (Wrapped Staked USR)
+    address: "0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055"
+    category: vault
+    note: ERC-4626 wrapper of stUSR; non-rebasing
+  - id: stUSR
+    label: stUSR (Staked USR)
+    address: "0x6c8984bc7DBBeDAf4F6b2FD766f16eBB7d10AAb4"
+    category: vault
+    note: Rebasing ERC-20; 1:1 USR backing
+  - id: USR
+    label: USR (Stablecoin)
+    address: "0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110"
+    category: vault
+    note: Underlying stablecoin; collateral compromised 2026-03-22
+  - id: RLP
+    label: RLP (Junior Tranche)
+    address: "0x4956b52aE2fF65D74CA2d61207523288e4528f96"
+    category: vault
+    note: First-loss capital protecting USR/stUSR/wstUSR
+
+  # === Internal infra ===
+  - id: usr-requests-manager
+    label: USR Requests Manager
+    address: "0xAC85eF29192487E0a109b7f9E40C267a9ea95f2e"
+    category: infra
+    note: Mint/burn flow for USR (requires whitelist)
+  - id: usr-counter
+    label: USR Counter (TheCounter)
+    address: "0xa27a69Ae180e202fDe5D38189a3F24Fe24E55861"
+    category: infra
+    note: completeSwap() exploited 2026-03-22 — ~80M USR unbacked mint
+  - id: reward-distributor
+    label: RewardDistributor
+    address: "0xbE23BB6D817C08E7EC4Cd0adB0E23156189c1bA9"
+    category: infra
+    note: Drips USR rewards into stUSR (SERVICE_ROLE revoked 2025-05-26)
+  - id: whitelist
+    label: Whitelist
+    address: "0x5943026E21E3936538620ba27e01525bBA311255"
+    category: infra
+    note: Gates USR mint/redeem (not wstUSR wrapping)
+  - id: fee-collector
+    label: Fee Collector
+    address: "0x6E02e225329E32c854178d7c865cF70fE1617f02"
+    category: infra
+  - id: treasury
+    label: Treasury (onchain wallet)
+    address: "0xacb7027f271b03b502d65feba617a0d817d62b8e"
+    category: infra
+
+  # === Governance ===
+  - id: multisig
+    label: Gnosis Safe (3-of-5)
+    address: "0xd6889f307be1b83bb355d5da7d4478fb0d2af547"
+    category: governance
+    note: DEFAULT_ADMIN_ROLE on all core contracts; 5 anonymous EOAs
+  - id: timelock
+    label: TimelockController (3-day)
+    address: "0x290d9544669c9c7a64f6899a0a3b28d563f6ebee"
+    category: governance
+    note: Owns all ProxyAdmins; upgrades only
+  - id: stusr-proxy-admin
+    label: stUSR ProxyAdmin
+    address: "0xeb88058615eaf3e4833af053484012c4d6cbfa37"
+    category: governance
+  - id: wstusr-proxy-admin
+    label: wstUSR ProxyAdmin
+    address: "0xD89784610EefD4d11444788F7A85AaDfd57AF7E5"
+    category: governance
+
+  # === Strategy / custody legs (offchain hedge) ===
+  - id: fireblocks-deribit
+    label: Fireblocks (Deribit) Wallet
+    address: "0x22062B644aADD7e7Bb11e58C37BC1b022f4Ec3aC"
+    category: strategy
+  - id: fireblocks-bybit
+    label: Fireblocks (Bybit) Wallet
+    address: "0x2a144e059cd8a8200298976ce55e8938f33b1d3b"
+    category: strategy
+  - id: ceffu-binance
+    label: Ceffu (Binance) Custody
+    category: strategy
+    note: Omnibus wallet for Binance perp margin
+  - id: defi-allocations
+    label: DeFi / RWA Allocations
+    category: strategy
+    note: Aave v3, Lido, EtherFi, Superstate USCC
+
+  # === External dependencies ===
+  - id: dep-binance
+    label: Binance (Perp Futures)
+    category: dependency
+  - id: dep-deribit
+    label: Deribit (Perp Futures)
+    category: dependency
+  - id: dep-bybit
+    label: Bybit (Perp Futures)
+    category: dependency
+  - id: dep-hyperliquid
+    label: Hyperliquid (Perp DEX)
+    category: dependency
+  - id: dep-aave
+    label: Aave v3
+    category: dependency
+  - id: dep-lido
+    label: Lido (stETH)
+    category: dependency
+  - id: dep-etherfi
+    label: EtherFi (weETH)
+    category: dependency
+  - id: dep-uscc
+    label: Superstate USCC + Aave Horizon RWA
+    category: dependency
+
+edges:
+  # === Governance ===
+  - from: multisig
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR (sole)
+  - from: timelock
+    to: stusr-proxy-admin
+    kind: controls
+    label: owner (3d delay)
+  - from: timelock
+    to: wstusr-proxy-admin
+    kind: controls
+    label: owner (3d delay)
+  - from: stusr-proxy-admin
+    to: stUSR
+    kind: manages
+    label: upgrades
+  - from: wstusr-proxy-admin
+    to: wstUSR
+    kind: manages
+    label: upgrades
+  - from: multisig
+    to: wstUSR
+    kind: holds-role
+    label: DEFAULT_ADMIN_ROLE
+  - from: multisig
+    to: stUSR
+    kind: holds-role
+    label: DEFAULT_ADMIN_ROLE
+  - from: multisig
+    to: USR
+    kind: holds-role
+    label: DEFAULT_ADMIN_ROLE + SERVICE_ROLE (added 2026-03-22)
+  - from: multisig
+    to: reward-distributor
+    kind: holds-role
+    label: DEFAULT_ADMIN_ROLE
+  - from: multisig
+    to: whitelist
+    kind: manages
+    label: allowlist control
+
+  # === Mint authority on USR (the compromised surface) ===
+  - from: usr-counter
+    to: USR
+    kind: mints
+    label: SERVICE_ROLE (exploited 2026-03-22)
+  - from: usr-requests-manager
+    to: USR
+    kind: mints
+    label: SERVICE_ROLE (whitelist gated)
+  - from: multisig
+    to: USR
+    kind: mints
+    label: SERVICE_ROLE — uncapped, post-incident
+  - from: reward-distributor
+    to: USR
+    kind: mints
+    label: SERVICE_ROLE (revoked 2025-05-26)
+
+  # === Wrapping flow: USR → stUSR → wstUSR ===
+  - from: wstUSR
+    to: stUSR
+    kind: deposits-into
+    label: ERC-4626 wrap (~344.9M stUSR)
+  - from: stUSR
+    to: USR
+    kind: deposits-into
+    label: 1:1 staked (~347.2M USR)
+
+  # === Yield: rewards drip into stUSR (mint authority shown above) ===
+  - from: reward-distributor
+    to: stUSR
+    kind: routes-through
+    label: USR drip (vested)
+
+  # === USR mint/redeem entry ===
+  - from: usr-requests-manager
+    to: USR
+    kind: routes-through
+    label: requestMint/Burn (whitelist)
+  - from: whitelist
+    to: usr-requests-manager
+    kind: manages
+    label: allowlist check
+  - from: USR
+    to: fee-collector
+    kind: routes-fees-to
+
+  # === Senior/junior tranche: RLP absorbs losses before USR ===
+  - from: RLP
+    to: USR
+    kind: routes-through
+    label: first-loss tranche
+
+  # === USR collateral pool → strategy/custody legs ===
+  - from: USR
+    to: fireblocks-deribit
+    kind: allocates-to
+    label: "Deribit margin"
+  - from: USR
+    to: fireblocks-bybit
+    kind: allocates-to
+    label: "Bybit margin"
+  - from: USR
+    to: ceffu-binance
+    kind: allocates-to
+    label: "Binance margin"
+  - from: USR
+    to: defi-allocations
+    kind: allocates-to
+    label: "DeFi + RWA"
+  - from: USR
+    to: treasury
+    kind: routes-through
+    label: onchain custody
+
+  # === Custody legs → hedging venues ===
+  - from: fireblocks-deribit
+    to: dep-deribit
+    kind: deposits-into
+    label: short perps
+  - from: fireblocks-bybit
+    to: dep-bybit
+    kind: deposits-into
+    label: short perps
+  - from: ceffu-binance
+    to: dep-binance
+    kind: deposits-into
+    label: short perps
+  - from: treasury
+    to: dep-hyperliquid
+    kind: deposits-into
+    label: short perps (DEX)
+
+  # === DeFi allocations → individual venues ===
+  - from: defi-allocations
+    to: dep-aave
+    kind: deposits-into
+  - from: defi-allocations
+    to: dep-lido
+    kind: deposits-into
+  - from: defi-allocations
+    to: dep-etherfi
+    kind: deposits-into
+  - from: defi-allocations
+    to: dep-uscc
+    kind: deposits-into

--- a/reports/graph/royco-srroyusdc.yaml
+++ b/reports/graph/royco-srroyusdc.yaml
@@ -1,0 +1,247 @@
+slug: royco-srroyusdc
+title: Royco Dawn (srRoyUSDC) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Strategy / Market
+  - id: governance
+    label: Governance / Multisig
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: srroyusdc
+    label: srRoyUSDC (Senior Vault)
+    address: "0xcD9f5907F92818bC06c9Ad70217f089E190d2a32"
+    category: vault
+    note: ERC-4626 / ERC-7540 async vault; ERC-1967 proxy
+  - id: vault-impl
+    label: ConcreteAsyncVaultImpl
+    address: "0x1b5cd91e61505d431d2a61192a1006146bd9bb28"
+    category: vault
+
+  # === Governance ===
+  - id: owner-safe
+    label: Owner Safe (3-of-5)
+    address: "0x85de42e5697d16b853ea24259c42290dace35190"
+    category: governance
+    note: Vault owner; ADMIN_UPGRADER on RoycoFactory; owns MultisigStrategy ProxyAdmin
+  - id: vault-mgr
+    label: VAULT_MANAGER Safe (3-of-4)
+    address: "0x7c405bbD131e42af506d14e752f2e59B19D49997"
+    category: governance
+    note: Fee / queue management
+  - id: treasury-safe
+    label: Treasury Safe (3-of-5, same signers as Owner)
+    address: "0x170ff06326eBb64BF609a848Fc143143994AF6c8"
+    category: governance
+    note: Holds Senior Tranche tokens; calls adjustTotalAssets
+  - id: concrete-factory-owner
+    label: ConcreteFactory Owner (Concrete team 3-of-5)
+    address: "0xdc29BD10CB9000dffBb5aAcD30606c66f07c866C"
+    category: governance
+    note: Approves vault implementation upgrades
+
+  # === Protocol infra ===
+  - id: multisig-strategy
+    label: MultisigStrategy (full-custody handoff)
+    address: "0xd3F8Edff57570c4F9B11CC95eA65117e2D7A6C2D"
+    category: infra
+    note: Forwards USDC to Treasury Safe; adjustTotalAssets admin-reported
+  - id: makina-strategy
+    label: RoycoVaultMakinaStrategy (secondary, ~1K USDC)
+    address: "0xc5FeF644d59415cec65049e0653CA10eD9Cba778"
+    category: infra
+  - id: concrete-factory
+    label: ConcreteFactory (Vault Proxy Admin)
+    address: "0x0265d73a8e61f698d8eb0dfeb91ddce55516844c"
+    category: infra
+  - id: royco-factory
+    label: RoycoFactory (AccessManager, 5d setback)
+    address: "0xD567cCbb336Eb71eC2537057E2bCF6DB840bB71d"
+    category: infra
+  - id: royco-factory-proxy
+    label: RoycoFactory Proxy (Dawn Market Factory)
+    address: "0x7cC6fB28eC7b5e7afC3cB3986141797ffc27253C"
+    category: infra
+  - id: adaptive-ydm
+    label: AdaptiveCurveYDM (immutable)
+    address: "0x071B0FA065774b403B8dae0aE93A09Df5DE3DFAc"
+    category: infra
+    note: Yield distribution model; no admin
+
+  # === Strategy: Dawn markets (Senior Tranche tokens held by Treasury) ===
+  - id: st-snusd
+    label: ROY-ST-sNUSD (Senior)
+    address: "0x2070Af1C865f5d764F673Baf5654822947e71243"
+    category: strategy
+    note: Neutrl sNUSD market; PERPETUAL (fixedTermDuration=0)
+  - id: st-snusd-legacy
+    label: ROY-ST-sNUSD legacy (Senior)
+    address: "0x3b2df77f0eaa0ca98aaabffa96b03eaf08ec6c8e"
+    category: strategy
+  - id: st-autousd
+    label: ROY-ST-autoUSD (Senior)
+    address: "0x73C641fe41EB0270C7f473f3c3E4A40eb97fd8dE"
+    category: strategy
+    note: 2-day Fixed-Term protection
+  - id: st-savusd
+    label: ROY-ST-savUSD (Senior, Avalanche)
+    category: strategy
+    note: Avalanche chain; address 0xDA7bf1788aecb94fE6D5D3f739358De94f43E5C9
+  - id: kernel-snusd
+    label: Neutrl sNUSD Kernel
+    address: "0x0aE0978B868804929fd4C06B3B22D9197B8cd3c6"
+    category: infra
+  - id: kernel-autousd
+    label: Tokemak autoUSD Kernel
+    address: "0x8748D1c21CC550B435487F473d9Aaf6C84dA46A6"
+    category: infra
+  - id: aave-position
+    label: Aave aUSDC position
+    address: "0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c"
+    category: strategy
+    note: ~$2.1M liquidity reserve
+
+  # === External dependencies (underlying yield protocols) ===
+  - id: dep-neutrl
+    label: Neutrl sNUSD
+    category: dependency
+    note: ~29% of vault
+  - id: dep-tokemak
+    label: Tokemak autoUSD
+    category: dependency
+    note: ~11% of vault
+  - id: dep-avant
+    label: Avant savUSD (Avalanche)
+    category: dependency
+    note: ~40% of vault (concentration cap)
+  - id: dep-aave
+    label: Aave v3 Core USDC
+    category: dependency
+    note: ~20% liquidity reserve
+
+edges:
+  # === Governance flow ===
+  - from: owner-safe
+    to: srroyusdc
+    kind: holds-role
+    label: vault owner
+  - from: vault-mgr
+    to: srroyusdc
+    kind: holds-role
+    label: fee / queue management
+  - from: owner-safe
+    to: multisig-strategy
+    kind: manages
+    label: ProxyAdmin (no timelock)
+  - from: owner-safe
+    to: royco-factory
+    kind: holds-role
+    label: ADMIN_UPGRADER (1d delay)
+  - from: concrete-factory-owner
+    to: concrete-factory
+    kind: controls
+    label: owner
+  - from: concrete-factory
+    to: srroyusdc
+    kind: manages
+    label: proxy admin (impl upgrade)
+  - from: treasury-safe
+    to: multisig-strategy
+    kind: controls
+    label: adjustTotalAssets (admin-reported NAV)
+  - from: royco-factory
+    to: royco-factory-proxy
+    kind: manages
+  - from: royco-factory-proxy
+    to: kernel-snusd
+    kind: deploys
+  - from: royco-factory-proxy
+    to: kernel-autousd
+    kind: deploys
+
+  # === Vault internal wiring ===
+  - from: vault-impl
+    to: srroyusdc
+    kind: manages
+    label: ERC-1967 implementation
+
+  # === Capital flow: vault → MultisigStrategy → Treasury → Senior Tranches ===
+  - from: srroyusdc
+    to: multisig-strategy
+    kind: allocates-to
+    label: ~100% (full-custody handoff)
+  - from: srroyusdc
+    to: makina-strategy
+    kind: allocates-to
+    label: ~$1K (secondary)
+  - from: multisig-strategy
+    to: treasury-safe
+    kind: routes-through
+    label: safeTransfer to multisig
+
+  # === Treasury → Senior Tranche allocations ===
+  - from: treasury-safe
+    to: st-snusd
+    kind: allocates-to
+    label: "~11% (Neutrl)"
+  - from: treasury-safe
+    to: st-snusd-legacy
+    kind: allocates-to
+    label: "~18% (Neutrl legacy)"
+  - from: treasury-safe
+    to: st-autousd
+    kind: allocates-to
+    label: "~11% (Tokemak)"
+  - from: treasury-safe
+    to: st-savusd
+    kind: allocates-to
+    label: "~40% (Avant, Avalanche)"
+  - from: treasury-safe
+    to: aave-position
+    kind: allocates-to
+    label: "~20% (Aave reserve)"
+
+  # === Senior Tranche → Kernel → Underlying ===
+  - from: st-snusd
+    to: kernel-snusd
+    kind: deposits-into
+  - from: st-snusd-legacy
+    to: kernel-snusd
+    kind: deposits-into
+  - from: st-autousd
+    to: kernel-autousd
+    kind: deposits-into
+  - from: kernel-snusd
+    to: dep-neutrl
+    kind: deposits-into
+    label: sNUSD wrap
+  - from: kernel-autousd
+    to: dep-tokemak
+    kind: deposits-into
+    label: autoUSD wrap
+  - from: st-savusd
+    to: dep-avant
+    kind: deposits-into
+    label: savUSD wrap
+  - from: aave-position
+    to: dep-aave
+    kind: deposits-into
+    label: aUSDC supply
+
+  # === Yield distribution model wiring ===
+  - from: adaptive-ydm
+    to: kernel-snusd
+    kind: manages
+    label: ST/JT yield split
+  - from: adaptive-ydm
+    to: kernel-autousd
+    kind: manages
+    label: ST/JT yield split

--- a/reports/graph/spectra-finance.yaml
+++ b/reports/graph/spectra-finance.yaml
@@ -1,0 +1,191 @@
+slug: spectra-finance
+title: Spectra Finance — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: PT/YT Market
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: metavault
+    label: MetaVault (ERC-7540)
+    category: vault
+    note: AsyncVault + MetavaultWrapper; e.g. Gami Spectra USDC (Base), vbUSDC (Katana)
+  - id: pt
+    label: Principal Tokens (PT)
+    category: vault
+    note: Per-market PT tokens; redeem 1:1 at maturity (minus negative yield)
+  - id: yt
+    label: Yield Tokens (YT)
+    category: vault
+    note: Claim on future yield until maturity
+  - id: spectra-token
+    label: SPECTRA (governance token)
+    address: "0x6a89228055c7c28430692e342f149f37462b478b"
+    category: vault
+    note: veSPECTRA for governance + fee share
+
+  # === Internal infra ===
+  - id: registry
+    label: Spectra Registry
+    address: "0x4973b53b300d64ab72147EFF8C9d962f6b1dA02e"
+    category: infra
+    note: Implementation registry; fee config
+  - id: pt-factory
+    label: PrincipalToken Factory (AMBeacon)
+    category: infra
+    note: Permissionless market deployment
+  - id: oracle-factories
+    label: Oracle Factories
+    category: infra
+    note: SpectraPriceOracleFactory, TwapOracleFactoryNG, TwapOracleFactorySNG (12 feed types)
+  - id: zodiac-roles
+    label: Zodiac Roles Module (Curator)
+    category: infra
+    note: Whitelisted curator actions; receivers restricted to SAFE
+  - id: zodiac-delay
+    label: Zodiac Delay Module (Guardian)
+    category: infra
+    note: Time-locked sensitive operations
+  - id: metavault-safe
+    label: MetaVault SAFE (Gnosis)
+    category: infra
+    note: Holds Accountant/Curator/Guardian roles; can pause AsyncVault
+
+  # === Governance ===
+  - id: dao-multisig
+    label: DAO Multisig (3-of-5 Safe)
+    address: "0xDbbfc051D200438dd5847b093B22484B842de9E7"
+    category: governance
+    note: ADMIN (role 0) + UPGRADE (role 1) + roles 2-8,11,14,101; 5 EOAs; getRoleGrantDelay(1)=0
+  - id: access-manager
+    label: AccessManager (OZ 5.0)
+    address: "0x7EA3097E2AF59eA705398544e0f58EdDb7bd1852"
+    category: governance
+    note: Central role authority; 0-second grant/execution delay
+
+  # === Strategy / PT-YT markets ===
+  - id: market-pt-cusd
+    label: PT-cUSD Spectra Market
+    category: strategy
+    note: "Example: cUSD market backing PT-cUSD-29JAN2026"
+  - id: curve-pool
+    label: Curve Pool (PT/IBT)
+    category: strategy
+    note: Per-market Curve AMM pool — twocrypto-ng / stableswap-ng
+
+  # === External dependencies ===
+  - id: dep-curve
+    label: Curve Finance (AMM + price_oracle)
+    category: dependency
+    note: Battle-tested since 2020; CurveOracleLib for TWAP
+  - id: dep-ibt
+    label: Underlying ERC-4626 IBT
+    category: dependency
+    note: Source of yield; PT inherits IBT risk (negative yield)
+  - id: dep-morpho
+    label: Morpho Blue (PT collateral)
+    category: dependency
+    note: e.g. PT-cUSD/USDC market; uses Spectra hybrid oracle
+
+edges:
+  # === Governance ===
+  - from: dao-multisig
+    to: access-manager
+    kind: controls
+    label: ADMIN_ROLE (0) — no delay
+  - from: access-manager
+    to: registry
+    kind: manages
+    label: upgrade authority
+  - from: access-manager
+    to: pt-factory
+    kind: manages
+    label: AMBeacon admin
+  - from: dao-multisig
+    to: spectra-token
+    kind: manages
+    label: 60% swap fees → veSPECTRA voters
+
+  # === MetaVault governance ===
+  - from: metavault-safe
+    to: zodiac-roles
+    kind: manages
+    label: enables curator module
+  - from: metavault-safe
+    to: zodiac-delay
+    kind: manages
+    label: guardian time-lock
+  - from: metavault-safe
+    to: metavault
+    kind: manages
+    label: pause/unpause AsyncVault
+  - from: zodiac-roles
+    to: metavault
+    kind: controls
+    label: curator execTransactionWithRole (whitelisted actions)
+  - from: zodiac-delay
+    to: metavault
+    kind: controls
+    label: guardian-verified ops
+
+  # === MetaVault → PT markets ===
+  - from: metavault
+    to: market-pt-cusd
+    kind: allocates-to
+    label: curator allocation
+  - from: market-pt-cusd
+    to: pt
+    kind: routes-through
+    label: split IBT → PT + YT
+  - from: market-pt-cusd
+    to: yt
+    kind: routes-through
+    label: split IBT → PT + YT
+  - from: pt-factory
+    to: market-pt-cusd
+    kind: deploys
+    label: permissionless market
+  - from: oracle-factories
+    to: market-pt-cusd
+    kind: deploys
+    label: deterministic / TWAP / hybrid
+
+  # === Liquidity routing ===
+  - from: pt
+    to: curve-pool
+    kind: routes-through
+    label: PT/IBT trading
+  - from: curve-pool
+    to: dep-curve
+    kind: deposits-into
+    label: AMM pool
+
+  # === PT backing → underlying IBT ===
+  - from: market-pt-cusd
+    to: dep-ibt
+    kind: deposits-into
+    label: 1 PT = 1 unit at maturity
+
+  # === External oracle consumption ===
+  - from: oracle-factories
+    to: dep-curve
+    kind: routes-through
+    label: price_oracle() for TWAP
+  - from: dep-morpho
+    to: oracle-factories
+    kind: routes-through
+    label: hybrid oracle for PT collateral
+  - from: pt
+    to: dep-morpho
+    kind: deposits-into
+    label: PT as collateral

--- a/reports/graph/stakedhype-sthype.yaml
+++ b/reports/graph/stakedhype-sthype.yaml
@@ -1,0 +1,226 @@
+slug: stakedhype-sthype
+title: StakedHYPE (stHYPE) — Contract Dependency Graph
+chain: hyperevm
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Validator Staking Module
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: stHYPE
+    label: stHYPE (LST)
+    address: "0xfFaa4a3D97fE9107Cef8a3F48c069F577Ff76cC1"
+    category: vault
+    note: ERC-20 upgradeable proxy
+  - id: wstHYPE
+    label: wstHYPE (Wrapped Shares)
+    address: "0x94e8396e0869c9F2200760aF0621aFd240E1CF38"
+    category: vault
+    note: Wrapped share token; ~$65M used as lending collateral
+  - id: overseer
+    label: OverseerV1 (Mint/Burn)
+    address: "0xB96f07367e69e86d6e9C3F29215885104813eeAE"
+    category: vault
+    note: Mint/burn controller; holds MINTER + BURNER on stHYPE
+
+  # === Protocol infra ===
+  - id: withdrawal-amm
+    label: stHYPE/WHYPE AMM Withdrawal Module
+    address: "0x69e487aa3132708d08a979b2d07c5119bb77f698"
+    category: infra
+    note: Services AMM-pool unstakes (dominant net-receiver)
+  - id: manager-role
+    label: MANAGER (Operator)
+    address: "0x53D6c6594d14f9bBDFC572f048312728F7B2418e"
+    category: infra
+    note: Operational manager per Roles registry
+  - id: rebaser
+    label: REBASER (Exchange-rate trigger)
+    address: "0x4eb038eb501045daa520b972fcad48c429531e10"
+    category: infra
+  - id: fee-recipient
+    label: FEE_RECIPIENT
+    address: "0xa2666b4dd1242def4c3cf5731a85aa8457fe01c1"
+    category: infra
+  - id: hyena-hip3
+    label: HyENA HIP-3 / USDe Quote Asset
+    address: "0xa5101b03675294c87ab7381b41d4225eb8709128"
+    category: infra
+  - id: hyena-deployer
+    label: HyENA HIP-3 Deployer
+    address: "0x358e783c32147b344a1168e0984d3350de4e07cb"
+    category: infra
+
+  # === Validator staking modules ===
+  - id: staking-module-1
+    label: HyperCore Staking Module #1
+    address: "0x591540F231055743A37F691C3ffd50E4E53561ab"
+    category: strategy
+  - id: staking-module-2
+    label: HyperCore Staking Module #2
+    address: "0x16a4814e8eB502C56CeBd73F9c8aC7FDee29c042"
+    category: strategy
+  - id: staking-module-3
+    label: HyperCore Staking Module #3
+    address: "0xf992aa323ec183733213f874b6322b8bd1aAD625"
+    category: strategy
+  - id: staking-module-4
+    label: HyperCore Staking Module #4
+    address: "0x06b5659f16110319137220D1EFd680053F5e72a2"
+    category: strategy
+  - id: staking-module-5
+    label: HyperCore Staking Module #5
+    address: "0xe787dD1347A29e6807D164C4FA43105b64048556"
+    category: strategy
+
+  # === Governance ===
+  - id: multisig
+    label: Governance Multisig (4/6)
+    address: "0x97dee0ea4ca10560f260a0f6f45bdc128a1d51f9"
+    category: governance
+    note: Gnosis Safe v1.3.0; raised from 3/5 on 2026-04-07
+  - id: timelock
+    label: TimelockController (48h)
+    address: "0xc5DEd4F7F53919c714059a17d31371aE847E23D2"
+    category: governance
+    note: OZ TimelockController; owns all ProxyAdmins
+  - id: sthype-proxyadmin
+    label: stHYPE ProxyAdmin
+    address: "0xe7b0f26e8e20e109441f0ad1c885fffbb27125dc"
+    category: governance
+  - id: overseer-proxyadmin
+    label: OverseerV1 ProxyAdmin
+    address: "0x943a7e81373423f7bb0fb6a3e55553638264fd6b"
+    category: governance
+  - id: wsthype-proxyadmin
+    label: wstHYPE ProxyAdmin
+    address: "0xa29a2043b2fcbc9189beb9e6efcb2ba48bb3d586"
+    category: governance
+
+  # === External dependencies ===
+  - id: hyperliquid-l1
+    label: Hyperliquid L1 Validators
+    category: dependency
+    note: Validator delegation via HSM (HSM still unshipped May 2026)
+
+edges:
+  # === Governance ===
+  - from: multisig
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR + CANCELLER
+  - from: timelock
+    to: sthype-proxyadmin
+    kind: controls
+    label: owner (48h delay)
+  - from: timelock
+    to: overseer-proxyadmin
+    kind: controls
+    label: owner (48h delay)
+  - from: timelock
+    to: wsthype-proxyadmin
+    kind: controls
+    label: owner (48h delay)
+  - from: sthype-proxyadmin
+    to: stHYPE
+    kind: manages
+    label: upgradeable proxy
+  - from: overseer-proxyadmin
+    to: overseer
+    kind: manages
+    label: upgradeable proxy
+  - from: wsthype-proxyadmin
+    to: wstHYPE
+    kind: manages
+    label: upgradeable proxy
+  - from: multisig
+    to: stHYPE
+    kind: holds-role
+    label: DEFAULT_ADMIN (no timelock)
+  - from: multisig
+    to: overseer
+    kind: holds-role
+    label: DEFAULT_ADMIN (no timelock)
+  - from: manager-role
+    to: overseer
+    kind: holds-role
+    label: MANAGER
+  - from: rebaser
+    to: stHYPE
+    kind: holds-role
+    label: REBASER
+
+  # === Mint authority on stHYPE ===
+  - from: overseer
+    to: stHYPE
+    kind: mints
+    label: MINTER_ROLE + BURNER_ROLE
+
+  # === Internal vault flow ===
+  - from: wstHYPE
+    to: stHYPE
+    kind: deposits-into
+    label: wraps stHYPE shares
+
+  # === Flow: deposits → Overseer → staking modules → validators ===
+  - from: stHYPE
+    to: overseer
+    kind: allocates-to
+    label: "100%"
+  - from: overseer
+    to: withdrawal-amm
+    kind: routes-through
+    label: AMM withdrawal leg
+  - from: overseer
+    to: staking-module-1
+    kind: deposits-into
+  - from: overseer
+    to: staking-module-2
+    kind: deposits-into
+  - from: overseer
+    to: staking-module-3
+    kind: deposits-into
+  - from: overseer
+    to: staking-module-4
+    kind: deposits-into
+  - from: overseer
+    to: staking-module-5
+    kind: deposits-into
+  - from: overseer
+    to: hyena-hip3
+    kind: routes-through
+    label: HIP-3 quote asset
+  - from: hyena-deployer
+    to: hyena-hip3
+    kind: manages
+
+  # === Staking modules → Hyperliquid validators ===
+  - from: staking-module-1
+    to: hyperliquid-l1
+    kind: deposits-into
+  - from: staking-module-2
+    to: hyperliquid-l1
+    kind: deposits-into
+  - from: staking-module-3
+    to: hyperliquid-l1
+    kind: deposits-into
+  - from: staking-module-4
+    to: hyperliquid-l1
+    kind: deposits-into
+  - from: staking-module-5
+    to: hyperliquid-l1
+    kind: deposits-into
+
+  # === Fees ===
+  - from: stHYPE
+    to: fee-recipient
+    kind: routes-fees-to

--- a/reports/graph/strata-srusde.yaml
+++ b/reports/graph/strata-srusde.yaml
@@ -1,0 +1,265 @@
+slug: strata-srusde
+title: Strata (srUSDe) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Strategy
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: srUSDe
+    label: srUSDe (Senior Tranche)
+    address: "0x3d7d6fdf07EE548B939A80edbc9B2256d0cdc003"
+    category: vault
+    note: ERC-4626 Meta Vault; principal-protected by junior tranche
+  - id: jrUSDe
+    label: jrUSDe (Junior Tranche)
+    address: "0xC58D044404d8B14e953C115E67823784dEA53d8F"
+    category: vault
+    note: ERC-4626 first-loss capital; ~$10M backing
+  - id: tranche-depositor
+    label: TrancheDepositor
+    address: "0x50E850641F43F65BF8fB3a7d0CF082a1D252F47e"
+    category: vault
+    note: Routes deposits into tranches (USDe/sUSDe/USDT/USDC/DAI)
+
+  # === Strategy ===
+  - id: strata-cdo
+    label: StrataCDO (Orchestrator)
+    address: "0x908B3921aaE4fC17191D382BB61020f2Ee6C0e20"
+    category: strategy
+    note: Core orchestrator across tranches/accounting/strategy
+  - id: susde-strategy
+    label: sUSDeStrategy
+    address: "0xdbf4FB6C310C1C85D0b41B5DbCA06096F2E7099F"
+    category: strategy
+    note: Deposits into Ethena sUSDe vault
+
+  # === Protocol infra ===
+  - id: accounting
+    label: Accounting (TVL / fees)
+    address: "0xa436c5Dd1Ba62c55D112C10cd10E988bb3355102"
+    category: infra
+    note: TVL calculations + DYS yield split
+  - id: erc20-cooldown
+    label: ERC20Cooldown
+    address: "0xd6dAD17d025cDdDEd27305aEbAB8b277996A6fAF"
+    category: infra
+    note: Token lockup during cooldown
+  - id: unstake-cooldown
+    label: UnstakeCooldown
+    address: "0x735edDF50Ca2371aa48466469C742e684c610F74"
+    category: infra
+    note: sUSDe unstaking cooldown (~7d)
+  - id: cooldown-request-impl
+    label: SUSDeCooldownRequestImpl
+    address: "0x00A96056c30A22b684fF7a09F4A0AfEaE426dde2"
+    category: infra
+  - id: apr-pair-feed
+    label: AprPairFeed
+    address: "0x2bb416614D740E5313aA64A0E3e419B39e800EC2"
+    category: infra
+    note: Benchmark + collateral APY inputs
+  - id: aave-apr-provider
+    label: AaveAprPairProvider
+    address: "0x1c137776e04803F807616c382AbBA12d9BF0AF73"
+    category: infra
+    note: Fetches benchmark APR from Aave v3
+  - id: two-step-config
+    label: TwoStepConfigManager
+    address: "0x0f93bAC77c3dDD1341d3Ecc388c5F8A180818994"
+    category: infra
+    note: Two-step exit-fee governance
+
+  # === Governance ===
+  - id: admin-multisig
+    label: Admin Multisig (3/4)
+    address: "0xA27cA9292268ee0f0258B749f1D5740c9Bb68B50"
+    category: governance
+    note: Gnosis Safe; internal team + founding contributors
+  - id: ops-multisig
+    label: Operational Multisig (2/3)
+    address: "0x4be3749a0F6557b8fd98F3967e859DbD7C694eF4"
+    category: governance
+    note: 2 signers overlap with Admin Safe
+  - id: timelock-48h
+    label: Timelock (48h)
+    address: "0xb2A3CF69C97AFD4dE7882E5fEE120e4efC77B706"
+    category: governance
+    note: Owns Ownable contracts; open EXECUTOR
+  - id: timelock-24h
+    label: Timelock (24h)
+    address: "0x4f2682b78F37910704fB1AFF29358A1da07E022d"
+    category: governance
+    note: Strategy config / reserves; NO EXECUTOR — inoperative
+  - id: guardian
+    label: Guardian (Patrick Collins)
+    address: "0x277D26a45Add5775F21256159F089769892CEa5B"
+    category: governance
+    note: Cyfrin CEO; CANCELLER on 48h timelock
+  - id: access-control-manager
+    label: AccessControlManager
+    address: "0x1d19E18ECaC4ef332a0d5d6Aa3a0f0f772605f60"
+    category: governance
+    note: Role-based access control
+  - id: cdo-proxyadmin
+    label: StrataCDO ProxyAdmin
+    address: "0xcAb791D0D44eBaC17378fF2AF6356c012F15c9e6"
+    category: governance
+  - id: cooldown-proxyadmin
+    label: ERC20Cooldown ProxyAdmin
+    address: "0xeD6c7b379F73DF0618406d263b13b2386E398166"
+    category: governance
+
+  # === External dependencies ===
+  - id: ethena-susde
+    label: Ethena sUSDe (Yield Source)
+    category: dependency
+    note: Delta-neutral ETH/BTC basis trade
+  - id: aave-v3
+    label: Aave v3 Core (Benchmark Rate)
+    category: dependency
+    note: Supply-weighted USDC/USDT lending rate
+
+edges:
+  # === Governance ===
+  - from: admin-multisig
+    to: timelock-48h
+    kind: proposes-on
+    label: PROPOSER
+  - from: admin-multisig
+    to: timelock-24h
+    kind: proposes-on
+    label: PROPOSER (no executor → blocked)
+  - from: guardian
+    to: timelock-48h
+    kind: cancels-on
+    label: CANCELLER
+  - from: admin-multisig
+    to: timelock-48h
+    kind: cancels-on
+    label: CANCELLER
+  - from: timelock-48h
+    to: cdo-proxyadmin
+    kind: controls
+    label: owner (48h delay)
+  - from: timelock-48h
+    to: cooldown-proxyadmin
+    kind: controls
+    label: owner (48h delay)
+  - from: cdo-proxyadmin
+    to: strata-cdo
+    kind: manages
+    label: upgradeable proxy
+  - from: cdo-proxyadmin
+    to: srUSDe
+    kind: manages
+    label: upgradeable proxy
+  - from: cdo-proxyadmin
+    to: jrUSDe
+    kind: manages
+    label: upgradeable proxy
+  - from: cdo-proxyadmin
+    to: susde-strategy
+    kind: manages
+    label: upgradeable proxy
+  - from: timelock-48h
+    to: access-control-manager
+    kind: holds-role
+    label: DEFAULT_ADMIN
+  - from: timelock-24h
+    to: access-control-manager
+    kind: holds-role
+    label: DEFAULT_ADMIN
+  - from: ops-multisig
+    to: strata-cdo
+    kind: holds-role
+    label: PAUSER_ROLE
+  - from: ops-multisig
+    to: accounting
+    kind: holds-role
+    label: UPDATER_FEED_ROLE
+  - from: admin-multisig
+    to: two-step-config
+    kind: holds-role
+    label: PROPOSER_CONFIG_ROLE
+  - from: ops-multisig
+    to: tranche-depositor
+    kind: holds-role
+    label: DEPOSITOR_CONFIG_ROLE
+  - from: timelock-24h
+    to: strata-cdo
+    kind: holds-role
+    label: RESERVE_MANAGER_ROLE (blocked)
+  - from: access-control-manager
+    to: strata-cdo
+    kind: manages
+    label: gates all roles
+
+  # === Internal flow: senior tranche → CDO → strategy → Ethena ===
+  - from: tranche-depositor
+    to: srUSDe
+    kind: routes-through
+    label: deposit routing
+  - from: tranche-depositor
+    to: jrUSDe
+    kind: routes-through
+    label: deposit routing
+  - from: srUSDe
+    to: strata-cdo
+    kind: allocates-to
+    label: "100% senior"
+  - from: jrUSDe
+    to: strata-cdo
+    kind: allocates-to
+    label: "100% junior (first-loss)"
+  - from: strata-cdo
+    to: susde-strategy
+    kind: routes-through
+    label: orchestrator → strategy
+  - from: susde-strategy
+    to: ethena-susde
+    kind: deposits-into
+    label: stake USDe → sUSDe
+
+  # === Infra wiring ===
+  - from: accounting
+    to: strata-cdo
+    kind: manages
+    label: TVL + fee accrual
+  - from: erc20-cooldown
+    to: srUSDe
+    kind: manages
+    label: withdrawal cooldown
+  - from: unstake-cooldown
+    to: susde-strategy
+    kind: manages
+    label: sUSDe unstaking
+  - from: cooldown-request-impl
+    to: unstake-cooldown
+    kind: manages
+  - from: apr-pair-feed
+    to: accounting
+    kind: manages
+    label: DYS APR inputs
+  - from: aave-apr-provider
+    to: apr-pair-feed
+    kind: routes-through
+    label: benchmark rate
+  - from: aave-apr-provider
+    to: aave-v3
+    kind: deposits-into
+    label: read USDC/USDT supply APR
+  - from: two-step-config
+    to: strata-cdo
+    kind: manages
+    label: exit-fee config

--- a/reports/graph/superstate-ustb.yaml
+++ b/reports/graph/superstate-ustb.yaml
@@ -1,0 +1,188 @@
+slug: superstate-ustb
+title: Superstate (USTB) — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Token
+  - id: governance
+    label: Governance / Owners
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Token layer ===
+  - id: ustb
+    label: USTB (Tokenized T-Bill Fund)
+    address: "0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e"
+    category: vault
+    note: EIP-1967 Proxy → SuperstateTokenV5_1
+
+  # === Protocol infra ===
+  - id: ustb-proxy-admin
+    label: USTB ProxyAdmin
+    address: "0xb9d285dcad879513dc9c1a3b2e0cccb21c3c2146"
+    category: infra
+  - id: allowlist
+    label: AllowList V3.1
+    address: "0x02f1fa8b196d21c7b733eb2700b825611d8a38e5"
+    category: infra
+    note: KYC-gated transfer allowlist
+  - id: allowlist-proxy-admin
+    label: AllowList ProxyAdmin
+    address: "0xb819692a58db9dd4d3b403a875439b6ca155c610"
+    category: infra
+  - id: redemption-idle
+    label: RedemptionIdle (USDC redeem)
+    address: "0x4c21b7577c8fe8b0b0669165ee7c8f67fa1454cf"
+    category: infra
+    note: Onchain USTB→USDC; ~$1.7M capacity
+  - id: redemption-proxy-admin
+    label: RedemptionIdle ProxyAdmin
+    address: "0xcaba8c12873fffed13431d98bf6b836dff08e869"
+    category: infra
+  - id: superstate-oracle
+    label: Superstate Continuous Price Oracle
+    address: "0xe4fa682f94610ccd170680cc3b045d77d9e528a8"
+    category: infra
+    note: Linear interpolation; 5d staleness
+  - id: usdc-sweep
+    label: USDC Sweep Destination (EOA)
+    address: "0x774AE279c21B6a17a6E2BD5ab5398FF98F398807"
+    category: infra
+
+  # === Governance (EOA owners — no multisig, no timelock) ===
+  - id: ustb-owner
+    label: USTB Owner (EOA)
+    address: "0xad309bb6f13074128b4f23ef9ea2fe8552afca83"
+    category: governance
+    note: Mint, adminBurn, pause, upgrade, oracle config
+  - id: allowlist-owner
+    label: AllowList Owner (EOA)
+    address: "0x7747940adbc7191f877a9b90596e0da4f8deb2fe"
+    category: governance
+    note: Whitelist + upgrade AllowList
+  - id: redemption-owner
+    label: RedemptionIdle Owner (EOA)
+    address: "0x8cf40e96e7d7fd8A7A9bEf70d3882fbBC4D40765"
+    category: governance
+    note: Pause, withdraw USDC, set fees, upgrade
+  - id: oracle-owner
+    label: Oracle Owner (EOA)
+    address: "0x4B1df64357a5D484563c9b7c16a80eD8B8fB1395"
+    category: governance
+    note: addCheckpoint (NAV pricing)
+
+  # === External dependencies ===
+  - id: dep-treasuries
+    label: U.S. Treasury Bills (Offchain)
+    category: dependency
+    note: ≥95% short-duration T-Bills + Agency
+  - id: dep-umb-bank
+    label: UMB Bank (Custodian)
+    category: dependency
+    note: OCC-regulated qualified custodian
+  - id: dep-federated-hermes
+    label: Federated Hermes (Sub-Advisor)
+    category: dependency
+    note: Daily portfolio management
+  - id: dep-chainlink-nav
+    label: Chainlink USTB NAV Feed
+    address: "0x289B5036cd942e619E1Ee48670F98d214E745AAC"
+    category: dependency
+    note: Independent NAV oracle
+  - id: dep-circle
+    label: Circle / USDC
+    category: dependency
+    note: Subscription + redemption rail
+
+edges:
+  # === Ownership (EOAs control proxies + tokens) ===
+  - from: ustb-owner
+    to: ustb-proxy-admin
+    kind: controls
+    label: owner (no timelock)
+  - from: ustb-proxy-admin
+    to: ustb
+    kind: manages
+    label: upgradeable proxy
+  - from: ustb-owner
+    to: ustb
+    kind: holds-role
+    label: owner (mint / adminBurn / pause)
+  - from: allowlist-owner
+    to: allowlist-proxy-admin
+    kind: controls
+    label: owner (no timelock)
+  - from: allowlist-proxy-admin
+    to: allowlist
+    kind: manages
+    label: upgradeable proxy
+  - from: allowlist-owner
+    to: allowlist
+    kind: holds-role
+    label: owner (whitelist)
+  - from: redemption-owner
+    to: redemption-proxy-admin
+    kind: controls
+    label: owner (no timelock)
+  - from: redemption-proxy-admin
+    to: redemption-idle
+    kind: manages
+    label: upgradeable proxy
+  - from: redemption-owner
+    to: redemption-idle
+    kind: holds-role
+    label: owner (pause / withdraw / fees)
+  - from: oracle-owner
+    to: superstate-oracle
+    kind: holds-role
+    label: owner (addCheckpoint)
+
+  # === Mint authority on USTB ===
+  - from: ustb-owner
+    to: ustb
+    kind: mints
+    label: mint / bulkMint / adminBurn
+
+  # === Internal wiring ===
+  - from: allowlist
+    to: ustb
+    kind: manages
+    label: transfer gate
+  - from: superstate-oracle
+    to: ustb
+    kind: routes-through
+    label: NAV/share for subscribe/redeem
+  - from: redemption-idle
+    to: ustb
+    kind: routes-through
+    label: USTB → USDC redemption
+  - from: redemption-idle
+    to: usdc-sweep
+    kind: routes-fees-to
+    label: USDC sweep
+
+  # === Backing & external dependencies ===
+  - from: ustb
+    to: dep-treasuries
+    kind: deposits-into
+    label: offchain T-Bill fund
+  - from: dep-treasuries
+    to: dep-umb-bank
+    kind: routes-through
+    label: custody
+  - from: dep-treasuries
+    to: dep-federated-hermes
+    kind: routes-through
+    label: sub-advisor
+  - from: redemption-idle
+    to: dep-circle
+    kind: routes-through
+    label: USDC rail
+  - from: ustb
+    to: dep-chainlink-nav
+    kind: routes-through
+    label: independent NAV feed

--- a/reports/graph/unit-ubtc.yaml
+++ b/reports/graph/unit-ubtc.yaml
@@ -1,0 +1,142 @@
+slug: unit-ubtc
+title: Unit Bitcoin (UBTC) — Contract Dependency Graph
+chain: hyperevm
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Custody
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # === Vault / token layer ===
+  - id: UBTC
+    label: UBTC (HyperEVM proxy)
+    address: "0x9FDBdA0A5e284c32744D2f17Ee5c74B284993463"
+    category: vault
+    note: UUPS ERC-1967 proxy; 8 decimals; 21M cap; verified
+  - id: ubtc-impl
+    label: UBTC Implementation
+    address: "0x1a7689c3b783eb37550efbb9c81e7f468f7034fc"
+    category: vault
+    note: UNVERIFIED; OZ ERC20Upgradeable + Ownable + UUPS + blacklist + compliance
+
+  # === Internal infra ===
+  - id: hypercore-treasury
+    label: HyperCore Treasury (EVM)
+    address: "0x574bAFCe69d9411f662a433896e74e4F153096FA"
+    category: infra
+    note: HyperCore treasury for UBTC reflection
+  - id: hypercore-deployer
+    label: HyperCore Token Deployer
+    address: "0xF036a5261406a394bd63Eb4dF49C464634a66155"
+    category: infra
+    note: Multi-sig user; HIP-1 native token (hardcoded coreDeployer())
+
+  # === Governance ===
+  - id: hyperevm-owner
+    label: HyperEVM Deployer / Owner
+    address: "0xB4FC973924a91362D301E583E839Cdaf4f19cdF8"
+    category: governance
+    note: EOA onchain; claimed-MPC offchain. Holds owner() + complianceAuthority()
+  - id: guardian-network
+    label: Guardian Network (2-of-3 MPC TSS)
+    category: governance
+    note: Unit + Hyperliquid + Infinite Field; DKG keyshares in AWS Nitro enclaves
+
+  # === Custody (offchain) ===
+  - id: btc-treasury
+    label: Bitcoin Treasury
+    category: strategy
+    note: "bc1pdwu79dady576y3fupmm82m3g7p2p9f6hgyeqy0tdg7ztxg7xrayqlkl8j9 — 3,361.95 BTC vs 3,273 UBTC"
+
+  # === External dependencies ===
+  - id: dep-bitcoin
+    label: Bitcoin Network
+    category: dependency
+    note: Native BTC custody chain; 2-conf required
+  - id: dep-hyperliquid-l1
+    label: Hyperliquid L1 (HyperBFT)
+    category: dependency
+    note: Hyper Foundation 56.4% validator stake
+  - id: dep-aws-nitro
+    label: AWS Nitro Enclaves + KMS
+    category: dependency
+    note: Guardian secure enclaves + key encryption at rest
+  - id: dep-morpho
+    label: Morpho Blue UBTC-USDC Market
+    category: dependency
+    note: Market id 0x45af9c…942f; 77% LLTV; uses UBTC as collateral
+
+edges:
+  # === Governance ===
+  - from: hyperevm-owner
+    to: UBTC
+    kind: holds-role
+    label: owner() — UUPS upgrade (no timelock)
+  - from: hyperevm-owner
+    to: UBTC
+    kind: holds-role
+    label: complianceAuthority() — blacklist control
+  - from: guardian-network
+    to: hyperevm-owner
+    kind: controls
+    label: claimed-MPC (offchain only)
+  - from: guardian-network
+    to: btc-treasury
+    kind: controls
+    label: 2-of-3 TSS co-sign Bitcoin spends
+  - from: guardian-network
+    to: hypercore-deployer
+    kind: controls
+    label: HIP-1 multisig user
+
+  # === Mint authority (HyperCore-side) ===
+  - from: hypercore-deployer
+    to: UBTC
+    kind: mints
+    label: HIP-1 native supply via HyperCore↔HyperEVM bridge
+
+  # === Internal vault / bridge flow ===
+  - from: UBTC
+    to: ubtc-impl
+    kind: routes-through
+    label: ERC-1967 delegate (UUPS)
+  - from: hypercore-treasury
+    to: UBTC
+    kind: routes-through
+    label: HyperCore↔HyperEVM bridge reflection
+  - from: hypercore-deployer
+    to: hypercore-treasury
+    kind: manages
+    label: HyperCore token deployer
+
+  # === Bridge custody ===
+  - from: UBTC
+    to: btc-treasury
+    kind: allocates-to
+    label: 1:1 BTC backing (over-backed ~2.7%)
+  - from: btc-treasury
+    to: dep-bitcoin
+    kind: deposits-into
+    label: native BTC custody
+
+  # === External dependencies ===
+  - from: UBTC
+    to: dep-hyperliquid-l1
+    kind: routes-through
+    label: HyperBFT consensus
+  - from: guardian-network
+    to: dep-aws-nitro
+    kind: routes-through
+    label: secure enclave + KMS
+  - from: UBTC
+    to: dep-morpho
+    kind: deposits-into
+    label: collateral on UBTC-USDC market

--- a/reports/graph/yearn-yvdai.yaml
+++ b/reports/graph/yearn-yvdai.yaml
@@ -1,0 +1,184 @@
+slug: yearn-yvdai
+title: yvDAI-1 — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault
+  - id: strategy
+    label: Strategy
+  - id: governance
+    label: Governance / Multisig
+  - id: infra
+    label: Yearn Infra / Bot
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # Vault layer
+  - id: yvDAI
+    label: yvDAI-1
+    address: "0x028eC7330ff87667b6dfb0D94b954c820195336c"
+    category: vault
+  - id: accountant
+    label: Accountant (0% mgmt, 10% perf)
+    address: "0x5A74Cb32D36f2f517DB6f7b0A0591e09b22cDE69"
+    category: vault
+  - id: dumper
+    label: Fee Recipient (Dumper)
+    address: "0x590Dd9399bB53f1085097399C3265C7137c1C4Cf"
+    category: vault
+
+  # Governance
+  - id: daddy
+    label: Daddy / ySafe (6-of-9)
+    address: "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"
+    category: governance
+  - id: brain
+    label: Brain (3-of-8)
+    address: "0x16388463d60FFE0661Cf7F1f31a7D658aC790ff7"
+    category: governance
+  - id: security
+    label: Security (4-of-7)
+    address: "0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"
+    category: governance
+  - id: timelock
+    label: Strategy Manager (7-day Timelock)
+    address: "0x88Ba032be87d5EF1fbE87336b7090767F367BF73"
+    category: governance
+  - id: role-manager
+    label: Yearn V3 Role Manager
+    address: "0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41"
+    category: governance
+
+  # Infra / bots
+  - id: keeper
+    label: Keeper (yHaaSRelayer)
+    address: "0x604e586F17cE106B64185A7a0d2c1Da5bAce711E"
+    category: infra
+  - id: debt-allocator
+    label: Debt Allocator
+    address: "0x1e9eB053228B1156831759401dE0E115356b8671"
+    category: infra
+  - id: vault-factory
+    label: Vault Factory (v3.0.2)
+    address: "0x444045c5C13C246e117eD36437303cac8E250aB0"
+    category: infra
+
+  # Strategies
+  - id: dai-to-usdc-depositor
+    label: DAI → yvUSDC-1 Depositor (72.97%)
+    address: "0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5"
+    category: strategy
+  - id: dai-to-usds-depositor
+    label: DAI → yvUSDS-1 Depositor (27.03%)
+    address: "0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d"
+    category: strategy
+
+  # External dependencies (cross-linked Yearn vaults)
+  - id: yvUSDC
+    label: yvUSDC-1 (intermediate vault)
+    address: "0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204"
+    category: dependency
+  - id: yvUSDS
+    label: yvUSDS-1 (intermediate vault)
+    address: "0x182863131F9a4630fF9E27830d945B1413e347E8"
+    category: dependency
+
+  # External dependencies (Sky conversion infrastructure)
+  - id: psm-lite
+    label: MakerDAO PSM Lite (DAI ↔ USDC)
+    address: "0xf6e72Db5454dd049d0788e411b06CfAF16853042"
+    category: dependency
+  - id: dai-usds-exchanger
+    label: Sky DAI ↔ USDS Exchanger
+    address: "0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A"
+    category: dependency
+
+edges:
+  # Deployment / vault infrastructure
+  - from: vault-factory
+    to: yvDAI
+    kind: deploys
+    label: minimal proxy
+  - from: yvDAI
+    to: accountant
+    kind: routes-fees-to
+  - from: accountant
+    to: dumper
+    kind: routes-fees-to
+
+  # Vault → strategies (allocation)
+  - from: yvDAI
+    to: dai-to-usdc-depositor
+    kind: allocates-to
+    label: "72.97%"
+  - from: yvDAI
+    to: dai-to-usds-depositor
+    kind: allocates-to
+    label: "27.03%"
+
+  # Governance roles on vault
+  - from: daddy
+    to: yvDAI
+    kind: holds-role
+    label: "all 14 roles"
+  - from: brain
+    to: yvDAI
+    kind: holds-role
+    label: "QUEUE / DEBT / EMERGENCY"
+  - from: security
+    to: yvDAI
+    kind: holds-role
+    label: "DEBT / MAX_DEBT / EMERGENCY"
+  - from: timelock
+    to: yvDAI
+    kind: holds-role
+    label: "ADD_STRATEGY (7d)"
+  - from: keeper
+    to: yvDAI
+    kind: holds-role
+    label: "REPORTING"
+  - from: debt-allocator
+    to: yvDAI
+    kind: holds-role
+    label: "REPORTING + DEBT_MANAGER"
+
+  # Role manager wiring
+  - from: daddy
+    to: role-manager
+    kind: controls
+  - from: security
+    to: role-manager
+    kind: controls
+  - from: role-manager
+    to: yvDAI
+    kind: manages
+
+  # Timelock flow
+  - from: daddy
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR
+  - from: brain
+    to: timelock
+    kind: cancels-on
+    label: CANCELLER
+
+  # Strategy → intermediate vault pipelines (vault-of-vaults)
+  - from: dai-to-usdc-depositor
+    to: psm-lite
+    kind: routes-through
+    label: "DAI → USDC"
+  - from: dai-to-usdc-depositor
+    to: yvUSDC
+    kind: deposits-into
+    label: "USDC → yvUSDC-1"
+  - from: dai-to-usds-depositor
+    to: dai-usds-exchanger
+    kind: routes-through
+    label: "DAI → USDS"
+  - from: dai-to-usds-depositor
+    to: yvUSDS
+    kind: deposits-into
+    label: "USDS → yvUSDS-1"

--- a/reports/graph/yearn-yvusd.yaml
+++ b/reports/graph/yearn-yvusd.yaml
@@ -1,0 +1,279 @@
+slug: yearn-yvusd
+title: yvUSD — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault
+  - id: strategy
+    label: Strategy
+  - id: governance
+    label: Governance / Multisig
+  - id: infra
+    label: Yearn Infra / Bot
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # Vault layer
+  - id: yvUSD
+    label: yvUSD
+    address: "0x696d02Db93291651ED510704c9b286841d506987"
+    category: vault
+  - id: locked-yvusd
+    label: LockedyvUSD (Cooldown + Accountant)
+    address: "0xAaaFEa48472f77563961Cdb53291DEDfB46F9040"
+    category: vault
+    note: 14d cooldown + 5d withdraw window; also serves as accountant
+  - id: fee-splitter
+    label: Fee Splitter
+    address: "0xd744B7D6bE69b334766802245Db2895e861cb470"
+    category: vault
+    note: Governance still held by Deployer EOA (low-impact)
+
+  # Governance
+  - id: daddy
+    label: Daddy / ySafe (6-of-9)
+    address: "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"
+    category: governance
+  - id: brain
+    label: Brain (3-of-8)
+    address: "0x16388463d60FFE0661Cf7F1f31a7D658aC790ff7"
+    category: governance
+  - id: security
+    label: Security (4-of-7)
+    address: "0xe5e2BAf96198c56380DDd5e992D7d1adA0E989C0"
+    category: governance
+  - id: timelock
+    label: Strategy Manager (7-day Timelock)
+    address: "0x88ba032be87d5eF1FbE87336b7090767f367bF73"
+    category: governance
+  - id: role-manager
+    label: Yearn V3 Role Manager
+    address: "0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41"
+    category: governance
+  - id: deployer-eoa
+    label: Deployer EOA (Fee Splitter only)
+    address: "0x1b5f15DCb82d25f91c65b53CEe151E8b9fBdD271"
+    category: governance
+    note: 0 vault roles; retains Fee Splitter governance
+
+  # Infra / bots
+  - id: keeper
+    label: Keeper (yHaaSRelayer)
+    address: "0x604e586F17cE106B64185a7A0d2c1DA5BaCe711e"
+    category: infra
+  - id: debt-allocator
+    label: Debt Allocator
+    address: "0x1E9eB053228B1156831759401DE0E115356b8671"
+    category: infra
+  - id: vault-factory
+    label: Vault Factory (v3.0.4)
+    address: "0x770D0d1Fb036483Ed4AbB6d53c1C88fb277D812F"
+    category: infra
+
+  # Strategies (≥1% TVL only; 4 strategies with 0%/<1% omitted)
+  - id: syrup-morpho-looper
+    label: syrupUSDC/USDC Morpho Looper (43.35%)
+    address: "0xF28DC8B6DeD7E45F8cf84B9972487C8e1857A442"
+    category: strategy
+  - id: morpho-yearn-og
+    label: Morpho Yearn OG USDC Compounder (24.08%)
+    address: "0x0e297dE4005883C757c9F09fdF7cF1363C20e626"
+    category: strategy
+  - id: infinifi-siusd-looper
+    label: InfiniFi sIUSD Morpho Looper (15.20%)
+    address: "0x5f9DBa2805411a8382FDb4E69d4f2Da8EFaF1F89"
+    category: strategy
+  - id: usdc-to-susds
+    label: USDC → sUSDS Depositor (10.45%)
+    address: "0x7130570BCEfCedBe9d15B5b11A33006156460f8f"
+    category: strategy
+  - id: usdc-to-spark-usds
+    label: USDC → Spark USDS Depositor (2.49%)
+    address: "0x9e0A5943dFc1A85B48C191aa7c10487297aA675b"
+    category: strategy
+  - id: arb-syrup-looper
+    label: Arbitrum syrupUSDC Morpho Looper (2.48%)
+    address: "0x2F56D106C6Df739bdbb777C2feE79FFaED88D179"
+    category: strategy
+  - id: usd3-pendle-pt
+    label: USD3 Pendle PT Maxi (1.24%)
+    address: "0x4C0e4d3cB62B91afBbf1Fe8e830f98A513c7234b"
+    category: strategy
+
+  # External dependencies
+  - id: maple-syrupusdc
+    label: Maple syrupUSDC
+    address: "0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b"
+    category: dependency
+    note: Overcollateralized institutional lending (~$1.7B TVL)
+  - id: morpho-yearn-og-vault
+    label: Morpho Yearn OG USDC Vault
+    category: dependency
+    note: Morpho MetaMorpho vault
+  - id: infinifi-siusd
+    label: InfiniFi siUSD
+    address: "0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB"
+    category: dependency
+  - id: sky-susds
+    label: Sky / sUSDS (Savings Rate)
+    address: "0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD"
+    category: dependency
+  - id: spark-usds-market
+    label: Spark USDS Market (Sky sub-DAO)
+    category: dependency
+  - id: pendle-usd3-pt
+    label: Pendle USD3 PT
+    category: dependency
+    note: Fixed-rate PT backed by 3Jane USD3
+  - id: cctp
+    label: Circle CCTP (cross-chain bridge)
+    category: dependency
+    note: Origin → Arbitrum; trust-minimized, Circle attestation
+  - id: morpho-protocol
+    label: Morpho Protocol (lending base)
+    category: dependency
+    note: Used by all looper strategies and Yearn OG compounder
+
+edges:
+  # Deployment / vault infrastructure
+  - from: vault-factory
+    to: yvUSD
+    kind: deploys
+    label: minimal proxy
+  - from: yvUSD
+    to: locked-yvusd
+    kind: routes-fees-to
+    label: accountant
+  - from: locked-yvusd
+    to: fee-splitter
+    kind: routes-fees-to
+
+  # Vault → strategies (allocation)
+  - from: yvUSD
+    to: syrup-morpho-looper
+    kind: allocates-to
+    label: "43.35%"
+  - from: yvUSD
+    to: morpho-yearn-og
+    kind: allocates-to
+    label: "24.08%"
+  - from: yvUSD
+    to: infinifi-siusd-looper
+    kind: allocates-to
+    label: "15.20%"
+  - from: yvUSD
+    to: usdc-to-susds
+    kind: allocates-to
+    label: "10.45%"
+  - from: yvUSD
+    to: usdc-to-spark-usds
+    kind: allocates-to
+    label: "2.49%"
+  - from: yvUSD
+    to: arb-syrup-looper
+    kind: allocates-to
+    label: "2.48%"
+  - from: yvUSD
+    to: usd3-pendle-pt
+    kind: allocates-to
+    label: "1.24%"
+
+  # Governance roles on vault
+  - from: daddy
+    to: yvUSD
+    kind: holds-role
+    label: "bitmask 0x3FF6 (nearly all roles)"
+  - from: brain
+    to: yvUSD
+    kind: holds-role
+    label: "QUEUE / DEBT / EMERGENCY"
+  - from: security
+    to: yvUSD
+    kind: holds-role
+    label: "DEBT / MAX_DEBT / EMERGENCY"
+  - from: timelock
+    to: yvUSD
+    kind: holds-role
+    label: "ADD_STRATEGY (7d)"
+  - from: keeper
+    to: yvUSD
+    kind: holds-role
+    label: "REPORTING"
+  - from: debt-allocator
+    to: yvUSD
+    kind: holds-role
+    label: "REPORTING + DEBT_MANAGER"
+
+  # Role manager wiring
+  - from: daddy
+    to: role-manager
+    kind: controls
+  - from: security
+    to: role-manager
+    kind: controls
+  - from: role-manager
+    to: yvUSD
+    kind: manages
+
+  # Timelock flow
+  - from: daddy
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR
+  - from: brain
+    to: timelock
+    kind: cancels-on
+    label: CANCELLER
+
+  # Deployer EOA → Fee Splitter (residual governance)
+  - from: deployer-eoa
+    to: fee-splitter
+    kind: controls
+    label: "sole governance"
+
+  # Strategy → underlying protocol pipelines
+  - from: syrup-morpho-looper
+    to: maple-syrupusdc
+    kind: deposits-into
+    label: "syrupUSDC collateral"
+  - from: syrup-morpho-looper
+    to: morpho-protocol
+    kind: routes-through
+    label: "loop borrow"
+  - from: morpho-yearn-og
+    to: morpho-yearn-og-vault
+    kind: deposits-into
+    label: "USDC deposit"
+  - from: morpho-yearn-og-vault
+    to: morpho-protocol
+    kind: routes-through
+  - from: infinifi-siusd-looper
+    to: infinifi-siusd
+    kind: deposits-into
+    label: "siUSD collateral"
+  - from: infinifi-siusd-looper
+    to: morpho-protocol
+    kind: routes-through
+    label: "loop borrow"
+  - from: usdc-to-susds
+    to: sky-susds
+    kind: deposits-into
+    label: "USDC → sUSDS"
+  - from: usdc-to-spark-usds
+    to: spark-usds-market
+    kind: deposits-into
+    label: "USDS supply"
+  - from: arb-syrup-looper
+    to: cctp
+    kind: routes-through
+    label: "USDC → Arbitrum"
+  - from: arb-syrup-looper
+    to: maple-syrupusdc
+    kind: deposits-into
+    label: "syrupUSDC collateral (Arb)"
+  - from: usd3-pendle-pt
+    to: pendle-usd3-pt
+    kind: deposits-into
+    label: "PT-USD3"

--- a/reports/graph/yearn-yvusds.yaml
+++ b/reports/graph/yearn-yvusds.yaml
@@ -1,0 +1,186 @@
+slug: yearn-yvusds
+title: yvUSDS-1 — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault
+  - id: strategy
+    label: Strategy
+  - id: governance
+    label: Governance / Multisig
+  - id: infra
+    label: Yearn Infra / Bot
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # Vault layer
+  - id: yvUSDS
+    label: yvUSDS-1
+    address: "0x182863131F9a4630fF9E27830d945B1413e347E8"
+    category: vault
+  - id: accountant
+    label: Accountant (0% mgmt, 10% perf)
+    address: "0x5A74Cb32D36f2f517DB6f7b0A0591e09b22cDE69"
+    category: vault
+  - id: dumper
+    label: Fee Recipient (Dumper)
+    address: "0x590Dd9399bB53f1085097399C3265C7137c1C4Cf"
+    category: vault
+
+  # Governance
+  - id: daddy
+    label: Daddy / ySafe (6-of-9)
+    address: "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"
+    category: governance
+  - id: brain
+    label: Brain (3-of-8)
+    address: "0x16388463d60FFE0661Cf7F1f31a7D658aC790ff7"
+    category: governance
+  - id: security
+    label: Security (4-of-7)
+    address: "0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"
+    category: governance
+  - id: timelock
+    label: Strategy Manager (7-day Timelock)
+    address: "0x88Ba032be87d5EF1fbE87336b7090767F367BF73"
+    category: governance
+  - id: role-manager
+    label: Yearn V3 Role Manager
+    address: "0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41"
+    category: governance
+
+  # Infra / bots
+  - id: keeper
+    label: Keeper (yHaaSRelayer)
+    address: "0x604e586F17cE106B64185A7a0d2c1Da5bAce711E"
+    category: infra
+  - id: debt-allocator
+    label: Debt Allocator
+    address: "0x1e9eB053228B1156831759401dE0E115356b8671"
+    category: infra
+  - id: vault-factory
+    label: Vault Factory (v3.0.3)
+    address: "0x5577EdcB8A856582297CdBbB07055E6a6E38eb5f"
+    category: infra
+
+  # Strategies
+  - id: susds-lender
+    label: sUSDS Lender (80.03%)
+    address: "0x3F2dE801629116A83B9734bB72012A554e01CfC1"
+    category: strategy
+  - id: spark-usds-compounder
+    label: Spark USDS Compounder (19.97%)
+    address: "0xc9f01b5c6048B064E6d925d1c2d7206d4fEeF8a3"
+    category: strategy
+  - id: usds-sky-rewards-compounder
+    label: USDS Sky Rewards Compounder (queued, 0%)
+    address: "0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81"
+    category: strategy
+
+  # External dependencies
+  - id: sky-susds
+    label: Sky / sUSDS (Savings Rate)
+    address: "0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD"
+    category: dependency
+  - id: usds-staking-rewards
+    label: Sky USDS Staking Rewards (SPK farm)
+    address: "0x173e314C7635B45322cd8Cb14f44b312e079F3af"
+    category: dependency
+  - id: spk-token
+    label: SPK Reward Token
+    address: "0xc20059e0317DE91738d13af027DfC4a50781b066"
+    category: dependency
+
+edges:
+  # Deployment / vault infrastructure
+  - from: vault-factory
+    to: yvUSDS
+    kind: deploys
+    label: minimal proxy
+  - from: yvUSDS
+    to: accountant
+    kind: routes-fees-to
+  - from: accountant
+    to: dumper
+    kind: routes-fees-to
+
+  # Vault → strategies (allocation)
+  - from: yvUSDS
+    to: susds-lender
+    kind: allocates-to
+    label: "80.03%"
+  - from: yvUSDS
+    to: spark-usds-compounder
+    kind: allocates-to
+    label: "19.97%"
+  - from: yvUSDS
+    to: usds-sky-rewards-compounder
+    kind: allocates-to
+    label: "queued"
+
+  # Governance roles on vault
+  - from: daddy
+    to: yvUSDS
+    kind: holds-role
+    label: "all 14 roles"
+  - from: brain
+    to: yvUSDS
+    kind: holds-role
+    label: "QUEUE / DEBT / EMERGENCY"
+  - from: security
+    to: yvUSDS
+    kind: holds-role
+    label: "DEBT / MAX_DEBT / EMERGENCY"
+  - from: timelock
+    to: yvUSDS
+    kind: holds-role
+    label: "ADD_STRATEGY (7d)"
+  - from: keeper
+    to: yvUSDS
+    kind: holds-role
+    label: "REPORTING"
+  - from: debt-allocator
+    to: yvUSDS
+    kind: holds-role
+    label: "REPORTING + DEBT_MANAGER"
+
+  # Role manager wiring
+  - from: daddy
+    to: role-manager
+    kind: controls
+  - from: security
+    to: role-manager
+    kind: controls
+  - from: role-manager
+    to: yvUSDS
+    kind: manages
+
+  # Timelock flow
+  - from: daddy
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR
+  - from: brain
+    to: timelock
+    kind: cancels-on
+    label: CANCELLER
+
+  # Strategy → underlying protocol
+  - from: susds-lender
+    to: sky-susds
+    kind: deposits-into
+    label: "USDS → sUSDS"
+  - from: spark-usds-compounder
+    to: usds-staking-rewards
+    kind: deposits-into
+    label: "USDS stake → SPK rewards"
+  - from: spark-usds-compounder
+    to: spk-token
+    kind: routes-through
+    label: "harvest SPK → USDS"
+  - from: usds-sky-rewards-compounder
+    to: usds-staking-rewards
+    kind: deposits-into
+    label: "USDS stake (queued)"

--- a/reports/graph/yearn-yvusdt.yaml
+++ b/reports/graph/yearn-yvusdt.yaml
@@ -1,0 +1,182 @@
+slug: yearn-yvusdt
+title: yvUSDT-1 — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault
+  - id: strategy
+    label: Strategy
+  - id: governance
+    label: Governance / Multisig
+  - id: infra
+    label: Yearn Infra / Bot
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # Vault layer
+  - id: yvUSDT
+    label: yvUSDT-1
+    address: "0x310B7Ea7475A0B449Cfd73bE81522F1B88eFAFaa"
+    category: vault
+  - id: accountant
+    label: Accountant (0% mgmt, 10% perf)
+    address: "0x5A74Cb32D36f2f517DB6f7b0A0591e09b22cDE69"
+    category: vault
+  - id: dumper
+    label: Fee Recipient (Dumper)
+    address: "0x590Dd9399bB53f1085097399C3265C7137c1C4Cf"
+    category: vault
+
+  # Governance
+  - id: daddy
+    label: Daddy / ySafe (6-of-9)
+    address: "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"
+    category: governance
+  - id: brain
+    label: Brain (3-of-8)
+    address: "0x16388463d60FFE0661Cf7F1f31a7D658aC790ff7"
+    category: governance
+  - id: security
+    label: Security (4-of-7)
+    address: "0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"
+    category: governance
+  - id: timelock
+    label: Strategy Manager (7-day Timelock)
+    address: "0x88Ba032be87d5EF1fbE87336b7090767F367BF73"
+    category: governance
+  - id: role-manager
+    label: Yearn V3 Role Manager
+    address: "0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41"
+    category: governance
+
+  # Infra / bots
+  - id: keeper
+    label: Keeper (yHaaSRelayer)
+    address: "0x604e586F17cE106B64185A7a0d2c1Da5bAce711E"
+    category: infra
+  - id: debt-allocator
+    label: Debt Allocator
+    address: "0x1e9eB053228B1156831759401dE0E115356b8671"
+    category: infra
+  - id: vault-factory
+    label: Vault Factory (v3.0.2)
+    address: "0x444045c5C13C246e117eD36437303cac8E250aB0"
+    category: infra
+
+  # Strategies
+  - id: spark-usdt-lender
+    label: Spark USDT Lender (45.58%)
+    address: "0xED48069a2b9982B4eec646CBfA7b81d181f9400B"
+    category: strategy
+  - id: morpho-gauntlet-usdt
+    label: Morpho Gauntlet USDT Prime (54.42%)
+    address: "0x6D2981FF9b8d7edbb7604de7A65BAC8694ac849F"
+    category: strategy
+  - id: morpho-steakhouse-usdt
+    label: Morpho Steakhouse USDT (queued, 0%)
+    address: "0x0a4ea2bDe8496a878a7ca2772056a8e6fe3245c5"
+    category: strategy
+
+  # External dependencies
+  - id: spark-lend-usdt
+    label: Spark Lend USDT Market
+    category: dependency
+    note: Sky sub-DAO; admin keys live under Sky governance
+  - id: morpho-gauntlet-vault
+    label: Morpho Gauntlet USDT Prime Vault
+    category: dependency
+    note: Gauntlet-curated Morpho MetaMorpho vault
+  - id: morpho-steakhouse-vault
+    label: Morpho Steakhouse USDT Vault
+    category: dependency
+    note: Steakhouse-curated Morpho MetaMorpho vault
+
+edges:
+  # Deployment / vault infrastructure
+  - from: vault-factory
+    to: yvUSDT
+    kind: deploys
+    label: minimal proxy
+  - from: yvUSDT
+    to: accountant
+    kind: routes-fees-to
+  - from: accountant
+    to: dumper
+    kind: routes-fees-to
+
+  # Vault → strategies (allocation)
+  - from: yvUSDT
+    to: spark-usdt-lender
+    kind: allocates-to
+    label: "45.58%"
+  - from: yvUSDT
+    to: morpho-gauntlet-usdt
+    kind: allocates-to
+    label: "54.42%"
+  - from: yvUSDT
+    to: morpho-steakhouse-usdt
+    kind: allocates-to
+    label: "queued"
+
+  # Governance roles on vault
+  - from: daddy
+    to: yvUSDT
+    kind: holds-role
+    label: "all 14 roles"
+  - from: brain
+    to: yvUSDT
+    kind: holds-role
+    label: "QUEUE / DEBT / EMERGENCY"
+  - from: security
+    to: yvUSDT
+    kind: holds-role
+    label: "DEBT / MAX_DEBT / EMERGENCY"
+  - from: timelock
+    to: yvUSDT
+    kind: holds-role
+    label: "ADD_STRATEGY (7d)"
+  - from: keeper
+    to: yvUSDT
+    kind: holds-role
+    label: "REPORTING"
+  - from: debt-allocator
+    to: yvUSDT
+    kind: holds-role
+    label: "REPORTING + DEBT_MANAGER"
+
+  # Role manager wiring
+  - from: daddy
+    to: role-manager
+    kind: controls
+  - from: security
+    to: role-manager
+    kind: controls
+  - from: role-manager
+    to: yvUSDT
+    kind: manages
+
+  # Timelock flow
+  - from: daddy
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR
+  - from: brain
+    to: timelock
+    kind: cancels-on
+    label: CANCELLER
+
+  # Strategy → underlying protocol
+  - from: spark-usdt-lender
+    to: spark-lend-usdt
+    kind: deposits-into
+    label: "USDT supply"
+  - from: morpho-gauntlet-usdt
+    to: morpho-gauntlet-vault
+    kind: deposits-into
+    label: "USDT deposit"
+  - from: morpho-steakhouse-usdt
+    to: morpho-steakhouse-vault
+    kind: deposits-into
+    label: "USDT deposit (queued)"

--- a/reports/graph/yearn-yvwbtc.yaml
+++ b/reports/graph/yearn-yvwbtc.yaml
@@ -1,0 +1,137 @@
+slug: yearn-yvwbtc
+title: yvWBTC-1 — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault
+  - id: governance
+    label: Governance / Multisig
+  - id: infra
+    label: Yearn Infra / Bot
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # Vault layer
+  - id: yvWBTC
+    label: yvWBTC-1 (100% idle, empty queue)
+    address: "0x751F0cC6115410A3eE9eC92d08f46Ff6Da98b708"
+    category: vault
+  - id: accountant
+    label: Accountant (0% mgmt, 10% perf)
+    address: "0x5A74Cb32D36f2f517DB6f7b0A0591e09b22cDE69"
+    category: vault
+  - id: dumper
+    label: Fee Recipient (Dumper)
+    address: "0x590Dd9399bB53f1085097399C3265C7137c1C4Cf"
+    category: vault
+
+  # Governance
+  - id: daddy
+    label: Daddy / ySafe (6-of-9)
+    address: "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"
+    category: governance
+  - id: brain
+    label: Brain (3-of-8)
+    address: "0x16388463d60FFE0661Cf7F1f31a7D658aC790ff7"
+    category: governance
+  - id: security
+    label: Security (4-of-7)
+    address: "0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"
+    category: governance
+  - id: timelock
+    label: Strategy Manager (7-day Timelock)
+    address: "0x88Ba032be87d5EF1fbE87336b7090767F367BF73"
+    category: governance
+  - id: role-manager
+    label: Yearn V3 Role Manager
+    address: "0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41"
+    category: governance
+
+  # Infra / bots
+  - id: keeper
+    label: Keeper (yHaaSRelayer)
+    address: "0x604e586F17cE106B64185A7a0d2c1Da5bAce711E"
+    category: infra
+  - id: debt-allocator
+    label: Debt Allocator
+    address: "0x1e9eB053228B1156831759401dE0E115356b8671"
+    category: infra
+  - id: vault-factory
+    label: Vault Factory (v3.0.4)
+    address: "0x770D0d1Fb036483Ed4AbB6d53c1C88fb277D812F"
+    category: infra
+
+  # Underlying asset (only dependency at snapshot)
+  - id: wbtc
+    label: WBTC (BitGo-custodied)
+    address: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+    category: dependency
+    note: Underlying asset only — no strategies attached at the snapshot
+
+edges:
+  # Deployment / vault infrastructure
+  - from: vault-factory
+    to: yvWBTC
+    kind: deploys
+    label: minimal proxy
+  - from: yvWBTC
+    to: accountant
+    kind: routes-fees-to
+  - from: accountant
+    to: dumper
+    kind: routes-fees-to
+
+  # Vault holds underlying directly (100% idle)
+  - from: yvWBTC
+    to: wbtc
+    kind: deposits-into
+    label: "100% idle (held at vault)"
+
+  # Governance roles on vault
+  - from: daddy
+    to: yvWBTC
+    kind: holds-role
+    label: "all 14 roles"
+  - from: brain
+    to: yvWBTC
+    kind: holds-role
+    label: "QUEUE / DEBT / EMERGENCY"
+  - from: security
+    to: yvWBTC
+    kind: holds-role
+    label: "DEBT / MAX_DEBT / EMERGENCY"
+  - from: timelock
+    to: yvWBTC
+    kind: holds-role
+    label: "ADD_STRATEGY (7d)"
+  - from: keeper
+    to: yvWBTC
+    kind: holds-role
+    label: "REPORTING"
+  - from: debt-allocator
+    to: yvWBTC
+    kind: holds-role
+    label: "REPORTING + DEBT_MANAGER"
+
+  # Role manager wiring
+  - from: daddy
+    to: role-manager
+    kind: controls
+  - from: security
+    to: role-manager
+    kind: controls
+  - from: role-manager
+    to: yvWBTC
+    kind: manages
+
+  # Timelock flow
+  - from: daddy
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR
+  - from: brain
+    to: timelock
+    kind: cancels-on
+    label: CANCELLER

--- a/reports/graph/yearn-yvweth.yaml
+++ b/reports/graph/yearn-yvweth.yaml
@@ -1,0 +1,198 @@
+slug: yearn-yvweth
+title: yvWETH-1 — Contract Dependency Graph
+chain: ethereum
+
+categories:
+  - id: vault
+    label: Vault
+  - id: strategy
+    label: Strategy
+  - id: governance
+    label: Governance / Multisig
+  - id: infra
+    label: Yearn Infra / Bot
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  # Vault layer
+  - id: yvWETH
+    label: yvWETH-1
+    address: "0xc56413869c6CDf96496f2b1eF801fEDBdFA7dDB0"
+    category: vault
+  - id: accountant
+    label: Accountant (0% mgmt, 10% perf)
+    address: "0x5A74Cb32D36f2f517DB6f7b0A0591e09b22cDE69"
+    category: vault
+  - id: dumper
+    label: Fee Recipient (Dumper)
+    address: "0x590Dd9399bB53f1085097399C3265C7137c1C4Cf"
+    category: vault
+
+  # Governance
+  - id: daddy
+    label: Daddy / ySafe (6-of-9)
+    address: "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"
+    category: governance
+  - id: brain
+    label: Brain (3-of-8)
+    address: "0x16388463d60FFE0661Cf7F1f31a7D658aC790ff7"
+    category: governance
+  - id: security
+    label: Security (4-of-7)
+    address: "0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"
+    category: governance
+  - id: timelock
+    label: Strategy Manager (7-day Timelock)
+    address: "0x88Ba032be87d5EF1fbE87336b7090767F367BF73"
+    category: governance
+  - id: role-manager
+    label: Yearn V3 Role Manager
+    address: "0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41"
+    category: governance
+
+  # Infra / bots
+  - id: keeper
+    label: Keeper (yHaaSRelayer)
+    address: "0x604e586F17cE106B64185A7a0d2c1Da5bAce711E"
+    category: infra
+  - id: debt-allocator
+    label: Debt Allocator
+    address: "0x1e9eB053228B1156831759401dE0E115356b8671"
+    category: infra
+  - id: vault-factory
+    label: Vault Factory (v3.0.2)
+    address: "0x444045c5C13C246e117eD36437303cac8E250aB0"
+    category: infra
+
+  # Strategies
+  - id: morpho-gauntlet-weth
+    label: Morpho Gauntlet WETH Prime (71.26%)
+    address: "0xeEB6Be70fF212238419cD638FAB17910CF61CBE7"
+    category: strategy
+  - id: steth-accumulator
+    label: stETH Accumulator (24.68%)
+    address: "0x470e0e048F85CFD72EEf325895e02c8D297E7435"
+    category: strategy
+  - id: spark-weth-lender
+    label: Spark WETH Lender (4.03%)
+    address: "0x365cC9c28Df1663fA37C565A3aC1Addc3A219e15"
+    category: strategy
+
+  # External dependencies
+  - id: morpho-gauntlet-vault
+    label: Morpho Gauntlet WETH Prime Vault
+    category: dependency
+    note: Gauntlet-curated Morpho MetaMorpho vault
+  - id: lido-steth
+    label: Lido stETH
+    address: "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
+    category: dependency
+  - id: curve-steth-pool
+    label: Curve ETH/stETH Pool
+    address: "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022"
+    category: dependency
+  - id: lido-withdrawal-queue
+    label: Lido Withdrawal Queue
+    address: "0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1"
+    category: dependency
+  - id: spark-lend-weth
+    label: Spark Lend WETH Market
+    category: dependency
+    note: Sky sub-DAO; admin keys live under Sky governance
+
+edges:
+  # Deployment / vault infrastructure
+  - from: vault-factory
+    to: yvWETH
+    kind: deploys
+    label: minimal proxy
+  - from: yvWETH
+    to: accountant
+    kind: routes-fees-to
+  - from: accountant
+    to: dumper
+    kind: routes-fees-to
+
+  # Vault → strategies (allocation)
+  - from: yvWETH
+    to: morpho-gauntlet-weth
+    kind: allocates-to
+    label: "71.26%"
+  - from: yvWETH
+    to: steth-accumulator
+    kind: allocates-to
+    label: "24.68%"
+  - from: yvWETH
+    to: spark-weth-lender
+    kind: allocates-to
+    label: "4.03%"
+
+  # Governance roles on vault
+  - from: daddy
+    to: yvWETH
+    kind: holds-role
+    label: "all 14 roles"
+  - from: brain
+    to: yvWETH
+    kind: holds-role
+    label: "QUEUE / DEBT / EMERGENCY"
+  - from: security
+    to: yvWETH
+    kind: holds-role
+    label: "DEBT / MAX_DEBT / EMERGENCY"
+  - from: timelock
+    to: yvWETH
+    kind: holds-role
+    label: "ADD_STRATEGY (7d)"
+  - from: keeper
+    to: yvWETH
+    kind: holds-role
+    label: "REPORTING"
+  - from: debt-allocator
+    to: yvWETH
+    kind: holds-role
+    label: "REPORTING + DEBT_MANAGER"
+
+  # Role manager wiring
+  - from: daddy
+    to: role-manager
+    kind: controls
+  - from: security
+    to: role-manager
+    kind: controls
+  - from: role-manager
+    to: yvWETH
+    kind: manages
+
+  # Timelock flow
+  - from: daddy
+    to: timelock
+    kind: proposes-on
+    label: PROPOSER + EXECUTOR
+  - from: brain
+    to: timelock
+    kind: cancels-on
+    label: CANCELLER
+
+  # Strategy → underlying protocol pipelines
+  - from: morpho-gauntlet-weth
+    to: morpho-gauntlet-vault
+    kind: deposits-into
+    label: "WETH deposit"
+  - from: steth-accumulator
+    to: curve-steth-pool
+    kind: routes-through
+    label: "ETH → stETH (stake/unwind)"
+  - from: steth-accumulator
+    to: lido-steth
+    kind: deposits-into
+    label: "ETH → stETH (submit)"
+  - from: steth-accumulator
+    to: lido-withdrawal-queue
+    kind: routes-through
+    label: "stETH → ETH (1:1 redeem)"
+  - from: spark-weth-lender
+    to: spark-lend-weth
+    kind: deposits-into
+    label: "WETH supply"


### PR DESCRIPTION
## Summary

- Adds contract dependency graph YAMLs at `reports/graph/<slug>.yaml` for every report that didn't already ship one in PR #205.
- 30 new graphs total. Excluded as already-published: `infinifi`, `cap-stcusd`, `yearn-yvusdc`.
- All YAMLs follow the schema and authoring rules in `reports/graph/SKILL.md` — 5-category enum, 11 edge kinds, addresses verbatim from each report, flow kinds (`allocates-to` / `deposits-into` / `routes-through`) used for capital movement.
- Cross-graph linking is wired where addresses match an existing graph: yvUSD → siUSD / syrupUSDC / sUSDS, yvDAI → yvUSDC / yvUSDS, yvUSDS → sUSDS, fluid → re-reusd, mezo-musd → wormhole-related, plus other implicit matches via address.

## What's in this PR

| Group | Slugs |
|------|-------|
| Yearn V3 vault family (6) | `yearn-yvdai`, `yearn-yvusd`, `yearn-yvusds`, `yearn-yvusdt`, `yearn-yvwbtc`, `yearn-yvweth` |
| Stablecoins A (5) | `3jane-usd3`, `buck`, `fluid`, `fx-fxusd`, `mezo-musd` |
| Stablecoins B (5) | `aave-sgho`, `paxos-usdg`, `apyx-apxusd`, `maple-syrupusdc`, `superstate-ustb` |
| LST/yield (5) | `kerneldao-hgeth`, `kinetiq-khype`, `midas-mhyper`, `stakedhype-sthype`, `strata-srusde` |
| Specialty A (5) | `across-protocol`, `origin-arm`, `re-reusd`, `reserve-ethplus`, `royco-srroyusdc` |
| Specialty B (4) | `resolv-rlp`, `resolv-wstusr`, `spectra-finance`, `unit-ubtc` |

## Test plan

- [x] `npm run build` completes cleanly
- [x] 33 `/graph/<slug>/index.html` files emitted (3 from #205 + 30 new)
- [x] All YAMLs pass the validator in `src/lib/graph.ts` (every edge endpoint resolves to a node id, all categories within the 5-enum, all edge kinds within the 11-enum)
- [x] One YAML fix during verification: `spectra-finance.yaml` had an unquoted `note: Example: ...` that broke YAML parsing — quoted the value
- [ ] Reviewer: spot-check a handful of graphs on the Vercel preview — confirm allocation `%` labels appear, hover-chain highlights backward flow, and addresses on cross-linked dep nodes (e.g. `siUSD` in `yearn-yvusd`) tint with the linked report's risk-tier color

🤖 Generated with [Claude Code](https://claude.com/claude-code)