### PR TITLE
feat(reports): add DEAD warning tag and skip reassessment for tagged reports

### DIFF
--- a/reports/report/buck.md
+++ b/reports/report/buck.md
@@ -5,6 +5,7 @@
 - **Chain:** Ethereum
 - **Token Address:** [`0xdb13997f4D83EF343845d0bAEb27d1173dF8c224`](https://etherscan.io/address/0xdb13997f4D83EF343845d0bAEb27d1173dF8c224)
 - **Final Score: 5.0/5.0**
+- **Warning:** DEAD
 
 ## Overview + Links
 

--- a/reports/report/resolv-rlp.md
+++ b/reports/report/resolv-rlp.md
@@ -5,7 +5,7 @@
 - **Chain:** Ethereum (primary), multi-chain (Base, BNB, Berachain, Arbitrum, HyperEVM, Soneium, TAC, Plasma)
 - **Token Address:** [`0x4956b52aE2fF65D74CA2d61207523288e4528f96`](https://etherscan.io/address/0x4956b52aE2fF65D74CA2d61207523288e4528f96)
 - **Final Score: 5.0/5.0**
-- **Warning:** HACKED — DO NOT USE
+- **Warning:** HACKED
 
 ## Overview + Links
 

--- a/reports/report/resolv-wstusr.md
+++ b/reports/report/resolv-wstusr.md
@@ -5,7 +5,7 @@
 - **Chain:** Ethereum (primary), multi-chain (Arbitrum, Base)
 - **Token Address:** [`0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055`](https://etherscan.io/address/0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055)
 - **Final Score: 5.0/5.0**
-- **Warning:** HACKED — DO NOT USE
+- **Warning:** HACKED
 
 ## Overview + Links
 

--- a/scripts/check_stale_reports.py
+++ b/scripts/check_stale_reports.py
@@ -26,6 +26,7 @@ LABEL = "reassessment"
 TITLE_PREFIX = "Reassessment: "
 
 ASSESSMENT_LINE_RE = re.compile(r"\*\*Assessment Date:\*\*\s*([^\n]+)", re.IGNORECASE)
+WARNING_LINE_RE = re.compile(r"\*\*Warning:\*\*\s*([^\n]+)", re.IGNORECASE)
 DATE_RE = re.compile(
     r"\b("
     r"January|February|March|April|May|June|July|August|September|October|November|December"
@@ -80,6 +81,8 @@ def parse_report(path: Path) -> dict:
     title = title_match.group(1).strip() if title_match else path.stem
     score_match = SCORE_RE.search(content)
     score = score_match.group(1) if score_match else None
+    warning_match = WARNING_LINE_RE.search(content)
+    warning = warning_match.group(1).strip() if warning_match else None
 
     date = parse_assessment_date(content)
     source = "report-header"
@@ -94,6 +97,7 @@ def parse_report(path: Path) -> dict:
         "score": score,
         "date": date,
         "date_source": source,
+        "warning": warning,
     }
 
 
@@ -196,6 +200,14 @@ def main() -> int:
     failed_count = 0
     for path in sorted(REPORTS_DIR.glob("*.md")):
         report = parse_report(path)
+        if report["warning"]:
+            log.info(
+                "SKIP %s — terminal warning: %s",
+                report["slug"],
+                report["warning"],
+            )
+            skipped_count += 1
+            continue
         if report["date"] is None:
             log.warning("could not determine date for %s; skipping", path.name)
             continue


### PR DESCRIPTION
## Summary
- Add `- **Warning:** DEAD` to `reports/report/buck.md` (project shutdown — see https://curation.yearn.fi/report/buck/)
- Shorten existing `HACKED — DO NOT USE` warnings on `resolv-rlp` and `resolv-wstusr` to just `HACKED`
- `scripts/check_stale_reports.py` now skips reassessment-issue creation for any report carrying a `**Warning:**` line (HACKED / DEAD are terminal states — no follow-ups needed)

## Test plan
- [x] `DRY_RUN=1 uv run scripts/check_stale_reports.py` shows buck / resolv-rlp / resolv-wstusr skipped via "terminal warning: …"
- [x] Reports page still renders the warning banner for the three tagged reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)