### PR TITLE
chore(reports): reassess cap-stcusd (May 2026)

### DIFF
--- a/reports/graph/cap-stcusd.yaml
+++ b/reports/graph/cap-stcusd.yaml
@@ -23,7 +23,7 @@ nodes:
     label: cUSD (Cap Stablecoin)
     address: "0xcCcc62962d17b8914c62D74FfB843d73B2a3cccC"
     category: vault
-    note: ERC-20 upgradeable proxy; backed 96% USDC / 4% wWTGXX
+    note: ERC-20 upgradeable proxy; backed ~95% USDC / ~5% wWTGXX
 
   # === Strategies (capital deployment legs) ===
   - id: usdc-frv
@@ -62,14 +62,20 @@ nodes:
     note: Role-based permission system; DEFAULT_ADMIN held by Timelock
 
   # === External dependencies ===
+  - id: morpho-steakhouse-prime
+    label: Morpho Steakhouse Prime USDC
+    address: "0xbeef088055857739C12CD3765F20b7679Def0f51"
+    category: dependency
+    note: ~$29.13M (60% of USDC FRV)
   - id: morpho-usdc-prime
     label: Morpho Gauntlet USDC Prime
+    address: "0x8c106EEDAd96553e64287A5A6839c3Cc78afA3D0"
     category: dependency
-    note: ~$50.2M (67% of USDC FRV)
+    note: ~$19.73M (40% of USDC FRV)
   - id: aave-v3-usdc
     label: Aave V3 USDC Core
     category: dependency
-    note: ~$25.0M (33% of USDC FRV)
+    note: Strategy wired in but max_debt=0 since Apr/May 2026 (effectively unused)
   - id: wwtgxx
     label: wWTGXX (WisdomTree Gov MMF)
     category: dependency
@@ -116,25 +122,29 @@ edges:
   - from: cUSD
     to: usdc-frv
     kind: allocates-to
-    label: "~$75M USDC"
+    label: "~$48.9M USDC"
   - from: cUSD
     to: lender
     kind: allocates-to
-    label: "~$49M op debt"
+    label: "~$43.8M op debt"
   - from: cUSD
     to: wwtgxx-frv
     kind: allocates-to
-    label: "~$5M wWTGXX"
+    label: "~$5.08M wWTGXX"
 
   # === Strategy legs → external dependencies ===
   - from: usdc-frv
+    to: morpho-steakhouse-prime
+    kind: deposits-into
+    label: "60%"
+  - from: usdc-frv
     to: morpho-usdc-prime
     kind: deposits-into
-    label: "67%"
+    label: "40%"
   - from: usdc-frv
     to: aave-v3-usdc
     kind: deposits-into
-    label: "33%"
+    label: "0% (deactivated)"
   - from: wwtgxx-frv
     to: wwtgxx
     kind: deposits-into

--- a/reports/report/cap-stcusd.md
+++ b/reports/report/cap-stcusd.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: Cap — stcUSD
 
