### PR TITLE
Add Pi prompt templates for report workflows

### DIFF
--- a/.pi/agents/dependency-graph-writer.md
+++ b/.pi/agents/dependency-graph-writer.md
@@ -1,7 +1,7 @@
 ---
 name: dependency-graph-writer
 description: Generates or updates contract dependency graph YAML files from completed Yearn risk reports.
-model: deepseek-v4-pro
+model: opencode-go/deepseek-v4-pro
 thinking: high
 skills:
   - generating-dependency-graphs

--- a/.pi/agents/dependency-graph-writer.md
+++ b/.pi/agents/dependency-graph-writer.md
@@ -1,7 +1,7 @@
 ---
 name: dependency-graph-writer
 description: Generates or updates contract dependency graph YAML files from completed Yearn risk reports.
-model: opencode-go/deepseek-v4-pro
+model: deepseek-v4-pro
 thinking: high
 skills:
   - generating-dependency-graphs

--- a/.pi/agents/risk-report-reassessor.md
+++ b/.pi/agents/risk-report-reassessor.md
@@ -1,7 +1,7 @@
 ---
 name: risk-report-reassessor
 description: Refreshes existing Yearn risk reports by validating roles, proxy implementations, TVL, allocations, and reassessment-trigger data.
-model: deepseek-v4-pro
+model: opencode-go/deepseek-v4-pro
 thinking: high
 skills:
   - risk-report-reassessment

--- a/.pi/agents/risk-report-reassessor.md
+++ b/.pi/agents/risk-report-reassessor.md
@@ -1,13 +1,13 @@
 ---
 name: risk-report-reassessor
 description: Refreshes existing Yearn risk reports by validating roles, proxy implementations, TVL, allocations, and reassessment-trigger data.
-model: opencode-go/deepseek-v4-pro
+model: deepseek-v4-pro
 thinking: high
 skills:
   - risk-report-reassessment
   - generating-risk-reports
   - generating-dependency-graphs
-  - Etherscan
+  - etherscan
 ---
 
 Reassess the requested existing risk report.

--- a/.pi/agents/risk-report-reviewer.md
+++ b/.pi/agents/risk-report-reviewer.md
@@ -1,11 +1,11 @@
 ---
 name: risk-report-reviewer
 description: Reviews Yearn risk assessment reports for factual correctness, source quality, unsupported claims, and missing monitoring details.
-model: opencode-go/qwen3.7-max
+model: qwen3.7-max
 thinking: high
 skills:
   - generating-risk-reports
-  - Etherscan
+  - etherscan
 ---
 
 Review the requested risk assessment report for correctness.

--- a/.pi/agents/risk-report-reviewer.md
+++ b/.pi/agents/risk-report-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: risk-report-reviewer
 description: Reviews Yearn risk assessment reports for factual correctness, source quality, unsupported claims, and missing monitoring details.
-model: qwen3.7-max
+model: opencode-go/qwen3.7-max
 thinking: high
 skills:
   - generating-risk-reports

--- a/.pi/agents/risk-report-writer.md
+++ b/.pi/agents/risk-report-writer.md
@@ -1,12 +1,12 @@
 ---
 name: risk-report-writer
 description: Generates or updates Yearn risk assessment reports from verified on-chain and off-chain evidence.
-model: opencode-go/deepseek-v4-pro
+model: deepseek-v4-pro
 thinking: high
 skills:
   - generating-risk-reports
   - generating-dependency-graphs
-  - Etherscan
+  - etherscan
 ---
 
 Generate or update the requested risk assessment report.

--- a/.pi/agents/risk-report-writer.md
+++ b/.pi/agents/risk-report-writer.md
@@ -1,7 +1,7 @@
 ---
 name: risk-report-writer
 description: Generates or updates Yearn risk assessment reports from verified on-chain and off-chain evidence.
