### PR TITLE
Fix reassessment report links

### DIFF
--- a/.github/workflows/reassessment-scan.yml
+++ b/.github/workflows/reassessment-scan.yml
@@ -28,5 +28,6 @@ jobs:
       - name: Scan for stale reports and open reassessment issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           DRY_RUN: ${{ inputs.dry_run && 'true' || '' }}
         run: uv run scripts/check_stale_reports.py

--- a/scripts/check_stale_reports.py
+++ b/scripts/check_stale_reports.py
@@ -24,6 +24,8 @@ REPORTS_DIR = Path("reports/report")
 STALE_DAYS = 60
 LABEL = "reassessment"
 TITLE_PREFIX = "Reassessment: "
+DEFAULT_REPO = "yearn/risk-score"
+PUBLIC_REPORT_BASE_URL = "https://risk.yearn.farm/report"
 
 ASSESSMENT_LINE_RE = re.compile(r"\*\*Assessment Date:\*\*\s*([^\n]+)", re.IGNORECASE)
 WARNING_LINE_RE = re.compile(r"\*\*Warning:\*\*\s*([^\n]+)", re.IGNORECASE)
@@ -121,23 +123,52 @@ def open_reassessment_titles() -> set[str]:
     return {issue["title"] for issue in json.loads(out)}
 
 
-def repo_slug() -> str | None:
-    return os.environ.get("GITHUB_REPOSITORY")
+def extract_repo_slug(remote_url: str) -> str | None:
+    """Return owner/repo from common GitHub remote URL forms."""
+    patterns = (
+        r"github\.com[:/]([^/\s]+)/([^/\s]+?)(?:\.git)?$",
+        r"^git@github\.com:([^/\s]+)/([^/\s]+?)(?:\.git)?$",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, remote_url.strip())
+        if match:
+            return f"{match.group(1)}/{match.group(2)}"
+    return None
+
+
+def git_remote_repo_slug() -> str | None:
+    try:
+        remote_url = subprocess.check_output(
+            ["git", "remote", "get-url", "origin"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return None
+    return extract_repo_slug(remote_url)
+
+
+def repo_slug() -> str:
+    return os.environ.get("GITHUB_REPOSITORY") or git_remote_repo_slug() or DEFAULT_REPO
+
+
+def public_report_url(slug: str) -> str:
+    return f"{PUBLIC_REPORT_BASE_URL}/{slug}/"
+
+
+def source_report_url(slug: str) -> str:
+    return f"https://github.com/{repo_slug()}/blob/master/reports/report/{slug}.md"
 
 
 def build_issue_body(report: dict, days: int) -> str:
-    repo = repo_slug()
     rel = f"reports/report/{report['slug']}.md"
-    if repo:
-        link = f"https://github.com/{repo}/blob/master/{rel}"
-    else:
-        link = rel
     date_str = report["date"].date().isoformat() if report["date"] else "unknown"
     score_str = f"{report['score']}/5.0" if report["score"] else "unknown"
     return (
         f"The risk assessment **{report['title']}** has not been updated in "
         f"{days} days and is due for reassessment.\n\n"
-        f"- **Report:** [`{rel}`]({link})\n"
+        f"- **Report:** [{report['slug']}]({public_report_url(report['slug'])})\n"
+        f"- **Source:** [`{rel}`]({source_report_url(report['slug'])})\n"
         f"- **Last Assessment Date:** {date_str} (source: {report['date_source']})\n"
         f"- **Current Score:** {score_str}\n"
         f"- **Days Since Last Assessment:** {days}\n"

--- a/tests/test_check_stale_reports.py
+++ b/tests/test_check_stale_reports.py
@@ -1,0 +1,63 @@
+import os
+import unittest
+from datetime import datetime, timezone
+from unittest import mock
+
+import scripts.check_stale_reports as stale_reports
+
+
+def sample_report() -> dict:
+    return {
+        "slug": "cap-stcusd",
+        "title": "Protocol Risk Assessment: Cap - stcUSD",
+        "score": "2.4",
+        "date": datetime(2026, 3, 20, tzinfo=timezone.utc),
+        "date_source": "report-header",
+    }
+
+
+class BuildIssueBodyTests(unittest.TestCase):
+    def test_body_uses_absolute_public_and_source_links_with_github_repository(self):
+        with mock.patch.dict(os.environ, {"GITHUB_REPOSITORY": "yearn/risk-score"}):
+            body = stale_reports.build_issue_body(sample_report(), days=68)
+
+        self.assertIn(
+            "- **Report:** [cap-stcusd](https://risk.yearn.farm/report/cap-stcusd/)",
+            body,
+        )
+        self.assertIn(
+            "- **Source:** [`reports/report/cap-stcusd.md`](https://github.com/yearn/risk-score/blob/master/reports/report/cap-stcusd.md)",
+            body,
+        )
+        self.assertIn("- **Last Assessment Date:** 2026-03-20 (source: report-header)", body)
+        self.assertIn("- **Current Score:** 2.4/5.0", body)
+        self.assertIn("- **Days Since Last Assessment:** 68", body)
+        self.assertIn("- **Threshold:** 60 days", body)
+
+    def test_body_without_github_repository_still_has_no_relative_source_link(self):
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(stale_reports, "git_remote_repo_slug", return_value=None),
+        ):
+            body = stale_reports.build_issue_body(sample_report(), days=68)
+
+        self.assertNotIn("](reports/report/cap-stcusd.md)", body)
+        self.assertIn(
+            "- **Source:** [`reports/report/cap-stcusd.md`](https://github.com/yearn/risk-score/blob/master/reports/report/cap-stcusd.md)",
+            body,
+        )
+
+    def test_repo_slug_falls_back_to_github_remote_origin(self):
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(
+                stale_reports.subprocess,
+                "check_output",
+                return_value="git@github.com:yearn/risk-score.git\n",
+            ),
+        ):
+            self.assertEqual(stale_reports.repo_slug(), "yearn/risk-score")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Make reassessment issues link to the public report page.
- Add an absolute GitHub source link with repo fallbacks.
- Pass GITHUB_REPOSITORY explicitly from the workflow.

## Tests
- uv run python -m unittest discover -s tests
- uv run python -m py_compile scripts/check_stale_reports.py
- uv run ruff check scripts/check_stale_reports.py tests/test_check_stale_reports.py