-- **Assessment Date:** March 20, 2026
+- **Assessment Date:** March 20, 2026 (Updated: May 23, 2026)
 - **Token:** stcUSD (Staked cap USD)
 - **Chain:** Ethereum
 - **Token Address:** [`0x88887bE419578051FF9F4eb6C858A951921D8888`](https://etherscan.io/address/0x88887bE419578051FF9F4eb6C858A951921D8888)
@@ -12,26 +12,29 @@ stcUSD is a **yield-bearing ERC-4626 vault token** issued by Cap (Covered Agent 
 
 **Key architecture:**
 
-- **cUSD:** Dollar-pegged stablecoin backed 1:1 by whitelisted reserve assets. Currently **2 assets accepted onchain**: USDC (~96% of reserves) and wWTGXX/WisdomTree Government Money Market Digital Fund (~4%). Max 40% single-asset concentration rule exists but is not binding given current composition. Users mint by depositing reserves and burn/redeem to withdraw
-- **stcUSD:** ERC-4626 vault wrapping cUSD. Yield accrues via exchange rate appreciation. ~76% of cUSD supply is staked as stcUSD
-- **Fractional Reserve:** ~$75M USDC deployed via the USDC Fractional Reserve Vault (a Yearn V3 vault) — split between **Morpho Gauntlet USDC Prime** (~$50.2M, 67%) and **Aave V3 USDC Lender** (~$25.0M, 33%). An additional ~$5M wWTGXX is held in a separate Fractional Reserve Vault via a simple holder strategy
+- **cUSD:** Dollar-pegged stablecoin backed 1:1 by whitelisted reserve assets. Currently **2 assets accepted onchain**: USDC (~95% of reserves) and wWTGXX/WisdomTree Government Money Market Digital Fund (~5%). Max 40% single-asset concentration rule exists but is not binding given current composition. Users mint by depositing reserves and burn/redeem to withdraw
+- **stcUSD:** ERC-4626 vault wrapping cUSD. Yield accrues via exchange rate appreciation. ~83% of cUSD supply is staked as stcUSD
+- **Fractional Reserve:** ~$48.86M USDC deployed via the USDC Fractional Reserve Vault (a Yearn V3 vault) — now split between **Morpho Steakhouse Prime USDC** (~$29.13M, 60%) and **Morpho Gauntlet USDC Prime** (~$19.73M, 40%). The Aave V3 USDC Lender strategy remains wired in the default queue but has been fully drained (current debt ≈ 0, max debt = 0). An additional ~$5.08M wWTGXX is held in a separate Fractional Reserve Vault via a simple holder strategy
 - **Operator Model:** Institutional operators borrow reserves at a dynamic hurdle rate (~5.2% avg over 90 days), execute offchain/proprietary strategies (HFT, private credit, arbitrage, MEV), and return principal + hurdle rate. Excess yield is split between operators and restakers
 - **Security Network:** Per-operator Symbiotic vaults with instant slashing. Restakers delegate collateral (ETH, wBTC, LSTs, stablecoins) to specific operators. If an operator defaults, their delegated collateral is slashed and redistributed to cover losses
 - **Governance:** 3-of-5 Gnosis Safe multisig → 24-hour TimelockController → Access Control system. All contracts are upgradeable proxies
 
-**Key metrics (March 20, 2026):**
+**Key metrics (verified onchain May 23, 2026 at block ~25,160,215):**
 
-- **cUSD Total Supply:** ~129,029,543 cUSD
-- **stcUSD Total Supply:** ~93,554,000 stcUSD
-- **stcUSD Total Assets:** ~98,522,086 cUSD
-- **Price Per Share:** ~1.0531 cUSD/stcUSD (~5.3% cumulative appreciation since launch)
-- **Fractional Reserve USDC:** ~$75.17M USDC (67% Morpho, 33% Aave V3)
-- **Fractional Reserve wWTGXX:** ~$5.0M wWTGXX (WisdomTree Gov MMF)
-- **Outstanding Debt USDC:** ~$48.86M
-- **Protocol TVL (DeFi Llama):** ~$288M (includes restaker collateral)
-- **Net APY:** ~5.2% (hurdle rate benchmark)
+- **cUSD Total Supply:** ~97,728,786 cUSD (down ~24% since March)
+- **stcUSD Total Supply:** ~81,567,930 stcUSD
+- **stcUSD Total Assets:** ~86,703,368 cUSD
+- **Price Per Share:** ~1.0630 cUSD/stcUSD (+0.93% vs. March 20 PPS of 1.0531; ~6.3% cumulative appreciation since launch)
+- **cUSD Reserves:** ~92.66M USDC + ~5.07M wWTGXX (sum matches total supply)
+- **Operator USDC Debt:** ~$43.80M outstanding
+- **Available USDC in Fractional Reserve:** ~$48.86M (= 92.66M reserves − 43.80M operator debt)
+  - **Morpho Steakhouse Prime USDC:** ~$29.13M (60% of FRV)
+  - **Morpho Gauntlet USDC Prime:** ~$19.73M (40% of FRV)
+  - **Aave V3 USDC Lender:** ~$0 (deactivated; 0 max debt)
+- **Fractional Reserve wWTGXX:** ~$5.08M wWTGXX
+- **Protocol TVL (DeFi Llama, Ethereum):** ~$300M (includes restaker collateral); **Peak TVL ~$484M on Jan 28, 2026**
 - **Minting Fee:** 0.10%
-- **Launch Date:** August 19, 2025 (~7 months in production)
+- **Launch Date:** August 19, 2025 (~9 months in production)
 
 **Links:**
 
@@ -69,11 +72,13 @@ stcUSD is a **yield-bearing ERC-4626 vault token** issued by Cap (Covered Agent 
 
 ### Governance Contracts
 
+All values in this table verified via `eth_call` on May 23, 2026.
+
 | Contract | Address | Configuration |
 |----------|---------|---------------|
-| Timelock | [`0xD8236031d8279d82E615aF2BFab5FC0127A329ab`](https://etherscan.io/address/0xD8236031d8279d82E615aF2BFab5FC0127A329ab) | OZ TimelockController, 24-hour delay. Holds DEFAULT_ADMIN_ROLE on Access Control |
-| Multisig | [`0xb8FC49402dF3ee4f8587268FB89fda4d621a8793`](https://etherscan.io/address/0xb8FC49402dF3ee4f8587268FB89fda4d621a8793) | 3-of-5 Gnosis Safe (v1.4.1). PROPOSER, EXECUTOR, CANCELLER roles on Timelock |
-| Deployer EOA | [`0xc1ab5a9593e6e1662a9a44f84df4f31fc8a76b52`](https://etherscan.io/address/0xc1ab5a9593e6e1662a9a44f84df4f31fc8a76b52) | Retains EXECUTOR_ROLE on Timelock (can execute queued proposals but cannot propose or cancel) |
+| Timelock | [`0xD8236031d8279d82E615aF2BFab5FC0127A329ab`](https://etherscan.io/address/0xD8236031d8279d82E615aF2BFab5FC0127A329ab) | OZ TimelockController. `getMinDelay() = 86400` (24h). Holds the sole DEFAULT_ADMIN_ROLE on Access Control (enumerated: 1 holder = this Timelock) |
+| Multisig | [`0xb8FC49402dF3ee4f8587268FB89fda4d621a8793`](https://etherscan.io/address/0xb8FC49402dF3ee4f8587268FB89fda4d621a8793) | Gnosis Safe v1.4.1, threshold = 3, 5 owners. `hasRole` confirms PROPOSER_ROLE, EXECUTOR_ROLE, and CANCELLER_ROLE on the Timelock. Owners are anonymous: `0xDD30a4712e6B34926d4f5aA99c1881573407538C`, `0xdf466Fa3ddd0042d990FA9A023e040884CBaD439`, `0x7c29F6A93df60Bcd3B20f03B57a2F9e698FD4128`, `0x62D0b3c0a77bE77EaB2060266a95FfaD9e6A3F51`, `0xA62f87A9D4B5EE1F83cb644Ea076832A396101b8` |
+| Deployer EOA | [`0xc1ab5a9593e6e1662a9a44f84df4f31fc8a76b52`](https://etherscan.io/address/0xc1ab5a9593e6e1662a9a44f84df4f31fc8a76b52) | `hasRole` returns true only for EXECUTOR_ROLE on Timelock — PROPOSER, CANCELLER, and DEFAULT_ADMIN are all false. Residual permission from deployment, not revoked as of this reassessment |
 
 ### Symbiotic Integration
 
@@ -91,19 +96,25 @@ stcUSD is a **yield-bearing ERC-4626 vault token** issued by Cap (Covered Agent 
 | Redstone cUSD | [`0x9A5a3c3Ed0361505cC1D4e824B3854De5724434A`](https://etherscan.io/address/0x9A5a3c3Ed0361505cC1D4e824B3854De5724434A) | cUSD price feed (0.05% deviation threshold) |
 | Morpho stcUSD | [`0x8E3386B2f6084eB1B0988070c3d826995BD175c0`](https://etherscan.io/address/0x8E3386B2f6084eB1B0988070c3d826995BD175c0) | stcUSD price feed for Morpho markets |
 
-### Morpho Markets (stcUSD as collateral)
+### Morpho Markets (stcUSD / PT-stcUSD / PT-cUSD as collateral)
+
+Sourced from Morpho Blue API on May 23, 2026. Composition has shifted materially since the March assessment — USDT/stcUSD is now the largest market (was USDC).
 
 | Market | Collateral | Loan Token | LLTV | Supply TVL | Utilization |
 |--------|-----------|------------|------|-----------|-------------|
-| stcUSD / USDC | stcUSD | USDC | 91.5% | ~$42M | ~91% |
-| PT-cUSD-23JUL2026 / USDC | PT-cUSD (Pendle) | USDC | 91.5% | ~$2.3M | ~91% |
-| PT-stcUSD-23JUL2026 / USDC | PT-stcUSD (Pendle) | USDC | 91.5% | ~$1.5M | ~91% |
+| stcUSD / USDT | stcUSD | USDT | 91.5% | ~$16.6M | ~70% |
+| stcUSD / USDC | stcUSD | USDC | 91.5% | ~$8.9M | ~91% |
+| PT-cUSD-23JUL2026 / USDC | PT-cUSD (Pendle) | USDC | 91.5% | ~$0.87M | ~90% |
+| PT-stcUSD-23JUL2026 / USDC | PT-stcUSD (Pendle) | USDC | 91.5% | ~$0.40M | ~90% |
+| PT-cUSD-23JUL2026 / USDT | PT-cUSD (Pendle) | USDT | 91.5% | ~$0.14M | ~70% |
+
+Several smaller / unused markets (AUSD pairs, mismatched-LLTV duplicates) also exist with <$20K supply each.
 
 ## Audits and Due Diligence Disclosures
 
 ### Cap Protocol Audits
 
-Cap has been audited by **7 firms** with **8 total reports** (including one PR review), covering the core protocol, security network, and invariant testing:
+Cap has been audited by **8 firms** with **9 total reports** (including PR / incremental reviews), covering the core protocol, security network, and invariant testing. One new incremental audit (Octane) has been added since the March 2026 assessment:
 
 | Auditor | Date | Scope | Report |
 |---------|------|-------|--------|
@@ -115,6 +126,7 @@ Cap has been audited by **7 firms** with **8 total reports** (including one PR r
 | [Sherlock](https://github.com/cap-labs-dev/cap-audits/blob/main/2025-09-03-Sherlock.pdf) | Jul–Sep 2025 | Cap protocol (contest, $126K pool) | PDF |
 | [Certora](https://github.com/cap-labs-dev/cap-audits/blob/main/2025-09-15-Certora%20(EigenAVS).pdf) | Sep 2025 | EigenLayer SSN (AVS) | PDF |
 | [Spearbit (PR Review)](https://github.com/cap-labs-dev/cap-audits/blob/main/2025-11-27-Spearbit%20(PR%20Review).pdf) | Nov 2025 | Incremental PR review | PDF |
+| [Octane](https://github.com/cap-labs-dev/cap-audits/blob/main/2026-03-24-Octane.pdf) | Mar 2026 | Token audit (incremental) | PDF |
 
 **Note:** Finding severity breakdowns are not publicly summarized. The audit PDFs are available in the [cap-audits repository](https://github.com/cap-labs-dev/cap-audits).
 
@@ -138,15 +150,14 @@ The Cap system is **high complexity**:
 
 ## Historical Track Record
 
-- **Launch date:** August 19, 2025 — **~7 months** in production
-- **cUSD supply:** ~129M cUSD
-- **stcUSD supply:** ~93.6M stcUSD (~76% staking ratio)
-- **stcUSD PPS:** 1.0000 → 1.0531 (~5.3% cumulative return over ~7 months, ~9-10% annualized)
+- **Launch date:** August 19, 2025 — **~9 months** in production as of this reassessment
+- **cUSD supply:** ~97.73M cUSD (was 129M in March 2026, down ~24%)
+- **stcUSD supply:** ~81.57M stcUSD (~83% staking ratio, up from ~76%)
+- **stcUSD PPS:** 1.0000 → 1.0531 (Mar 20) → 1.0630 (May 23) — ~6.3% cumulative since launch, ~9–10% annualized; PPS has not decreased
 - **Security incidents:** None known
-- **Cumulative yield paid:** $4M+ to stcUSD holders
-- **Peak TVL:** ~$500M (January 2026)
-- **Current TVL:** ~$288M (March 2026, includes restaker collateral)
-- **Protocol age:** Relatively new — launched August 2025, audited from February 2025
+- **Peak TVL:** ~$484M on January 28, 2026 (DeFi Llama)
+- **Current TVL:** ~$300M (May 23, 2026, includes restaker collateral)
+- **Protocol age:** Still relatively new — launched August 2025, first audit February 2025
 
 **Team track record:**
 
@@ -163,10 +174,15 @@ stcUSD earns yield from two primary sources:
 
 **1. Fractional Reserve Deployment**
 
-Idle cUSD reserves are deployed via two Yearn V3 Fractional Reserve Vaults:
+Idle cUSD reserves are deployed via two Yearn V3 Fractional Reserve Vaults. Strategy queue and per-strategy `totalAssets()` verified onchain on May 23, 2026:
 
-- **USDC FRV** ([`0x3Ed6aa32c930253fc990dE58fF882B9186cd0072`](https://etherscan.io/address/0x3Ed6aa32c930253fc990dE58fF882B9186cd0072)): ~$75.2M USDC split between **Morpho Gauntlet USDC Prime** (~$50.2M, 67%) and **Aave V3 USDC Lender** (~$25.0M, 33%)
-- **wWTGXX FRV** ([`0xb1c1C80FDbBde5B40264e1410550F3C864113bF8`](https://etherscan.io/address/0xb1c1C80FDbBde5B40264e1410550F3C864113bF8)): ~$5.0M wWTGXX held via simple holder strategy (wWTGXX is itself a yield-bearing WisdomTree Government Money Market fund token)
+- **USDC FRV** ([`0x3Ed6aa32c930253fc990dE58fF882B9186cd0072`](https://etherscan.io/address/0x3Ed6aa32c930253fc990dE58fF882B9186cd0072)): ~$48.86M USDC total assets. Default queue now contains three strategies:
+  - [Morpho Steakhouse Prime USDC Compounder](https://etherscan.io/address/0xBAed9839573d349e42DFbF23a8916e5AB9cAf2E3) — ~$29.13M (60% of FRV). Underlying MetaMorpho vault [`0xbeef088055857739C12CD3765F20b7679Def0f51`](https://etherscan.io/address/0xbeef088055857739C12CD3765F20b7679Def0f51) ("Steakhouse Prime USDC", $58M total assets)
+  - [Morpho Gauntlet USDC Prime Compounder](https://etherscan.io/address/0x8092C20351CF4048B464DF2144Dc8a4DD49ce71D) — ~$19.73M (40% of FRV). Underlying MetaMorpho vault [`0x8c106EEDAd96553e64287A5A6839c3Cc78afA3D0`](https://etherscan.io/address/0x8c106EEDAd96553e64287A5A6839c3Cc78afA3D0) ("Gauntlet USDC Prime", $98.6M total assets)
+  - [Aave V3 USDC Lender](https://etherscan.io/address/0x7D7F72d393F242DA6e22D3b970491C06742984Ff) — **~$0 (deactivated)**. `strategies[strat].max_debt = 0` and current debt is dust (~2 USDC). Still wired into the default queue but receives no new allocation
+- **wWTGXX FRV** ([`0xb1c1C80FDbBde5B40264e1410550F3C864113bF8`](https://etherscan.io/address/0xb1c1C80FDbBde5B40264e1410550F3C864113bF8)): ~$5.08M wWTGXX held via "Holder wWGTXX" strategy ([`0xB0D399E8A11E1c6df00E1Fb5698936B5614e9259`](https://etherscan.io/address/0xB0D399E8A11E1c6df00E1Fb5698936B5614e9259)). wWTGXX is itself a yield-bearing WisdomTree Government Money Market fund token ([`0x434558CB1EBe9950e8A66f1ef8A15A473Dce7D8c`](https://etherscan.io/address/0x434558CB1EBe9950e8A66f1ef8A15A473Dce7D8c))
+
+**Concentration note (change since March 2026):** USDC reserves were previously split ~67% Morpho / ~33% Aave V3. After the rebalance, **100% of deployed USDC reserves now sit in Morpho** (split across two MetaMorpho vaults: Steakhouse and Gauntlet). This increases concentration on a single underlying protocol (Morpho Blue + MetaMorpho), even though it spreads risk across two curators.
 
 **2. Operator Borrowing Fees (~10% of yield)**
 
@@ -183,8 +199,10 @@ Operators generate yield through proprietary strategies: HFT, private credit, cr
 
 ### Collateralization
 
-- **cUSD reserves:** Backed by 2 whitelisted assets onchain: **USDC** (~$124M, 96%) and **wWTGXX** (~$5M, 4%). USDC dominates — the 40% single-asset concentration cap is not binding
-- **Reserve deployment:** USDC Fractional Reserve Vault holds ~$75.2M (Morpho ~$50.2M + Aave ~$25.0M). ~$48.9M lent to operators. wWTGXX FRV holds ~$5M via holder strategy
+Backing breakdown verified via `Vault.totalSupplies(asset)` and per-asset balance checks on May 23, 2026:
+
+- **cUSD reserves:** Backed by 2 whitelisted assets onchain: **USDC** (~$92.66M, 95%) and **wWTGXX** (~$5.07M, 5%). Sum equals cUSD total supply (~97.73M), confirming 1:1 backing. USDC still dominates and the 40% single-asset concentration cap is not binding
+- **Reserve deployment:** USDC FRV holds ~$48.86M (Morpho Steakhouse ~$29.13M + Morpho Gauntlet ~$19.73M; Aave V3 leg drained). ~$43.80M of USDC reserves are lent to operators (`Vault.totalBorrows(USDC)`). wWTGXX FRV holds ~$5.08M via holder strategy
 - **Operator collateralization:** Each operator must secure over-collateralized Symbiotic delegations (default 50% LTV, 80% liquidation threshold) from restakers before borrowing
 - **Liquidation:** Health Factor < 1.0 triggers a 12-hour grace period, then a 3-day liquidation window via permissionless Dutch auction. Liquidation bonus capped at 10%. Target: 125% health ratio post-liquidation
 - **Slashing:** Instant slashing on two objective fault conditions: (1) failure to return expected amount, (2) insufficient active delegation. No governance intervention needed
@@ -200,7 +218,7 @@ Operators generate yield through proprietary strategies: HFT, private credit, cr
 
 ### Token Mint Authority
 
-Verified onchain on March 20, 2026 by inspecting `StakedCap.sol` and `Vault.sol` source via Etherscan. Cap does **not** implement a privileged `MINTER_ROLE` on either token — both mint paths are permissionless and require collateral in the same transaction.
+Re-verified onchain on May 23, 2026 against current Vault implementation [`0xa76645e15c267b876999bf7689e0b2c1ee29bfe6`](https://etherscan.io/address/0xa76645e15c267b876999bf7689e0b2c1ee29bfe6) and stcUSD implementation [`0x42c0e0ef7c2f35de073f4d6f9c0e4483429c3d31`](https://etherscan.io/address/0x42c0e0ef7c2f35de073f4d6f9c0e4483429c3d31) (both unchanged since the March assessment). Cap does **not** implement a privileged `MINTER_ROLE` on either token — both mint paths are permissionless and require collateral in the same transaction.
 
 **Mint mechanism:**
 
@@ -232,8 +250,8 @@ Verified onchain on March 20, 2026 by inspecting `StakedCap.sol` and `Vault.sol`
 
 - **Primary exit for stcUSD:** Redeem stcUSD for cUSD via ERC-4626 `withdraw()`/`redeem()`. Then burn/redeem cUSD for underlying reserves
 - **cUSD exit mechanisms:** Burn (receive single asset at oracle price, dynamic fee) or Redeem (receive proportional basket, fixed fee). The redemption mechanism is designed to prevent "last man standing" scenarios
-- **Morpho/Aave liquidity dependency:** ~$75M USDC deployed across Morpho (~$50M) and Aave V3 (~$25M). Withdrawal depends on available liquidity in both protocols. Generally liquid, but in extreme scenarios (high utilization spikes), withdrawal may be delayed
-- **Morpho markets:** stcUSD is collateral in Morpho markets with ~$42M supply TVL at ~91% utilization. High utilization means limited immediate liquidity for Morpho lenders
+- **Morpho liquidity dependency:** ~$48.9M of available USDC reserves now sit entirely in two MetaMorpho vaults (Steakhouse Prime $29M, Gauntlet Prime $19M). Withdrawal depends on idle USDC + Morpho market liquidity. Removal of the active Aave V3 leg has eliminated a secondary, blue-chip liquidity venue
+- **Morpho markets (stcUSD as collateral):** Top markets are USDT/stcUSD (~$16.6M @ 70% util) and USDC/stcUSD (~$8.9M @ 91% util). Pendle PT-cUSD / PT-stcUSD markets add ~$1.4M. High utilization on the USDC market means limited immediate exit for Morpho lenders
 - **No DEX liquidity pool required** — exit is via protocol's own mint/burn/redeem mechanism
 - **Restaker withdrawal:** Up to 14-day delay creates a potential friction point for operators needing to return capital
 - **Deposit/withdrawal:** Permissionless, no lock period for stcUSD stakers
@@ -275,13 +293,13 @@ Cap's governance flows through a **3-of-5 Gnosis Safe multisig** → **24-hour T
 
 | Dependency | Criticality | Notes |
 |-----------|-------------|-------|
-| **Morpho** | Critical | ~$50.2M USDC deployed (67% of USDC FRV). Also stcUSD collateral market (~$42M). Core yield source |
-| **Aave V3 Core Ethereum** | Critical | ~$25.0M USDC deployed (33% of USDC FRV). Blue-chip protocol ($30B+ TVL) |
+| **Morpho (Steakhouse Prime + Gauntlet Prime)** | Critical | **~$48.9M USDC** — 100% of the deployed USDC FRV is now in Morpho (split ~60/40 Steakhouse/Gauntlet). Also the venue for ~$26M of stcUSD collateral markets. A Morpho Blue protocol incident or simultaneous curator failure would impair both reserve liquidity and stcUSD collateral utility |
+| **Aave V3 Core Ethereum** | Low (currently) | Strategy still wired in but max debt set to 0; effectively unused. Was a critical dependency in March 2026 |
 | **Symbiotic** | Critical | Restaking infrastructure securing operator positions. Per-operator vault delegation model |
 | **RedStone** | High | cUSD price oracle (0.05% deviation threshold). Stale prices disable minting/burning |
-| **wWTGXX (WisdomTree)** | Low | ~$5M tokenized gov money market fund. Only 7 holders. Minimal DeFi track record |
-| **USDC (Circle)** | High | Primary reserve asset |
-| **USDT, pyUSD, BENJI, BUIDL** | Low | Listed in docs as potential reserve assets but **not currently whitelisted onchain** |
+| **wWTGXX (WisdomTree)** | Low | ~$5.08M tokenized gov money market fund. Minimal DeFi adoption and few holders |
+| **USDC (Circle)** | High | Primary reserve asset (~95% of cUSD backing) |
+| **USDT, pyUSD, BENJI, BUIDL** | Low | Listed in docs as potential reserve assets but **not currently whitelisted onchain** (`Vault.assets()` returns only USDC and wWTGXX) |
 | **Institutional Operators** | High | IMC Trading, Edge Capital, Susquehanna Crypto generate yield via offchain strategies. Counterparty risk mitigated by Symbiotic restaking |
 
 ## Operational Risk
@@ -301,42 +319,44 @@ Cap's governance flows through a **3-of-5 Gnosis Safe multisig** → **24-hour T
 | Contract | Address | Monitor |
 |----------|---------|---------|
 | stcUSD Vault | [`0x88887bE419578051FF9F4eb6C858A951921D8888`](https://etherscan.io/address/0x88887bE419578051FF9F4eb6C858A951921D8888) | PPS (`convertToAssets(1e18)`), `totalAssets()`, `totalSupply()` |
-| cUSD Token | [`0xcCcc62962d17b8914c62D74FfB843d73B2a3cccC`](https://etherscan.io/address/0xcCcc62962d17b8914c62D74FfB843d73B2a3cccC) | `totalSupply()`, `paused()`, Mint/Burn events |
-| Fractional Reserve | [`0x3Ed6aa32c930253fc990dE58fF882B9186cd0072`](https://etherscan.io/address/0x3Ed6aa32c930253fc990dE58fF882B9186cd0072) | `totalAssets()`, Aave aUSDC balance |
+| cUSD Token | [`0xcCcc62962d17b8914c62D74FfB843d73B2a3cccC`](https://etherscan.io/address/0xcCcc62962d17b8914c62D74FfB843d73B2a3cccC) | `totalSupply()`, `totalSupplies(asset)`, `totalBorrows(asset)`, `paused()`, Mint/Burn events |
+| USDC Fractional Reserve | [`0x3Ed6aa32c930253fc990dE58fF882B9186cd0072`](https://etherscan.io/address/0x3Ed6aa32c930253fc990dE58fF882B9186cd0072) | `totalAssets()`, `get_default_queue()`, per-strategy `totalAssets()` (esp. Steakhouse vs. Gauntlet share, Aave V3 re-activation) |
+| wWTGXX Fractional Reserve | [`0xb1c1C80FDbBde5B40264e1410550F3C864113bF8`](https://etherscan.io/address/0xb1c1C80FDbBde5B40264e1410550F3C864113bF8) | `totalAssets()` — wWTGXX holdings |
 | Debt USDC | [`0xfa8C6D0b95d9191B5A1D51C868Da2BDFd6C04Ff9`](https://etherscan.io/address/0xfa8C6D0b95d9191B5A1D51C868Da2BDFd6C04Ff9) | `totalSupply()` — tracks outstanding operator debt |
 | Multisig | [`0xb8FC49402dF3ee4f8587268FB89fda4d621a8793`](https://etherscan.io/address/0xb8FC49402dF3ee4f8587268FB89fda4d621a8793) | Signer/threshold changes, submitted transactions |
-| Timelock | [`0xD8236031d8279d82E615aF2BFab5FC0127A329ab`](https://etherscan.io/address/0xD8236031d8279d82E615aF2BFab5FC0127A329ab) | Scheduled/executed transactions, delay changes |
-| Access Control | [`0x7731129a10d51e18cDE607C5C115F26503D2c683`](https://etherscan.io/address/0x7731129a10d51e18cDE607C5C115F26503D2c683) | Role grants/revocations, implementation upgrades |
+| Timelock | [`0xD8236031d8279d82E615aF2BFab5FC0127A329ab`](https://etherscan.io/address/0xD8236031d8279d82E615aF2BFab5FC0127A329ab) | `getMinDelay()`, scheduled/executed transactions, role changes |
+| Access Control | [`0x7731129a10d51e18cDE607C5C115F26503D2c683`](https://etherscan.io/address/0x7731129a10d51e18cDE607C5C115F26503D2c683) | `RoleGranted` / `RoleRevoked` events, `getRoleMember(DEFAULT_ADMIN_ROLE, 0)`, implementation upgrades (ERC-1967 impl slot) |
 
 ### Critical Events to Monitor
 
 - **stcUSD PPS decrease** — any decrease in `convertToAssets(1e18)` indicates a loss event
 - **cUSD supply changes** — large mint/burn events may indicate reserve stress
 - **Operator liquidations** — Lender contract liquidation events indicate operator defaults
-- **Contract upgrades** — implementation changes on proxy contracts (24h timelock provides advance notice)
-- **Multisig changes** — signer additions/removals, threshold changes
-- **Morpho/Aave USDC utilization** — high utilization in either protocol could delay reserve withdrawal
+- **Contract upgrades** — implementation changes on proxy contracts (24h timelock provides advance notice). Current impls: cUSD `0xa766…bfe6`, stcUSD `0x42c0…3d31`, AccessControl `0x6681…4bc1`
+- **Multisig changes** — signer additions/removals, threshold changes on `0xb8FC…8793`
+- **FRV strategy queue changes** — `get_default_queue()` on the USDC FRV; reactivation of Aave V3 or addition/removal of Morpho legs
+- **Morpho vault utilization** — high utilization in Steakhouse Prime or Gauntlet Prime could delay reserve withdrawal; both are now single points of liquidity for the USDC reserve
 - **Oracle staleness** — stale RedStone prices disable minting/burning
-- **Reserve composition** — significant changes in backing asset ratios
+- **Reserve composition** — significant changes in backing asset ratios (USDC vs. wWTGXX); whitelist changes (`Vault.assets()`)
 
 ## Risk Summary
 
 ### Key Strengths
 
-- **Strong audit coverage:** 7 auditors including Trail of Bits, Spearbit, Zellic, Certora, and Sherlock contest. Comprehensive coverage of core protocol, security network, and invariant testing
+- **Strong audit coverage:** 8 auditors / 9 reports including Trail of Bits, Spearbit (core + incremental PR), Zellic, Certora, Sherlock contest, and a fresh Octane token audit (March 2026). Comprehensive coverage of core protocol, security network, and invariant testing
 - **Novel security model:** Per-operator Symbiotic restaking with instant slashing provides cryptoeconomic guarantees against operator defaults. Not pooled risk — each operator is independently collateralized
-- **Blue-chip reserve deployment:** ~$75M USDC deployed across Morpho (67%) and Aave V3 (33%), both battle-tested DeFi protocols
+- **1:1 onchain backing verified:** cUSD total supply (~97.73M) exactly matches USDC + wWTGXX held in the reserve system; no IOUs or unbacked mint paths
 - **Institutional backing:** $11M from tier-1 investors (Franklin Templeton, Kraken, a16z, Dragonfly). Named operators include major trading firms (IMC Trading, Susquehanna)
-- **24-hour Timelock:** All governance changes go through 24-hour delay, providing users a window to react
+- **24-hour Timelock with sole DEFAULT_ADMIN_ROLE:** Onchain enumeration confirms only the Timelock holds DEFAULT_ADMIN on Access Control. All governance changes go through 24-hour delay
 
 ### Key Risks
 
-- **Upgradeable contracts:** Core token contracts (cUSD, stcUSD) are upgradeable proxies. While upgrades go through the 24h Timelock, the 3-of-5 multisig can modify fundamental contract logic
-- **Weak multisig configuration:** 3-of-5 threshold with 2 dormant owners, 1 nested 1-of-2 Safe, and no public signer disclosure. Effective security is weaker than the threshold suggests
+- **Upgradeable contracts:** Core token contracts (cUSD, stcUSD, Access Control) are UUPS upgradeable proxies. While upgrades require Timelock execution (24h delay), the 3-of-5 multisig can ultimately modify fundamental contract logic
+- **Weak multisig configuration:** 3-of-5 threshold with anonymous signers. Confirmed onchain: 5 owners, threshold 3, Safe v1.4.1. Effective security is weaker than the threshold suggests; signer identities and nested-Safe composition are not disclosed
 - **Offchain operator strategies:** Operators execute proprietary yield strategies that are opaque to onchain verification. While slashing provides recourse, users cannot independently verify operator positions or risk exposure
-- **Morpho/Aave concentration risk:** ~$75M USDC reserves deployed across Morpho (~$50M) and Aave V3 (~$25M). An incident in either protocol would significantly impact reserves
-- **Relatively new protocol:** 7 months in production. While growing rapidly ($288M TVL), the operator model and Symbiotic slashing mechanism have not been stress-tested in adverse conditions
-- **Deployer EOA retains EXECUTOR_ROLE:** Residual permission on the Timelock that was never revoked
+- **Increased Morpho concentration:** USDC reserves are now 100% deployed in Morpho (was 67/33 Morpho/Aave). Risk is partially diversified across two MetaMorpho vaults (Steakhouse Prime, Gauntlet Prime), but a Morpho Blue protocol incident would now affect 100% of deployed USDC reserves
+- **Relatively new protocol:** ~9 months in production. TVL has receded from a peak of ~$484M (Jan 2026) to ~$300M (May 2026). The operator model and Symbiotic slashing mechanism still have not been stress-tested in adverse conditions
+- **Deployer EOA retains EXECUTOR_ROLE:** Still not revoked as of May 23, 2026. Cannot propose or cancel, but can execute any already-queued Timelock proposal
 
 ### Critical Risks
 
@@ -354,9 +374,9 @@ Cap's governance flows through a **3-of-5 Gnosis Safe multisig** → **24-hour T
 
 ### Critical Risk Gates
 
-- [x] **No audit** — 7 auditors with 8 reports including Trail of Bits, Spearbit, Zellic, Sherlock. ✅ PASS
-- [x] **Unverifiable reserves** — ERC-4626 standard. cUSD reserves onchain. Fractional reserve Aave positions verifiable. However, operator yield strategies are offchain. ⚠️ PARTIAL — core reserves verifiable, operator positions opaque
-- [x] **Total centralization** — 3-of-5 multisig with 24h Timelock. Not a single EOA or 1-of-N setup. ✅ PASS
+- [x] **No audit** — 8 auditors with 9 reports (added Octane in March 2026). ✅ PASS
+- [x] **Unverifiable reserves** — ERC-4626 standard. cUSD reserves enumerable onchain (`Vault.totalSupplies(asset)` matches token + strategy balances). Fractional reserve Morpho positions verifiable. Operator yield strategies remain offchain. ⚠️ PARTIAL — core reserves verifiable, operator positions opaque
+- [x] **Total centralization** — 3-of-5 multisig with 24h Timelock (verified `getMinDelay() = 86400`). Not a single EOA or 1-of-N setup. ✅ PASS
 
 **All gates pass (with caveat on operator opacity).** Proceed to category scoring.
 
@@ -366,14 +386,14 @@ Cap's governance flows through a **3-of-5 Gnosis Safe multisig** → **24-hour T
 
 | Factor | Assessment |
 |--------|-----------|
-| Audits | 7 auditors, 8 reports: Trail of Bits, Spearbit (×2), Zellic, Sherlock (contest), Certora, Electisec, Recon (invariant). Premium firms with comprehensive coverage |
+| Audits | 8 auditors, 9 reports: Trail of Bits, Spearbit (×2), Zellic, Sherlock (contest), Certora, Electisec, Recon (invariant), Octane (token, Mar 2026). Premium firms with comprehensive coverage |
 | Bug bounty | $1M on Sherlock (Critical only). No Immunefi |
-| Production history | **~7 months** (August 19, 2025). Relatively new |
-| TVL | **~$288M** total (includes restaker collateral). ~$129M cUSD supply |
+| Production history | **~9 months** (August 19, 2025). Still relatively new |
+| TVL | **~$300M** total (DeFi Llama, Ethereum; includes restaker collateral). ~$97.7M cUSD supply. Peak ~$484M on Jan 28, 2026 |
 | Security incidents | None known |
 | Finding details | Severity breakdowns not publicly summarized |
 
-**Score: 2.0/5** — Excellent audit coverage from premium firms (Trail of Bits, Spearbit, Zellic) with good breadth (core, security network, invariant testing, contest). However, only 7 months of production history is short compared to mature protocols. $1M bug bounty is strong. No incidents to date. The short track record and lack of public finding details prevent a score below 2.
+**Score: 2.0/5** — Excellent audit coverage from premium firms (Trail of Bits, Spearbit, Zellic) with good breadth (core, security network, invariant testing, contest). The added Octane audit in March 2026 strengthens coverage incrementally. ~9 months of production history is still short compared to mature protocols. $1M bug bounty is strong. No incidents to date. The short track record and lack of public finding details prevent a score below 2.
 
 #### Category 2: Centralization & Control Risks (Weight: 30%)
 
@@ -406,12 +426,12 @@ Cap's governance flows through a **3-of-5 Gnosis Safe multisig** → **24-hour T
 
 | Factor | Assessment |
 |--------|-----------|
-| Protocol count | Morpho (critical), Aave V3 (critical), Symbiotic (critical), RedStone (high), USDC/Circle (high), wWTGXX/WisdomTree (low) |
-| Morpho + Aave concentration | ~$75M USDC deployed across Morpho (67%) and Aave (33%). Both are yield dependencies |
+| Protocol count | Morpho (critical), Symbiotic (critical), RedStone (high), USDC/Circle (high), wWTGXX/WisdomTree (low). Aave V3 is wired in but no longer holds reserves |
+| Morpho concentration | ~$48.9M USDC — **100%** of deployed USDC reserves are in Morpho (Steakhouse Prime + Gauntlet Prime). Concentration on a single underlying lending protocol increased materially vs. March's 67/33 Morpho/Aave split |
 | Symbiotic | Novel restaking infrastructure, less battle-tested than established alternatives |
 | Operator counterparties | Institutional firms (IMC, Susquehanna, Edge) — blue-chip but opaque |
 
-**Dependencies Score: 3.0/5** — Heavy dependency on Morpho and Aave V3 for reserve deployment (~$75M USDC split 67/33). Symbiotic integration adds complexity and a dependency on relatively new restaking infrastructure. Multiple oracle dependencies (RedStone). The operator model introduces counterparty risk with institutional firms. More dependencies and more complexity than simple vault protocols.
+**Dependencies Score: 3.0/5** — The total dependency count is similar, but reserve concentration has shifted: 100% of the deployed USDC reserve now sits in Morpho (across two MetaMorpho curators), removing the Aave V3 diversification leg. This raises Morpho-specific risk while keeping cross-protocol risk count flat. Symbiotic integration adds complexity. Multiple oracle dependencies (RedStone). The operator model introduces counterparty risk with institutional firms. Score remains 3.0 — diversification across two curators (Steakhouse, Gauntlet) partially offsets the loss of the Aave leg, and Morpho Blue itself is battle-tested.
 
 **Centralization Score = (2.0 + 2.5 + 3.0) / 3 = 2.5**
 
@@ -423,14 +443,14 @@ Cap's governance flows through a **3-of-5 Gnosis Safe multisig** → **24-hour T
 
 | Factor | Assessment |
 |--------|-----------|
-| Backing | cUSD backed by 2 onchain whitelisted assets: USDC (~96%) and wWTGXX/WisdomTree (~4%). Heavy USDC concentration |
-| Reserve quality | USDC (Circle) is blue-chip. wWTGXX (WisdomTree Gov Money Market) is an institutional tokenized fund with only 7 holders — limited track record in DeFi |
-| Reserve deployment | USDC FRV: ~$50.2M in Morpho + ~$25.0M in Aave V3. ~$48.9M lent to operators. wWTGXX FRV: ~$5M in holder strategy |
+| Backing | cUSD backed by 2 onchain whitelisted assets: USDC (~95%) and wWTGXX/WisdomTree (~5%). Heavy USDC concentration. Per-asset `Vault.totalSupplies()` sums to cUSD total supply (1:1 backing confirmed) |
+| Reserve quality | USDC (Circle) is blue-chip. wWTGXX (WisdomTree Gov Money Market) is an institutional tokenized fund with minimal DeFi track record |
+| Reserve deployment | USDC FRV: ~$29.13M in Morpho Steakhouse Prime + ~$19.73M in Morpho Gauntlet Prime + ~$0 in Aave V3 (deactivated). ~$43.8M lent to operators. wWTGXX FRV: ~$5.08M in holder strategy |
 | Leverage | No direct leverage in reserve. Operators borrow from reserves (over-collateralized via Symbiotic) |
 | Operator collateral | Per-operator Symbiotic delegations (50% default LTV, 80% liquidation threshold) |
 | Verifiability | Reserves onchain. Operator positions partially verifiable (borrow/repay onchain, strategies offchain) |
 
-**Collateralization Score: 2.0/5** — USDC is blue-chip but makes up 96% of reserves (low diversification despite the 40% cap rule). wWTGXX is a tokenized money market fund with minimal DeFi adoption (7 holders). The per-operator over-collateralization via Symbiotic is a strong mechanism. However, the fractional reserve model means reserves are actively deployed (~$75M in Morpho/Aave, ~$49M lent to operators), and operator strategies are offchain.
+**Collateralization Score: 2.0/5** — USDC is blue-chip but makes up 95% of reserves (low diversification despite the 40% cap rule). wWTGXX is a tokenized money market fund with minimal DeFi adoption. The per-operator over-collateralization via Symbiotic is a strong mechanism. However, the fractional reserve model means reserves are actively deployed (~$48.9M now entirely in Morpho, ~$43.8M lent to operators), and operator strategies are offchain.
 
 **Subcategory B: Provability**
 
@@ -452,12 +472,12 @@ Cap's governance flows through a **3-of-5 Gnosis Safe multisig** → **24-hour T
 | Factor | Assessment |
 |--------|-----------|
 | Exit mechanism | stcUSD → cUSD (ERC-4626 redeem) → burn/redeem cUSD for reserves |
-| Morpho/Aave liquidity | ~$75M USDC in Morpho (67%) + Aave (33%). Withdrawal depends on available liquidity in both protocols |
+| Morpho liquidity | ~$48.9M USDC entirely in Morpho (Steakhouse + Gauntlet). Withdrawal depends on Morpho market liquidity for the underlying allocations. Loss of the Aave V3 leg removes a secondary withdrawal venue |
 | cUSD redemption | Proportional basket redemption prevents "last man standing" scenarios |
 | Withdrawal restrictions | No lock for stcUSD. Restaker withdrawals up to 14 days |
-| Large withdrawal impact | With ~$75M in Fractional Reserve and ~$49M lent to operators, a large withdrawal would need to be sourced from Aave or wait for operator repayment |
+| Large withdrawal impact | With ~$48.9M in Fractional Reserve and ~$43.8M lent to operators, a large redemption would need to be sourced from Morpho or wait for operator repayment |
 
-**Score: 3.0/5** — Multiple layers between stcUSD holder and underlying assets (stcUSD → cUSD → reserve assets). ~$75M deployed across Morpho/Aave (liquid but adds dependencies), ~$49M lent to operators (not immediately available — operator epoch-based repayment). The proportional redemption mechanism is well-designed for stress scenarios, but the fractional reserve model means not all capital is immediately liquid. In adverse scenarios (high utilization spikes + operator delays), significant redemptions could face delays.
+**Score: 3.0/5** — Multiple layers between stcUSD holder and underlying assets (stcUSD → cUSD → reserve assets). ~$48.9M deployed entirely through Morpho (liquid in normal conditions but now a single-protocol dependency), ~$43.8M lent to operators (not immediately available — operator epoch-based repayment). The proportional redemption mechanism is well-designed for stress scenarios, but the fractional reserve model means not all capital is immediately liquid. In adverse scenarios (Morpho utilization spike + operator delays), significant redemptions could face delays.
 
 #### Category 5: Operational Risk (Weight: 5%)
 
@@ -502,16 +522,16 @@ Final Score = (Centralization × 0.30) + (Funds Mgmt × 0.30) + (Audits × 0.20)
 
 **Final Risk Tier: Low Risk (2.4/5.0) — Approved with standard monitoring**
 
-The score sits at the upper end of Low risk. The strong audit coverage, institutional backing, and novel security model (Symbiotic restaking) are positives. The key risk drivers are the upgradeable contracts with a weak multisig, offchain operator strategy opacity, Aave concentration, and the relatively short production history (~7 months). Enhanced monitoring is recommended, particularly around operator positions, multisig transactions, and contract upgrade proposals.
+The score is unchanged from the March 2026 assessment. Strong audit coverage (now 8 firms / 9 reports with the added Octane review), institutional backing, novel security model (Symbiotic restaking), and onchain-verified 1:1 backing remain the primary positives. The key risk drivers are unchanged: upgradeable contracts with a 3-of-5 anonymous multisig, offchain operator strategy opacity, and the relatively short production history (~9 months). The shift from 67/33 Morpho/Aave deployment to 100% Morpho is flagged as a watch-item — it raises Morpho-specific risk but is partly offset by curator diversification (Steakhouse + Gauntlet) and is not severe enough on its own to move the score. Enhanced monitoring is recommended, particularly around operator positions, multisig transactions, FRV queue changes (potential Aave V3 reactivation or new strategies), and contract upgrade proposals.
 
 ---
 
 ## Reassessment Triggers
 
-- **Time-based:** Reassess in 6 months (September 2026) or after 12 months of production history
-- **TVL-based:** Reassess if TVL exceeds $500M or changes by more than ±50%
+- **Time-based:** Reassess in 6 months (November 2026) or after 12 months of production history
+- **TVL-based:** Reassess if TVL exceeds $500M or changes by more than ±50% from the current ~$300M
 - **Incident-based:** Reassess after any exploit, operator default, slashing event, or governance incident
 - **Governance-based:** Reassess if multisig threshold or signers change, or if deployer EOA's EXECUTOR_ROLE is revoked (positive signal)
 - **Operator-based:** Reassess if new operators are onboarded or existing operators experience issues
-- **Protocol-based:** Reassess if Morpho or Aave V3 USDC utilization consistently exceeds 90% or if either experiences a security incident
+- **Protocol-based:** Reassess if either Morpho vault (Steakhouse Prime, Gauntlet Prime) utilization consistently exceeds 90% or experiences a security incident; reassess if the Aave V3 leg is reactivated or any new strategy is added to the USDC FRV default queue
 - **Upgrade-based:** Reassess after any contract upgrade via Timelock


### PR DESCRIPTION
Closes #208.
Closes #221 

Refreshes the Cap stcUSD risk report after the 64-day staleness window. All governance roles, multisig signers/threshold, timelock delay, and reserve balances were re-verified onchain via `cast` against Ethereum mainnet.

## Material changes since March 20, 2026

- **USDC Fractional Reserve is now 100% in Morpho** — the Aave V3 strategy has been fully drained (`max_debt = 0`). USDC FRV (~$48.9M) is now split ~60% Morpho Steakhouse Prime / ~40% Morpho Gauntlet Prime. Flagged in dependencies, liquidity, and reassessment triggers; partially offset by curator diversification.
- **Metrics refreshed onchain:**
  - cUSD supply: 129.0M → 97.7M (-24%)
  - stcUSD PPS: 1.0531 → 1.0630 (+0.93%, no loss events)
  - Operator USDC debt: 48.9M → 43.8M
  - DefiLlama TVL: ~$300M (peak ~$484M on Jan 28, 2026)
- **Morpho stcUSD markets shifted** — USDT/stcUSD ($16.6M) is now the largest market (was USDC).
- **New audit:** Octane token audit added March 2026 → 8 firms / 9 reports total.
- **Backing reconciliation:** `Vault.totalSupplies(USDC) + totalSupplies(wWTGXX)` matches cUSD totalSupply (1:1 backing confirmed).

## Onchain governance verification (May 23, 2026)

- Multisig `0xb8FC…8793`: Gnosis Safe v1.4.1, threshold = 3, 5 owners (still anonymous; addresses now enumerated in the report)
- Timelock `0xD823…29ab`: `getMinDelay() = 86400` (24h)
- Multisig has PROPOSER + EXECUTOR + CANCELLER on Timelock
- Deployer EOA has **only** EXECUTOR_ROLE (residual, not revoked)
- AccessControl `0x7731…c683`: enumerated `DEFAULT_ADMIN_ROLE` → exactly 1 holder = the Timelock
- cUSD / stcUSD / AccessControl proxy admin slots all `0x0` (UUPS; upgrades gated by AccessControl)
- cUSD and stcUSD implementations unchanged

## Score

**Final score unchanged at 2.4/5.0 (Low Risk).** The shift from a 67/33 Morpho/Aave split to 100% Morpho raises Morpho-specific risk but is not severe enough to move the score, given curator diversification (Steakhouse + Gauntlet) and Morpho Blue's track record.

## Files

- `reports/report/cap-stcusd.md` — full reassessment update
- `reports/graph/cap-stcusd.yaml` — graph updated for new strategy mix (Steakhouse node added; Aave V3 marked deactivated)

## Test plan

- [ ] Reviewer spot-checks onchain values against current state (RPC or Etherscan)
- [ ] Reviewer confirms the audit count and the Octane PDF link resolves
- [ ] Reviewer agrees the Morpho concentration shift does not warrant a score change
- [ ] CI link-check passes on the updated report