-model: deepseek-v4-pro
+model: opencode-go/deepseek-v4-pro
 thinking: high
 skills:
   - generating-risk-reports

--- a/.pi/prompts/graph.md
+++ b/.pi/prompts/graph.md
@@ -1,0 +1,10 @@
+---
+description: Generate or update a dependency graph from a report
+argument-hint: "<report-path-or-slug>"
+---
+
+Use the `dependency-graph-writer` agent to create or update the dependency graph for:
+
+$ARGUMENTS
+
+Follow `reports/graph/SKILL.md`. Work from the completed report unless explicitly asked to do additional research. Keep the graph at `reports/graph/<slug>.yaml`, validate it with the project build when possible, and open a draft PR when the graph task is ready.

--- a/.pi/prompts/reassess.md
+++ b/.pi/prompts/reassess.md
@@ -1,0 +1,10 @@
+---
+description: Reassess an existing risk report
+argument-hint: "<report-path-or-slug>"
+---
+
+Use the `risk-report-reassessor` agent to reassess:
+
+$ARGUMENTS
+
+Before editing, pull the latest `master`. Use RPC and API variables from `.env` through `scripts/env.py`. Refresh privileged roles, proxy implementations, TVL, allocations, reassessment triggers, and other current-state data. Check the dependency graph and regenerate it if allocations, dependencies, governance, proxy, or mint-authority facts changed. Open a draft PR when the task is ready.

--- a/.pi/prompts/report.md
+++ b/.pi/prompts/report.md
@@ -1,0 +1,12 @@
+---
+description: Generate or update a risk report and graph
+argument-hint: "<protocol-or-token>"
+---
+
+Use the `risk-report-writer` agent to create or update the risk report for:
+
+$ARGUMENTS
+
+Follow `CLAUDE.md`, `reports/skill.md`, `reports/README.md`, `reports/etherscan/SKILL.md`, and `reports/graph/SKILL.md`.
+
+Before editing, pull the latest `master`. Use RPC and API variables from `.env` through `scripts/env.py`. Verify protocol documentation claims onchain where possible, include valid source links for claims and data, create or update the matching dependency graph, and open a draft PR when the task is ready.

--- a/.pi/prompts/review-report.md
+++ b/.pi/prompts/review-report.md
@@ -1,0 +1,12 @@
+---
+description: Review a risk report for correctness and evidence quality
+argument-hint: "<report-path-or-slug>"
+---
+
+Use the `risk-report-reviewer` agent to review:
+
+$ARGUMENTS
+
+Focus on unsupported claims, stale data, low-quality sources, incorrect addresses, roles, proxy implementations, TVL, allocations, liquidity risk, collateralization, provability, score reasoning, and missing monitoring details.
+
+Return findings first, ordered by severity. Do not rewrite the report unless explicitly asked.

--- a/reports/etherscan/SKILL.md
+++ b/reports/etherscan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Etherscan
+name: etherscan
 description: Documentation and capabilities reference for Etherscan
 metadata:
   mintlify-proj: etherscan


### PR DESCRIPTION
## Summary
- Add Pi prompt templates for report, review, reassessment, and graph workflows
- Keep explicit OpenCode Go model IDs in agent frontmatter, e.g. `opencode-go/deepseek-v4-pro`, so Pi resolves the intended provider
- Rename the Etherscan skill id to lowercase `etherscan` and update agent references so Pi loads it without a skill conflict

## Notes
- Intended Takopi usage: send `/pi` on the first line, then a Pi template such as `/reassess yearn-yvusdc` on the next line if Takopi intercepts leading slash commands.
- Project must be trusted by Pi for headless Takopi runs to load project-local `.pi` resources.

## Validation
- `git diff --cached --check`
- Checked skill/model/prompt identifiers with `rg`
- VPS model-resolution test showed bare `deepseek-v4-pro` resolves to native `deepseek`, so agent configs intentionally use provider-prefixed `opencode-go/...` model IDs.
