### PR TITLE
Plan: API-driven monitoring page + per-protocol alert history

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,9 @@ SONICSCAN_API_KEY=your-sonicscan-api-key
 # backend (CACHE_DIR=/tmp/monitoring-cache uv run python -m api) and use:
 # MONITORING_API_URL=http://127.0.0.1:8923
 MONITORING_API_URL=https://your-monitoring-host
+
+# Bearer token for the alerts API, forwarded by the edge proxy as
+# `Authorization: Bearer <token>`. Required when the reverse proxy enforces auth
+# (production); leave unset for the unauthenticated local backend. Secret — set
+# it in the Vercel project env, never commit a real value.
+MONITORING_API_TOKEN=your-monitoring-api-token

--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,10 @@ RPC_146=https://rpc.sonic.neuralinternet.ai
 ETHERSCAN_API_KEY=your-etherscan-api-key
 POLYGONSCAN_API_KEY=your-polygonscan-api-key
 SONICSCAN_API_KEY=your-sonicscan-api-key
+
+# Base URL of the yearn/monitoring alerts API, consumed server-side by the
+# api/monitoring.ts edge proxy (the browser never calls the backend directly).
+# Point at the reverse-proxied host in production; for local testing run the
+# backend (CACHE_DIR=/tmp/monitoring-cache uv run python -m api) and use:
+# MONITORING_API_URL=http://127.0.0.1:8923
+MONITORING_API_URL=https://your-monitoring-host

--- a/api/monitoring.test.ts
+++ b/api/monitoring.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test'
+import { getUpstreamPath } from './monitoring'
+
+describe('getUpstreamPath', () => {
+  test('maps /api/monitoring/protocols to /v1/protocols', () => {
+    const url = new URL('http://localhost/api/monitoring/protocols')
+    expect(getUpstreamPath(url)).toEqual({ path: '/v1/protocols' })
+  })
+
+  test('maps /api/monitoring/alerts with no query to /v1/alerts', () => {
+    const url = new URL('http://localhost/api/monitoring/alerts')
+    expect(getUpstreamPath(url)).toEqual({ path: '/v1/alerts' })
+  })
+
+  test('forwards whitelisted alert params verbatim', () => {
+    const url = new URL('http://localhost/api/monitoring/alerts?protocol=aave&severity=HIGH&limit=5')
+    expect(getUpstreamPath(url)).toEqual({ path: '/v1/alerts?protocol=aave&severity=HIGH&limit=5' })
+  })
+
+  test('forwards cursor pagination param', () => {
+    const url = new URL('http://localhost/api/monitoring/alerts?cursor=5021&limit=100')
+    expect(getUpstreamPath(url)).toEqual({ path: '/v1/alerts?cursor=5021&limit=100' })
+  })
+
+  test('maps single-alert path /api/monitoring/alerts/{id}', () => {
+    const url = new URL('http://localhost/api/monitoring/alerts/5021')
+    expect(getUpstreamPath(url)).toEqual({ path: '/v1/alerts/5021' })
+  })
+
+  test('tolerates a trailing slash', () => {
+    const url = new URL('http://localhost/api/monitoring/protocols/')
+    expect(getUpstreamPath(url)).toEqual({ path: '/v1/protocols' })
+  })
+
+  test('rejects an unsupported query param', () => {
+    const url = new URL('http://localhost/api/monitoring/alerts?protocol=aave&evil=1')
+    expect(getUpstreamPath(url)).toEqual({ error: 'unsupported query param: evil', status: 400 })
+  })
+
+  test('rejects an invalid severity', () => {
+    const url = new URL('http://localhost/api/monitoring/alerts?severity=URGENT')
+    expect(getUpstreamPath(url)).toEqual({ error: 'invalid severity', status: 400 })
+  })
+
+  test('rejects a non-numeric limit', () => {
+    const url = new URL('http://localhost/api/monitoring/alerts?limit=abc')
+    expect(getUpstreamPath(url)).toEqual({ error: 'invalid limit', status: 400 })
+  })
+
+  test('rejects a protocol with unsafe characters', () => {
+    const url = new URL('http://localhost/api/monitoring/alerts?protocol=../../etc')
+    expect(getUpstreamPath(url)).toEqual({ error: 'invalid protocol', status: 400 })
+  })
+
+  test('rejects an unknown sub-path', () => {
+    const url = new URL('http://localhost/api/monitoring/secrets')
+    expect(getUpstreamPath(url)).toEqual({ error: 'not found', status: 404 })
+  })
+
+  test('rejects a non-numeric alert id', () => {
+    const url = new URL('http://localhost/api/monitoring/alerts/not-a-number')
+    expect(getUpstreamPath(url)).toEqual({ error: 'not found', status: 404 })
+  })
+
+  test('rejects a path outside /api/monitoring/', () => {
+    const url = new URL('http://localhost/api/other')
+    expect(getUpstreamPath(url)).toEqual({ error: 'bad path', status: 400 })
+  })
+})

--- a/api/monitoring.test.ts
+++ b/api/monitoring.test.ts
@@ -42,6 +42,11 @@ describe('getUpstreamPath', () => {
     expect(getUpstreamPath(url)).toEqual({ error: 'invalid severity', status: 400 })
   })
 
+  test('rejects a param outside the allowlist (e.g. since)', () => {
+    const url = new URL('http://localhost/api/monitoring/alerts?since=2026-06-11T00:00:00Z')
+    expect(getUpstreamPath(url)).toEqual({ error: 'unsupported query param: since', status: 400 })
+  })
+
   test('rejects a non-numeric limit', () => {
     const url = new URL('http://localhost/api/monitoring/alerts?limit=abc')
     expect(getUpstreamPath(url)).toEqual({ error: 'invalid limit', status: 400 })

--- a/api/monitoring.test.ts
+++ b/api/monitoring.test.ts
@@ -22,6 +22,12 @@ describe('getUpstreamPath', () => {
     expect(getUpstreamPath(url)).toEqual({ path: '/v1/alerts?cursor=5021&limit=100' })
   })
 
+  test('strips the `path` param injected by the vercel rewrite', () => {
+    // Vercel's /api/monitoring/:path* rewrite appends ?path=alerts to the destination.
+    const url = new URL('http://localhost/api/monitoring/alerts?path=alerts&protocol=aave&limit=5')
+    expect(getUpstreamPath(url)).toEqual({ path: '/v1/alerts?protocol=aave&limit=5' })
+  })
+
   test('maps single-alert path /api/monitoring/alerts/{id}', () => {
     const url = new URL('http://localhost/api/monitoring/alerts/5021')
     expect(getUpstreamPath(url)).toEqual({ path: '/v1/alerts/5021' })

--- a/api/monitoring.ts
+++ b/api/monitoring.ts
@@ -13,12 +13,19 @@ export const config = { runtime: 'edge' }
 const ALLOWED_PARAMS = ['protocol', 'severity', 'source', 'from', 'to', 'cursor', 'limit']
 const SEVERITIES = new Set(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'])
 
+// The vercel.json `/api/monitoring/:path*` rewrite injects the matched sub-path as a `path`
+// query param. It's a routing artifact (routing uses url.pathname), so skip it here instead of
+// rejecting it as an unsupported param or forwarding it upstream.
+const REWRITE_PARAM = 'path'
+
 type UpstreamResult = { path: string } | { error: string; status: number }
 
-// Rejects any non-allowlisted or malformed alerts param. On success the (already validated)
-// querystring is forwarded verbatim, so there is nothing to return.
-function validateAlertsQuery(search: URLSearchParams): { error: string; status: number } | null {
+// Validates the alerts params and returns the allowlisted query to forward (the `path` rewrite
+// artifact and anything non-allowlisted are excluded / rejected).
+function validateAlertsQuery(search: URLSearchParams): { query: URLSearchParams } | { error: string; status: number } {
+  const out = new URLSearchParams()
   for (const [key, value] of search) {
+    if (key === REWRITE_PARAM) continue
     if (!ALLOWED_PARAMS.includes(key)) {
       return { error: `unsupported query param: ${key}`, status: 400 }
     }
@@ -34,8 +41,9 @@ function validateAlertsQuery(search: URLSearchParams): { error: string; status: 
     if ((key === 'from' || key === 'to') && !/^[0-9T:+.\- Z]+$/.test(value)) {
       return { error: `invalid ${key}`, status: 400 }
     }
+    out.append(key, value)
   }
-  return null
+  return { query: out }
 }
 
 // Maps an inbound `/api/monitoring/*` URL to the upstream path under MONITORING_API_URL.
@@ -50,9 +58,9 @@ export function getUpstreamPath(url: URL): UpstreamResult {
   }
 
   if (sub === 'alerts') {
-    const error = validateAlertsQuery(url.searchParams)
-    if (error) return error
-    const qs = url.searchParams.toString()
+    const result = validateAlertsQuery(url.searchParams)
+    if ('error' in result) return result
+    const qs = result.query.toString()
     return { path: qs ? `/v1/alerts?${qs}` : '/v1/alerts' }
   }
 

--- a/api/monitoring.ts
+++ b/api/monitoring.ts
@@ -5,6 +5,10 @@ export const config = { runtime: 'edge' }
 // browser cannot call it directly. This function fetches the internal API server-side and injects
 // CORS + caching. Only the read-only `/v1/protocols`, `/v1/alerts` and `/v1/alerts/{id}` endpoints
 // are exposed, and the alerts querystring is whitelisted to avoid open proxying.
+//
+// Config (Vercel project env): MONITORING_API_URL (required) is the public reverse-proxied base
+// URL; MONITORING_API_TOKEN (optional) is forwarded as `Authorization: Bearer <token>` and stays
+// server-side — never sent to the browser.
 
 const ALLOWED_PARAMS = ['protocol', 'severity', 'source', 'from', 'to', 'cursor', 'limit']
 const SEVERITIES = new Set(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'])
@@ -101,9 +105,13 @@ export default async function handler(req: Request): Promise<Response> {
       return jsonError(resolved.status, code, resolved.error)
     }
 
-    const upstreamRes = await fetch(`${base}${resolved.path}`, {
-      headers: { accept: 'application/json' },
-    })
+    // Forward a bearer token if configured. It stays server-side in the edge function and is
+    // never sent to the browser. Optional so the unauthenticated local backend still works.
+    const requestHeaders: Record<string, string> = { accept: 'application/json' }
+    const token = process.env.MONITORING_API_TOKEN
+    if (token) requestHeaders.authorization = `Bearer ${token}`
+
+    const upstreamRes = await fetch(`${base}${resolved.path}`, { headers: requestHeaders })
 
     const body = await upstreamRes.text()
     const headers = new Headers({

--- a/api/monitoring.ts
+++ b/api/monitoring.ts
@@ -6,13 +6,14 @@ export const config = { runtime: 'edge' }
 // CORS + caching. Only the read-only `/v1/protocols`, `/v1/alerts` and `/v1/alerts/{id}` endpoints
 // are exposed, and the alerts querystring is whitelisted to avoid open proxying.
 
-const ALLOWED_PARAMS = ['protocol', 'severity', 'source', 'from', 'to', 'since', 'cursor', 'limit']
+const ALLOWED_PARAMS = ['protocol', 'severity', 'source', 'from', 'to', 'cursor', 'limit']
 const SEVERITIES = new Set(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'])
 
 type UpstreamResult = { path: string } | { error: string; status: number }
 
-function validateAlertsQuery(search: URLSearchParams): { query: URLSearchParams } | { error: string; status: number } {
-  const out = new URLSearchParams()
+// Rejects any non-allowlisted or malformed alerts param. On success the (already validated)
+// querystring is forwarded verbatim, so there is nothing to return.
+function validateAlertsQuery(search: URLSearchParams): { error: string; status: number } | null {
   for (const [key, value] of search) {
     if (!ALLOWED_PARAMS.includes(key)) {
       return { error: `unsupported query param: ${key}`, status: 400 }
@@ -26,12 +27,11 @@ function validateAlertsQuery(search: URLSearchParams): { query: URLSearchParams 
     if ((key === 'protocol' || key === 'source') && !/^[a-zA-Z0-9_-]+$/.test(value)) {
       return { error: `invalid ${key}`, status: 400 }
     }
-    if ((key === 'from' || key === 'to' || key === 'since') && !/^[0-9T:+.\- Z]+$/.test(value)) {
+    if ((key === 'from' || key === 'to') && !/^[0-9T:+.\- Z]+$/.test(value)) {
       return { error: `invalid ${key}`, status: 400 }
     }
-    out.append(key, value)
   }
-  return { query: out }
+  return null
 }
 
 // Maps an inbound `/api/monitoring/*` URL to the upstream path under MONITORING_API_URL.
@@ -46,9 +46,9 @@ export function getUpstreamPath(url: URL): UpstreamResult {
   }
 
   if (sub === 'alerts') {
-    const result = validateAlertsQuery(url.searchParams)
-    if ('error' in result) return result
-    const qs = result.query.toString()
+    const error = validateAlertsQuery(url.searchParams)
+    if (error) return error
+    const qs = url.searchParams.toString()
     return { path: qs ? `/v1/alerts?${qs}` : '/v1/alerts' }
   }
 

--- a/api/monitoring.ts
+++ b/api/monitoring.ts
@@ -1,0 +1,124 @@
+export const config = { runtime: 'edge' }
+
+// Edge proxy for the yearn/monitoring alerts API (github.com/yearn/monitoring, api/server.py).
+// The upstream binds to 127.0.0.1, sets no CORS headers and `Cache-Control: no-store`, so the
+// browser cannot call it directly. This function fetches the internal API server-side and injects
+// CORS + caching. Only the read-only `/v1/protocols`, `/v1/alerts` and `/v1/alerts/{id}` endpoints
+// are exposed, and the alerts querystring is whitelisted to avoid open proxying.
+
+const ALLOWED_PARAMS = ['protocol', 'severity', 'source', 'from', 'to', 'since', 'cursor', 'limit']
+const SEVERITIES = new Set(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'])
+
+type UpstreamResult = { path: string } | { error: string; status: number }
+
+function validateAlertsQuery(search: URLSearchParams): { query: URLSearchParams } | { error: string; status: number } {
+  const out = new URLSearchParams()
+  for (const [key, value] of search) {
+    if (!ALLOWED_PARAMS.includes(key)) {
+      return { error: `unsupported query param: ${key}`, status: 400 }
+    }
+    if (key === 'severity' && !SEVERITIES.has(value)) {
+      return { error: 'invalid severity', status: 400 }
+    }
+    if ((key === 'cursor' || key === 'limit') && !/^\d+$/.test(value)) {
+      return { error: `invalid ${key}`, status: 400 }
+    }
+    if ((key === 'protocol' || key === 'source') && !/^[a-zA-Z0-9_-]+$/.test(value)) {
+      return { error: `invalid ${key}`, status: 400 }
+    }
+    if ((key === 'from' || key === 'to' || key === 'since') && !/^[0-9T:+.\- Z]+$/.test(value)) {
+      return { error: `invalid ${key}`, status: 400 }
+    }
+    out.append(key, value)
+  }
+  return { query: out }
+}
+
+// Maps an inbound `/api/monitoring/*` URL to the upstream path under MONITORING_API_URL.
+export function getUpstreamPath(url: URL): UpstreamResult {
+  if (!url.pathname.startsWith('/api/monitoring/')) {
+    return { error: 'bad path', status: 400 }
+  }
+  const sub = url.pathname.slice('/api/monitoring/'.length).replace(/\/+$/, '')
+
+  if (sub === 'protocols') {
+    return { path: '/v1/protocols' }
+  }
+
+  if (sub === 'alerts') {
+    const result = validateAlertsQuery(url.searchParams)
+    if ('error' in result) return result
+    const qs = result.query.toString()
+    return { path: qs ? `/v1/alerts?${qs}` : '/v1/alerts' }
+  }
+
+  const single = sub.match(/^alerts\/(\d+)$/)
+  if (single) {
+    return { path: `/v1/alerts/${single[1]}` }
+  }
+
+  return { error: 'not found', status: 404 }
+}
+
+function jsonError(status: number, code: string, message: string): Response {
+  return new Response(JSON.stringify({ error: code, message }), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'access-control-allow-origin': '*',
+      'cache-control': 'no-store',
+    },
+  })
+}
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'access-control-allow-origin': '*',
+        'access-control-allow-methods': 'GET, OPTIONS',
+        'access-control-allow-headers': '*',
+        'access-control-max-age': '86400',
+      },
+    })
+  }
+
+  if (req.method !== 'GET') {
+    return jsonError(405, 'method_not_allowed', 'only GET is supported')
+  }
+
+  const base = (process.env.MONITORING_API_URL || '').replace(/\/+$/, '')
+  if (!base) {
+    return jsonError(500, 'not_configured', 'MONITORING_API_URL is not set')
+  }
+
+  try {
+    const url = new URL(req.url)
+    const resolved = getUpstreamPath(url)
+    if ('error' in resolved) {
+      const code = resolved.status === 404 ? 'not_found' : 'bad_request'
+      return jsonError(resolved.status, code, resolved.error)
+    }
+
+    const upstreamRes = await fetch(`${base}${resolved.path}`, {
+      headers: { accept: 'application/json' },
+    })
+
+    const body = await upstreamRes.text()
+    const headers = new Headers({
+      'content-type': 'application/json',
+      'access-control-allow-origin': '*',
+    })
+    // Override the upstream's `no-store`; alert history tolerates brief staleness.
+    headers.set(
+      'cache-control',
+      upstreamRes.ok ? 'public, max-age=30, s-maxage=60, stale-while-revalidate=120' : 'no-store',
+    )
+
+    return new Response(body, { status: upstreamRes.status, headers })
+  } catch (error) {
+    console.error('monitoring proxy error:', error)
+    return jsonError(502, 'upstream_unreachable', 'failed to reach the monitoring API')
+  }
+}

--- a/proposals/monitoring-api-integration.md
+++ b/proposals/monitoring-api-integration.md
@@ -1,0 +1,152 @@
+# Plan: API-driven monitoring page + per-protocol alert history
+
+- **Repository:** `github.com/yearn/risk-score`
+- **Depends on:** `github.com/yearn/monitoring` alerts API (PR #273, merged to `main`)
+- **Status:** Draft / planning
+
+## Context
+
+The monitoring page (`/monitoring`) is currently static — it renders a hardcoded list of
+monitored protocols and their monitor descriptions from `src/data/monitoring.ts`, with no
+live data. Alerts only go to Telegram.
+
+The `monitoring-scripts-py` backend now ships a read-only HTTP API (merged on `main`, PR #273)
+backed by SQLite. It exposes:
+
+- `GET /v1/protocols` — `{ data: [{ name, tasks: [{ name, script, args, profile, cron }] }], count }`
+  (protocol = `protocols/<name>/` dir, cadence from `jobs.yaml`).
+- `GET /v1/alerts?protocol=&severity=&source=&from=&to=&cursor=&limit=` — newest-first,
+  cursor-paginated `{ data: [AlertEvent], next_cursor, limit }`.
+- `GET /v1/alerts/{id}` — single alert.
+- AlertEvent fields: `id, created_at, source, protocol, channel, severity (LOW|MEDIUM|HIGH|CRITICAL),
+  message, plain_text, silent, delivery_status, delivered_at, delivery_error, metadata`.
+
+Goal: surface live alert history on the site so users can see *what fired*, not just *what is watched*.
+
+Two backend constraints drive the design:
+
+1. The API binds to `127.0.0.1:8923` behind a reverse proxy and **sets no CORS headers** and
+   `Cache-Control: no-store` — the browser cannot call it directly.
+2. Protocol identifiers differ between the two repos (`monitoring.ts` uses display ids like
+   `aave-v3`/`compound-v3`/`maker-dao`/`superstate-ustb`; the API uses dir names `aave`/`compound`/
+   `maker`/`ustb`). Some site protocols (`silo`, `pendle`, `euler`) have no API job yet, and some
+   API protocols (`bad-debt`, `spark`, `stables`, `safe`, `timelock`) aren't on the site list.
+
+## Decisions
+
+- **Per-protocol detail pages** at `/monitoring/[id]` (static-generated like `report/[slug].astro`),
+  each fetching its own alert history client-side.
+- **Vercel Edge Function proxy** — reuse the `api/cdn.ts` pattern. The browser calls our own
+  `/api/monitoring/*`; the edge function fetches the internal API and injects CORS + caching.
+- **MVP first, then iterate.** Phase 1 = proxy + recent alerts. Phase 2 = full history pages.
+
+---
+
+## Phase 1 — MVP (edge proxy + recent alerts)
+
+### 1.1 Edge proxy: `api/monitoring.ts` (new)
+
+Model on `api/cdn.ts` (`export const config = { runtime: 'edge' }`, OPTIONS preflight, CORS headers,
+GET-only, try/catch).
+
+- Read base URL from `process.env.MONITORING_API_URL` (e.g. `https://<monitoring-host>`); return 500
+  if unset.
+- Allowlist only the two upstream paths and forward the querystring verbatim:
+  - `/api/monitoring/protocols` → `${BASE}/v1/protocols`
+  - `/api/monitoring/alerts`    → `${BASE}/v1/alerts?<query>`
+  - (Phase 2) `/api/monitoring/alerts/{id}` → `${BASE}/v1/alerts/{id}`
+- Validate/whitelist forwarded query params (`protocol, severity, source, from, to, cursor, limit`)
+  to avoid open proxying; reject anything else.
+- Override upstream `no-store` with `cache-control: public, max-age=30, s-maxage=60,
+  stale-while-revalidate=120` and `access-control-allow-origin: *` (same header style as `api/cdn.ts`).
+- Add `MONITORING_API_URL` to `.env.example` and set it in Vercel project env.
+- Add a `vercel.json` rewrite if pretty paths are wanted (optional; `/api/monitoring/*` resolves
+  natively without one).
+
+### 1.2 Protocol → API mapping in `src/data/monitoring.ts`
+
+Add an optional `apiProtocol?: string` field to the `Protocol` interface (top of the file, ~line 7)
+and populate it for every protocol that has an API job. Map the mismatches explicitly:
+`aave-v3→aave`, `compound-v3→compound`, `maker-dao→maker`, `superstate-ustb→ustb`,
+`rtoken→rtoken`, `lrt-pegs→lrt-pegs`, etc. Leave `apiProtocol` unset for `silo`/`pendle`/`euler`
+(no backend job yet) so the UI can omit live data for them gracefully.
+
+### 1.3 Shared client helper: `src/lib/monitoring.ts` (new)
+
+- TypeScript types `AlertEvent` and `AlertsResponse` mirroring the API shape (see Context).
+- `fetchAlerts(params)` → `GET /api/monitoring/alerts?…` returning `AlertsResponse`.
+- A severity→style/emoji map reused by both the list and detail views
+  (LOW ℹ️, MEDIUM ⚠️, HIGH 🚨, CRITICAL 🔴 — matches backend `utils/alert.py`).
+- Keep all fetching **client-side** (browser → our edge proxy); do not fetch at build time so the
+  static site stays decoupled from backend uptime.
+
+### 1.4 Monitoring list page: `src/pages/monitoring.astro` (edit)
+
+- Render each accordion card with `data-api-protocol={p.apiProtocol}` and link the header to
+  `/monitoring/{p.id}/`.
+- Add an inline `<script>` (extend the existing one at ~line 93) that, for cards with an
+  `apiProtocol`, calls `fetchAlerts({ protocol, limit: 1 })` and renders a small "last alert"
+  badge (relative time + severity dot). Batch/guard requests; fail silently to the current static
+  view on error.
+
+### 1.5 Detail page: `src/pages/monitoring/[id].astro` (new)
+
+- `getStaticPaths()` from `protocols` in `src/data/monitoring.ts` (same pattern as
+  `src/pages/report/[slug].astro`).
+- Server-render the static header (icon via `protocolIconUrl`, name, frequency, monitor
+  descriptions from `items[]`) so the page is useful even with JS off.
+- Client `<script>` fetches recent alerts via `fetchAlerts({ protocol: apiProtocol, limit: 20 })`
+  and renders a history list (time, severity, message). Show an empty/"no alerts" state, and a
+  "live history not yet available" note when `apiProtocol` is unset.
+- Reuse `BaseLayout.astro`; mirror styling/classes from `monitoring.astro` and `report/[slug].astro`.
+
+---
+
+## Phase 2 — Full history (iterate)
+
+- Detail page: severity/source filters + cursor pagination ("Load more" using `next_cursor`).
+- Optionally drive the protocol **list/cadence** from `GET /v1/protocols` (merge live cron/profile
+  with the human-readable descriptions in `monitoring.ts`, joined on `apiProtocol`); flag drift
+  between the two sources.
+- Optional `/api/monitoring/alerts/{id}` passthrough for deep-linking a single alert.
+- Consider a global "recent alerts" feed on the page or home.
+
+---
+
+## Critical files
+
+| File | Action |
+|------|--------|
+| `api/monitoring.ts` | **new** — edge proxy (pattern: `api/cdn.ts`) |
+| `src/lib/monitoring.ts` | **new** — types + `fetchAlerts` + severity map |
+| `src/data/monitoring.ts` | edit — add `apiProtocol?` field + values |
+| `src/pages/monitoring.astro` | edit — last-alert badge + links to detail |
+| `src/pages/monitoring/[id].astro` | **new** — detail page (pattern: `report/[slug].astro`) |
+| `.env.example` | edit — add `MONITORING_API_URL` |
+| Vercel project env | add `MONITORING_API_URL` (ops) |
+
+All work stays in `risk-score`; no changes to `monitoring-scripts-py` (API already supports the
+needed endpoints).
+
+## Reuse (don't reinvent)
+
+- `api/cdn.ts` — edge runtime config, OPTIONS preflight, CORS + cache-control headers, error handling.
+- `src/lib/icons.ts` `protocolIconUrl()` — protocol icons.
+- `src/pages/report/[slug].astro` — `getStaticPaths` dynamic-route pattern.
+- `src/layouts/BaseLayout.astro` — page shell.
+- Severity emojis/levels — mirror `monitoring-scripts-py/utils/alert.py`.
+
+## Verification
+
+1. **Backend reachable:** run the API locally — from `monitoring-scripts-py`:
+   `CACHE_DIR=/tmp/monitoring-cache uv run python -m api`, then
+   `curl 'http://127.0.0.1:8923/v1/protocols'` and `curl 'http://127.0.0.1:8923/v1/alerts?limit=5'`.
+2. **Proxy:** set `MONITORING_API_URL=http://127.0.0.1:8923`, run `npm run dev`, then
+   `curl 'http://localhost:4321/api/monitoring/alerts?protocol=aave&limit=5'` — expect JSON with
+   CORS + non-`no-store` cache headers; confirm disallowed params are rejected.
+3. **List page:** load `/monitoring`, confirm cards with `apiProtocol` show a last-alert badge and
+   that protocols without one (e.g. Silo) degrade gracefully.
+4. **Detail page:** load `/monitoring/aave`, confirm static header renders and alert history
+   populates; check empty state on a protocol with no alerts.
+5. **Build:** `npm run build` succeeds and generates a static page per protocol id.
+6. **Format:** repo formatting passes before merge.

--- a/src/data/monitoring.ts
+++ b/src/data/monitoring.ts
@@ -9,6 +9,11 @@ export interface Protocol {
   defillamaSlug: string;
   frequency: string;
   items: MonitoringItem[];
+  // Protocol name in the alerts API (= the `protocols/<name>/` dir in yearn/monitoring, as
+  // returned by GET /v1/protocols). Site ids differ from API names (e.g. aave-v3 -> aave), so
+  // this is the join key for live alert history. Left unset for protocols with no enabled
+  // backend job yet (euler, pendle, silo) — the UI omits live data for those.
+  apiProtocol?: string;
 }
 
 export const protocols: Protocol[] = [
@@ -17,6 +22,7 @@ export const protocols: Protocol[] = [
     name: "3Jane",
     defillamaSlug: "3jane",
     frequency: "Hourly",
+    apiProtocol: "3jane",
     items: [
       {
         label: "Price Per Share",
@@ -49,6 +55,7 @@ export const protocols: Protocol[] = [
     name: "Aave V3",
     defillamaSlug: "aave-v3",
     frequency: "Hourly",
+    apiProtocol: "aave",
     items: [
       {
         label: "Bad Debt Ratio",
@@ -78,6 +85,7 @@ export const protocols: Protocol[] = [
     name: "CAP",
     defillamaSlug: "cap-protocol",
     frequency: "Daily",
+    apiProtocol: "cap",
     items: [
       {
         label: "Withdrawable Liquidity",
@@ -95,6 +103,7 @@ export const protocols: Protocol[] = [
     name: "Compound V3",
     defillamaSlug: "compound-v3",
     frequency: "Hourly / Daily",
+    apiProtocol: "compound",
     items: [
       {
         label: "Market Utilization",
@@ -124,6 +133,7 @@ export const protocols: Protocol[] = [
     name: "Ethena",
     defillamaSlug: "ethena",
     frequency: "Daily",
+    apiProtocol: "ethena",
     items: [
       {
         label: "USDe Backing Ratio",
@@ -173,6 +183,7 @@ export const protocols: Protocol[] = [
     name: "Fluid",
     defillamaSlug: "fluid",
     frequency: "Hourly",
+    apiProtocol: "fluid",
     items: [
       {
         label: "Governance Proposals",
@@ -189,6 +200,7 @@ export const protocols: Protocol[] = [
     name: "Infinifi",
     defillamaSlug: "infinifi",
     frequency: "Hourly",
+    apiProtocol: "infinifi",
     items: [
       {
         label: "Reserves & Backing",
@@ -225,6 +237,7 @@ export const protocols: Protocol[] = [
     name: "Lido",
     defillamaSlug: "lido",
     frequency: "Hourly / Real-time",
+    apiProtocol: "lido",
     items: [
       {
         label: "DAO Voting",
@@ -259,6 +272,7 @@ export const protocols: Protocol[] = [
     name: "LRT Pegs",
     defillamaSlug: "",
     frequency: "Hourly",
+    apiProtocol: "lrt-pegs",
     items: [
       {
         label: "Curve Pool Depegs",
@@ -296,6 +310,7 @@ export const protocols: Protocol[] = [
     name: "Maker DAO",
     defillamaSlug: "sky",
     frequency: "Hourly",
+    apiProtocol: "maker",
     items: [
       {
         label: "Executive Proposals",
@@ -324,6 +339,7 @@ export const protocols: Protocol[] = [
     name: "Maple Finance",
     defillamaSlug: "maple",
     frequency: "Hourly / Daily",
+    apiProtocol: "maple",
     items: [
       {
         label: "Price Per Share",
@@ -360,6 +376,7 @@ export const protocols: Protocol[] = [
     name: "Morpho",
     defillamaSlug: "morpho",
     frequency: "Hourly / Daily",
+    apiProtocol: "morpho",
     items: [
       {
         label: "Governance Timelock",
@@ -418,6 +435,7 @@ export const protocols: Protocol[] = [
     name: "RToken (ETH+)",
     defillamaSlug: "reserve-protocol",
     frequency: "Hourly / Real-time",
+    apiProtocol: "rtoken",
     items: [
       {
         label: "Collateral Coverage",
@@ -467,6 +485,7 @@ export const protocols: Protocol[] = [
     name: "Strata",
     defillamaSlug: "strata-finance",
     frequency: "Daily",
+    apiProtocol: "strata",
     items: [
       {
         label: "srUSDe Exchange Rate",
@@ -505,6 +524,7 @@ export const protocols: Protocol[] = [
     name: "Superstate USTB",
     defillamaSlug: "superstate",
     frequency: "Hourly",
+    apiProtocol: "ustb",
     items: [
       {
         label: "NAV/Share Monotonicity",
@@ -540,6 +560,7 @@ export const protocols: Protocol[] = [
     name: "USDAI",
     defillamaSlug: "",
     frequency: "Hourly",
+    apiProtocol: "usdai",
     items: [
       {
         label: "Collateral Backing",
@@ -569,6 +590,7 @@ export const protocols: Protocol[] = [
     name: "Yearn",
     defillamaSlug: "yearn-finance",
     frequency: "Hourly",
+    apiProtocol: "yearn",
     items: [
       {
         label: "Large Flows",

--- a/src/lib/monitoring.ts
+++ b/src/lib/monitoring.ts
@@ -1,0 +1,148 @@
+// Client + types for the monitoring alerts API, consumed through the `/api/monitoring` edge
+// proxy (see api/monitoring.ts). The shapes mirror the backend contract in
+// github.com/yearn/monitoring `api/server.py` / `deploy/alerts-api.md` (PR #273).
+//
+// All fetching happens in the browser so the static site stays decoupled from backend uptime —
+// do not call these at build time.
+
+export type Severity = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+
+export interface AlertEvent {
+  id: number;
+  created_at: string;
+  source: string;
+  protocol: string;
+  channel: string;
+  severity: Severity;
+  message: string;
+  plain_text: boolean;
+  silent: boolean;
+  delivery_status: string;
+  delivered_at: string | null;
+  delivery_error: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export interface AlertsResponse {
+  data: AlertEvent[];
+  next_cursor: string | null;
+  limit: number;
+}
+
+export interface AlertsQuery {
+  protocol?: string;
+  severity?: Severity;
+  source?: string;
+  from?: string;
+  to?: string;
+  since?: string;
+  cursor?: string;
+  limit?: number;
+}
+
+export interface ProtocolTask {
+  name: string;
+  script: string;
+  args: Record<string, string>;
+  profile: string;
+  cron: string;
+}
+
+export interface ProtocolEntry {
+  name: string;
+  tasks: ProtocolTask[];
+}
+
+export interface ProtocolsResponse {
+  data: ProtocolEntry[];
+  count: number;
+}
+
+export interface SeverityStyle {
+  emoji: string;
+  label: string;
+  color: string;
+}
+
+// Mirrors the backend severity ladder in utils/alert.py.
+export const SEVERITY_META: Record<Severity, SeverityStyle> = {
+  LOW: { emoji: "ℹ️", label: "Low", color: "#3B82F6" },
+  MEDIUM: { emoji: "⚠️", label: "Medium", color: "#FACC15" },
+  HIGH: { emoji: "🚨", label: "High", color: "#FB923C" },
+  CRITICAL: { emoji: "🔴", label: "Critical", color: "#EF4444" },
+};
+
+const FALLBACK_SEVERITY: SeverityStyle = { emoji: "•", label: "Unknown", color: "#9CA3AF" };
+
+export function severityMeta(severity: string): SeverityStyle {
+  return SEVERITY_META[severity as Severity] ?? { ...FALLBACK_SEVERITY, label: severity || "Unknown" };
+}
+
+const API_BASE = "/api/monitoring";
+
+function buildQuery(query: Record<string, string | number | undefined | null>): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== null && value !== "") {
+      params.set(key, String(value));
+    }
+  }
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
+
+export async function fetchAlerts(query: AlertsQuery = {}, init?: RequestInit): Promise<AlertsResponse> {
+  const res = await fetch(`${API_BASE}/alerts${buildQuery(query)}`, init);
+  if (!res.ok) {
+    throw new Error(`alerts request failed: ${res.status}`);
+  }
+  return (await res.json()) as AlertsResponse;
+}
+
+export async function fetchProtocols(init?: RequestInit): Promise<ProtocolsResponse> {
+  const res = await fetch(`${API_BASE}/protocols`, init);
+  if (!res.ok) {
+    throw new Error(`protocols request failed: ${res.status}`);
+  }
+  return (await res.json()) as ProtocolsResponse;
+}
+
+// Buckets a newest-first alert list into the most recent alert per protocol.
+export function latestByProtocol(alerts: AlertEvent[]): Map<string, AlertEvent> {
+  const latest = new Map<string, AlertEvent>();
+  for (const alert of alerts) {
+    if (!latest.has(alert.protocol)) {
+      latest.set(alert.protocol, alert);
+    }
+  }
+  return latest;
+}
+
+export function formatRelativeTime(iso: string, now: number = Date.now()): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const sec = Math.round((now - then) / 1000);
+  if (sec < 0) return "just now";
+  if (sec < 45) return "just now";
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  const mo = Math.round(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.round(mo / 12)}y ago`;
+}
+
+export function formatTimestamp(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/src/lib/monitoring.ts
+++ b/src/lib/monitoring.ts
@@ -35,7 +35,6 @@ export interface AlertsQuery {
   source?: string;
   from?: string;
   to?: string;
-  since?: string;
   cursor?: string;
   limit?: number;
 }
@@ -122,7 +121,6 @@ export function formatRelativeTime(iso: string, now: number = Date.now()): strin
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) return "";
   const sec = Math.round((now - then) / 1000);
-  if (sec < 0) return "just now";
   if (sec < 45) return "just now";
   const min = Math.round(sec / 60);
   if (min < 60) return `${min}m ago`;

--- a/src/lib/monitoring.ts
+++ b/src/lib/monitoring.ts
@@ -106,12 +106,16 @@ export async function fetchProtocols(init?: RequestInit): Promise<ProtocolsRespo
   return (await res.json()) as ProtocolsResponse;
 }
 
-// Buckets a newest-first alert list into the most recent alert per protocol.
+// Buckets a newest-first alert list into the most recent alert per protocol. Keys are
+// lowercased because the backend stores `protocol` with inconsistent casing (e.g. both `aave`
+// and `AAVE`); lowercasing merges those so a card matches all of its alerts. Forward-compatible:
+// a no-op once the backend canonicalizes the field.
 export function latestByProtocol(alerts: AlertEvent[]): Map<string, AlertEvent> {
   const latest = new Map<string, AlertEvent>();
   for (const alert of alerts) {
-    if (!latest.has(alert.protocol)) {
-      latest.set(alert.protocol, alert);
+    const key = alert.protocol.toLowerCase();
+    if (!latest.has(key)) {
+      latest.set(key, alert);
     }
   }
   return latest;

--- a/src/lib/monitoring.ts
+++ b/src/lib/monitoring.ts
@@ -135,6 +135,23 @@ export function formatRelativeTime(iso: string, now: number = Date.now()): strin
   return `${Math.round(mo / 12)}y ago`;
 }
 
+const ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+// Escape untrusted alert text before injecting it into innerHTML.
+export function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (c) => ESCAPE_MAP[c]);
+}
+
+export function truncate(value: string, max = 140): string {
+  return value.length > max ? `${value.slice(0, max - 1).trimEnd()}…` : value;
+}
+
 export function formatTimestamp(iso: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;

--- a/src/pages/monitoring.astro
+++ b/src/pages/monitoring.astro
@@ -195,11 +195,11 @@ import { protocols } from "../data/monitoring";
       const info = protoMeta.get(alert.protocol);
       const name = escapeHtml(info?.name || alert.protocol);
       const label = info?.href
-        ? `<a class="recent-proto" href="${info.href}">${name}</a>`
+        ? `<a class="recent-proto" href="${escapeHtml(info.href)}">${name}</a>`
         : `<span class="recent-proto">${name}</span>`;
       return `
         <li class="recent-row">
-          <span class="recent-dot" style="background:${meta.color}" title="${meta.label}"></span>
+          <span class="recent-dot" style="background:${meta.color}" title="${escapeHtml(meta.label)}"></span>
           ${label}
           <span class="recent-msg">${escapeHtml(truncate(alert.message, 110))}</span>
           <time class="recent-time" datetime="${escapeHtml(alert.created_at)}">${escapeHtml(formatRelativeTime(alert.created_at))}</time>

--- a/src/pages/monitoring.astro
+++ b/src/pages/monitoring.astro
@@ -36,6 +36,14 @@ import { protocols } from "../data/monitoring";
     </a>
   </div>
 
+  <section class="recent-alerts" id="recent-alerts" hidden>
+    <div class="recent-head">
+      <span class="recent-title">Recent alerts</span>
+      <span class="recent-sub">across all monitored protocols</span>
+    </div>
+    <ul class="recent-list" id="recent-list"></ul>
+  </section>
+
   <div class="block-head">
     <span class="block-meta"><span id="visible-count">{protocols.length}</span> of {protocols.length} protocols</span>
   </div>
@@ -100,6 +108,10 @@ import { protocols } from "../data/monitoring";
     <p>No monitored protocols match your search.</p>
   </div>
 
+  <p class="monitoring-footer">
+    <a href="/monitoring/status/">API integration status &rarr;</a>
+  </p>
+
   <script is:inline>
     (() => {
       // Accordion toggle
@@ -144,38 +156,107 @@ import { protocols } from "../data/monitoring";
   </script>
 
   <script>
-    // Live "last alert" badges. One request fetches the recent alert feed and we bucket the
-    // newest alert per protocol; cards whose protocol has no recent alert simply stay static.
-    // Failures degrade silently to the static view.
-    import { fetchAlerts, severityMeta, formatRelativeTime, latestByProtocol } from "../lib/monitoring";
+    // Live data for the monitoring page: a cross-protocol "recent alerts" feed and a per-card
+    // "last alert" badge, both filled from one request and refreshed while the tab is visible.
+    // Everything degrades silently to the static view on error.
+    import {
+      fetchAlerts,
+      severityMeta,
+      formatRelativeTime,
+      latestByProtocol,
+      escapeHtml,
+      truncate,
+      type AlertEvent,
+    } from "../lib/monitoring";
 
     const cards = Array.from(
       document.querySelectorAll<HTMLElement>(".protocol-accordion[data-api-protocol]"),
     );
 
-    if (cards.length > 0) {
-      fetchAlerts({ limit: 100 })
-        .then((resp) => {
-          const latest = latestByProtocol(resp.data);
-          const now = Date.now();
-          for (const card of cards) {
-            const proto = card.dataset.apiProtocol;
-            if (!proto) continue;
-            const alert = latest.get(proto);
-            const badge = card.querySelector<HTMLElement>(".last-alert");
-            if (!badge || !alert) continue;
-            const meta = severityMeta(alert.severity);
-            const dot = badge.querySelector<HTMLElement>(".last-alert-dot");
-            const text = badge.querySelector<HTMLElement>(".last-alert-text");
-            if (dot) dot.style.background = meta.color;
-            if (text) text.textContent = formatRelativeTime(alert.created_at, now);
-            badge.title = `${meta.emoji} ${meta.label} · ${alert.message}`;
-            badge.hidden = false;
-          }
-        })
-        .catch(() => {
-          /* keep the static view */
-        });
+    // apiProtocol -> { name, href }, read from the rendered cards so we don't duplicate the
+    // protocol registry in client code.
+    const protoMeta = new Map<string, { name: string; href: string | null }>();
+    for (const card of cards) {
+      const proto = card.dataset.apiProtocol;
+      if (!proto) continue;
+      const name = card.querySelector(".protocol-name")?.textContent?.trim() || proto;
+      const href =
+        card.querySelector<HTMLAnchorElement>(".history-link")?.getAttribute("href") ?? null;
+      protoMeta.set(proto, { name, href });
+    }
+
+    const feedSection = document.getElementById("recent-alerts");
+    const feedList = document.getElementById("recent-list");
+    const FEED_SIZE = 8;
+    const REFRESH_MS = 60000;
+
+    function renderFeedRow(alert: AlertEvent): string {
+      const meta = severityMeta(alert.severity);
+      const info = protoMeta.get(alert.protocol);
+      const name = escapeHtml(info?.name || alert.protocol);
+      const label = info?.href
+        ? `<a class="recent-proto" href="${info.href}">${name}</a>`
+        : `<span class="recent-proto">${name}</span>`;
+      return `
+        <li class="recent-row">
+          <span class="recent-dot" style="background:${meta.color}" title="${meta.label}"></span>
+          ${label}
+          <span class="recent-msg">${escapeHtml(truncate(alert.message, 110))}</span>
+          <time class="recent-time" datetime="${escapeHtml(alert.created_at)}">${escapeHtml(formatRelativeTime(alert.created_at))}</time>
+        </li>`;
+    }
+
+    function applyBadges(alerts: AlertEvent[]) {
+      const latest = latestByProtocol(alerts);
+      const now = Date.now();
+      for (const card of cards) {
+        const proto = card.dataset.apiProtocol;
+        if (!proto) continue;
+        const badge = card.querySelector<HTMLElement>(".last-alert");
+        if (!badge) continue;
+        const alert = latest.get(proto);
+        if (!alert) {
+          badge.hidden = true;
+          continue;
+        }
+        const meta = severityMeta(alert.severity);
+        const dot = badge.querySelector<HTMLElement>(".last-alert-dot");
+        const text = badge.querySelector<HTMLElement>(".last-alert-text");
+        if (dot) dot.style.background = meta.color;
+        if (text) text.textContent = formatRelativeTime(alert.created_at, now);
+        badge.title = `${meta.emoji} ${meta.label} · ${alert.message}`;
+        badge.hidden = false;
+      }
+    }
+
+    function applyFeed(alerts: AlertEvent[]) {
+      if (!feedSection || !feedList) return;
+      if (!alerts.length) {
+        feedSection.hidden = true;
+        return;
+      }
+      feedList.innerHTML = alerts.slice(0, FEED_SIZE).map(renderFeedRow).join("");
+      feedSection.hidden = false;
+    }
+
+    async function refresh() {
+      try {
+        const resp = await fetchAlerts({ limit: 100 });
+        applyBadges(resp.data);
+        applyFeed(resp.data);
+      } catch {
+        /* keep whatever is currently shown */
+      }
+    }
+
+    if (cards.length > 0 || feedList) {
+      refresh();
+      setInterval(() => {
+        if (!document.hidden) refresh();
+      }, REFRESH_MS);
+      document.addEventListener("visibilitychange", () => {
+        if (!document.hidden) refresh();
+      });
     }
   </script>
 </BaseLayout>
@@ -493,6 +574,86 @@ import { protocols } from "../data/monitoring";
     transform: translateX(2px);
   }
 
+  /* === Recent alerts feed === */
+  .recent-alerts {
+    margin: 0 0 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--bg-card) 55%, transparent);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    padding: 0.85rem 1rem;
+  }
+  .recent-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+  .recent-title {
+    font-weight: 600;
+    font-size: 0.92rem;
+    letter-spacing: -0.01em;
+  }
+  .recent-sub {
+    font-size: 0.74rem;
+    color: var(--text-secondary);
+  }
+  .recent-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .recent-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0;
+    font-size: 0.83rem;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 35%, transparent);
+    min-width: 0;
+  }
+  .recent-row:last-child {
+    border-bottom: none;
+  }
+  .recent-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .recent-proto {
+    font-weight: 600;
+    color: var(--text-primary);
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  a.recent-proto:hover {
+    color: var(--brand-blue);
+    text-decoration: none;
+  }
+  .recent-msg {
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+  }
+  .recent-time {
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    flex-shrink: 0;
+    font-size: 0.76rem;
+  }
+  @media (max-width: 640px) {
+    .recent-sub,
+    .recent-msg {
+      display: none;
+    }
+  }
+
   /* Chevron */
   .chevron {
     color: var(--text-secondary);
@@ -543,6 +704,19 @@ import { protocols } from "../data/monitoring";
   }
   .monitor-desc {
     color: var(--text-secondary);
+  }
+
+  /* Footer link to the integration-status page */
+  .monitoring-footer {
+    text-align: center;
+    margin: 0 0 2.5rem;
+    font-size: 0.8rem;
+  }
+  .monitoring-footer a {
+    color: var(--text-secondary);
+  }
+  .monitoring-footer a:hover {
+    color: var(--brand-blue);
   }
 
   /* Empty state */

--- a/src/pages/monitoring.astro
+++ b/src/pages/monitoring.astro
@@ -36,14 +36,6 @@ import { protocols } from "../data/monitoring";
     </a>
   </div>
 
-  <section class="recent-alerts" id="recent-alerts" hidden>
-    <div class="recent-head">
-      <span class="recent-title">Recent alerts</span>
-      <span class="recent-sub">across all monitored protocols</span>
-    </div>
-    <ul class="recent-list" id="recent-list"></ul>
-  </section>
-
   <div class="block-head">
     <span class="block-meta"><span id="visible-count">{protocols.length}</span> of {protocols.length} protocols</span>
   </div>
@@ -107,6 +99,14 @@ import { protocols } from "../data/monitoring";
     </div>
     <p>No monitored protocols match your search.</p>
   </div>
+
+  <section class="recent-alerts" id="recent-alerts" hidden>
+    <div class="recent-head">
+      <span class="recent-title">Recent alerts</span>
+      <span class="recent-sub">across all monitored protocols</span>
+    </div>
+    <ul class="recent-list" id="recent-list"></ul>
+  </section>
 
   <p class="monitoring-footer">
     <a href="/monitoring/status/">API integration status &rarr;</a>

--- a/src/pages/monitoring.astro
+++ b/src/pages/monitoring.astro
@@ -44,7 +44,7 @@ import { protocols } from "../data/monitoring";
     {protocols.map((p) => {
       const iconUrl = protocolIconUrl(p.defillamaSlug);
       return (
-        <div class="protocol-accordion" data-name={p.name.toLowerCase()}>
+        <div class="protocol-accordion" data-name={p.name.toLowerCase()} data-api-protocol={p.apiProtocol}>
           <div class="card-glow" aria-hidden="true"></div>
           <button class="accordion-trigger" aria-expanded="false">
             <div class="accordion-left">
@@ -61,6 +61,12 @@ import { protocols } from "../data/monitoring";
                 <span class="protocol-meta">
                   <span class="meta-pill">{p.items.length} monitors</span>
                   <span class="meta-pill meta-pill--blue">{p.frequency}</span>
+                  {p.apiProtocol && (
+                    <span class="last-alert" hidden title="Most recent alert">
+                      <span class="last-alert-dot"></span>
+                      <span class="last-alert-text"></span>
+                    </span>
+                  )}
                 </span>
               </div>
             </div>
@@ -77,6 +83,10 @@ import { protocols } from "../data/monitoring";
                 </li>
               ))}
             </ul>
+            <a class="history-link" href={`/monitoring/${p.id}/`}>
+              View alert history
+              <span aria-hidden="true">&rarr;</span>
+            </a>
           </div>
         </div>
       );
@@ -131,6 +141,42 @@ import { protocols } from "../data/monitoring";
         });
       });
     })();
+  </script>
+
+  <script>
+    // Live "last alert" badges. One request fetches the recent alert feed and we bucket the
+    // newest alert per protocol; cards whose protocol has no recent alert simply stay static.
+    // Failures degrade silently to the static view.
+    import { fetchAlerts, severityMeta, formatRelativeTime, latestByProtocol } from "../lib/monitoring";
+
+    const cards = Array.from(
+      document.querySelectorAll<HTMLElement>(".protocol-accordion[data-api-protocol]"),
+    );
+
+    if (cards.length > 0) {
+      fetchAlerts({ limit: 100 })
+        .then((resp) => {
+          const latest = latestByProtocol(resp.data);
+          const now = Date.now();
+          for (const card of cards) {
+            const proto = card.dataset.apiProtocol;
+            if (!proto) continue;
+            const alert = latest.get(proto);
+            const badge = card.querySelector<HTMLElement>(".last-alert");
+            if (!badge || !alert) continue;
+            const meta = severityMeta(alert.severity);
+            const dot = badge.querySelector<HTMLElement>(".last-alert-dot");
+            const text = badge.querySelector<HTMLElement>(".last-alert-text");
+            if (dot) dot.style.background = meta.color;
+            if (text) text.textContent = formatRelativeTime(alert.created_at, now);
+            badge.title = `${meta.emoji} ${meta.label} · ${alert.message}`;
+            badge.hidden = false;
+          }
+        })
+        .catch(() => {
+          /* keep the static view */
+        });
+    }
   </script>
 </BaseLayout>
 
@@ -405,6 +451,46 @@ import { protocols } from "../data/monitoring";
     background: color-mix(in srgb, var(--brand-blue) 12%, transparent);
     color: #7eb4ff;
     border: 1px solid color-mix(in srgb, var(--brand-blue) 25%, transparent);
+  }
+
+  /* Live last-alert badge (populated client-side) */
+  .last-alert {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bg-secondary) 70%, transparent);
+    color: var(--text-secondary);
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+  }
+  .last-alert-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--text-secondary);
+    flex-shrink: 0;
+  }
+
+  /* Link from a card to its per-protocol detail page */
+  .history-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0.85rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--brand-blue);
+  }
+  .history-link:hover {
+    text-decoration: underline;
+  }
+  .history-link span {
+    transition: transform 0.2s;
+  }
+  .history-link:hover span {
+    transform: translateX(2px);
   }
 
   /* Chevron */

--- a/src/pages/monitoring/[id].astro
+++ b/src/pages/monitoring/[id].astro
@@ -63,8 +63,35 @@ const apiProtocol = protocol.apiProtocol ?? "";
       <h2>Alert history</h2>
       <span class="history-status" id="history-status"></span>
     </div>
+    {apiProtocol && (
+      <div class="history-filters">
+        <label class="filter-field">
+          <span>Severity</span>
+          <select id="filter-severity">
+            <option value="">All</option>
+            <option value="CRITICAL">Critical</option>
+            <option value="HIGH">High</option>
+            <option value="MEDIUM">Medium</option>
+            <option value="LOW">Low</option>
+          </select>
+        </label>
+        <label class="filter-field">
+          <span>Source</span>
+          <select id="filter-source">
+            <option value="">All</option>
+            <option value="protocol">protocol</option>
+            <option value="ops_error">ops_error</option>
+            <option value="crash">crash</option>
+            <option value="automation_digest">automation_digest</option>
+          </select>
+        </label>
+      </div>
+    )}
     <div class="alert-history" id="alert-history" data-api-protocol={apiProtocol}>
       <div class="history-empty">Loading recent alerts…</div>
+    </div>
+    <div class="history-more" id="history-more" hidden>
+      <button type="button" class="load-more-btn" id="load-more">Load more</button>
     </div>
     <p class="history-note">
       Alerts are also streamed to
@@ -79,16 +106,34 @@ const apiProtocol = protocol.apiProtocol ?? "";
       severityMeta,
       formatRelativeTime,
       formatTimestamp,
+      escapeHtml,
       type AlertEvent,
+      type Severity,
     } from "../../lib/monitoring";
 
     const root = document.getElementById("alert-history");
     const statusEl = document.getElementById("history-status");
+    const moreWrap = document.getElementById("history-more");
+    const moreBtn = document.getElementById("load-more") as HTMLButtonElement | null;
+    const sevSel = document.getElementById("filter-severity") as HTMLSelectElement | null;
+    const srcSel = document.getElementById("filter-source") as HTMLSelectElement | null;
+    const proto = root?.dataset.apiProtocol || "";
 
-    function escapeHtml(value: string): string {
-      return value.replace(/[&<>"']/g, (c) =>
-        ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] as string,
-      );
+    const PAGE = 20;
+    const REFRESH_MS = 60000;
+
+    let cursor: string | null = null;
+    let maxId = 0;
+    let generation = 0; // bumped on each (re)load so stale fetches can't write to the DOM
+    let loadingMore = false;
+    let listEl: HTMLUListElement | null = null;
+
+    function filters(): { protocol: string; severity?: Severity; source?: string } {
+      return {
+        protocol: proto,
+        severity: (sevSel?.value || undefined) as Severity | undefined,
+        source: srcSel?.value || undefined,
+      };
     }
 
     function renderAlert(alert: AlertEvent): string {
@@ -109,35 +154,124 @@ const apiProtocol = protocol.apiProtocol ?? "";
         </li>`;
     }
 
-    async function load() {
-      if (!root) return;
-      const proto = root.dataset.apiProtocol || "";
-
-      if (!proto) {
-        if (statusEl) statusEl.textContent = "";
-        root.innerHTML =
-          '<div class="history-empty">Live alert history is not yet available for this protocol.</div>';
-        return;
-      }
-
-      try {
-        const resp = await fetchAlerts({ protocol: proto, limit: 20 });
-        if (!resp.data.length) {
-          if (statusEl) statusEl.textContent = "";
-          root.innerHTML =
-            '<div class="history-empty">No alerts recorded yet — this protocol is monitored but has not fired any alerts.</div>';
-          return;
-        }
-        if (statusEl) statusEl.textContent = `${resp.data.length} most recent`;
-        root.innerHTML = `<ul class="alert-list">${resp.data.map(renderAlert).join("")}</ul>`;
-      } catch {
-        if (statusEl) statusEl.textContent = "";
-        root.innerHTML =
-          '<div class="history-error">Couldn\'t load alert history right now. Please try again later.</div>';
+    function setStatus() {
+      if (statusEl) {
+        const n = listEl?.children.length ?? 0;
+        statusEl.textContent = n ? `${n} shown` : "";
       }
     }
 
-    load();
+    function setMore(next: string | null) {
+      cursor = next;
+      if (moreWrap) moreWrap.hidden = !next;
+    }
+
+    function showState(cls: string, html: string) {
+      if (root) root.innerHTML = `<div class="${cls}">${html}</div>`;
+      listEl = null;
+      if (moreWrap) moreWrap.hidden = true;
+      setStatus();
+    }
+
+    async function loadFirst() {
+      if (!root) return;
+      const gen = ++generation;
+      if (statusEl) statusEl.textContent = "Loading…";
+      if (moreWrap) moreWrap.hidden = true;
+      let resp;
+      try {
+        resp = await fetchAlerts({ ...filters(), limit: PAGE });
+      } catch {
+        if (gen === generation) {
+          showState("history-error", "Couldn't load alert history right now. Please try again later.");
+        }
+        return;
+      }
+      if (gen !== generation) return; // superseded by a newer filter change
+      if (!resp.data.length) {
+        maxId = 0;
+        cursor = null;
+        showState(
+          "history-empty",
+          "No alerts match — this protocol is monitored but nothing has fired for this filter.",
+        );
+        return;
+      }
+      root.innerHTML = '<ul class="alert-list"></ul>';
+      listEl = root.querySelector(".alert-list");
+      if (listEl) listEl.innerHTML = resp.data.map(renderAlert).join("");
+      maxId = resp.data[0].id;
+      setMore(resp.next_cursor);
+      setStatus();
+    }
+
+    async function loadMore() {
+      if (loadingMore || !listEl || !cursor) return;
+      const gen = generation;
+      loadingMore = true;
+      if (moreBtn) {
+        moreBtn.disabled = true;
+        moreBtn.textContent = "Loading…";
+      }
+      let resp;
+      try {
+        resp = await fetchAlerts({ ...filters(), cursor, limit: PAGE });
+      } catch {
+        loadingMore = false;
+        if (moreBtn) {
+          moreBtn.textContent = "Couldn't load — retry";
+          moreBtn.disabled = false;
+        }
+        return;
+      }
+      loadingMore = false;
+      if (gen !== generation || !listEl) return; // filters changed mid-flight
+      listEl.insertAdjacentHTML("beforeend", resp.data.map(renderAlert).join(""));
+      setMore(resp.next_cursor);
+      if (moreBtn) {
+        moreBtn.disabled = false;
+        moreBtn.textContent = "Load more";
+      }
+      setStatus();
+    }
+
+    // Poll the newest page and prepend alerts above the current top, respecting active filters.
+    async function pollNew() {
+      if (!listEl) return;
+      const gen = generation;
+      let resp;
+      try {
+        resp = await fetchAlerts({ ...filters(), limit: PAGE });
+      } catch {
+        return;
+      }
+      if (gen !== generation || !listEl) return;
+      const fresh = resp.data.filter((a) => a.id > maxId);
+      if (!fresh.length) return;
+      listEl.insertAdjacentHTML("afterbegin", fresh.map(renderAlert).join(""));
+      maxId = fresh[0].id;
+      setStatus();
+    }
+
+    function start() {
+      if (!root) return;
+      if (!proto) {
+        showState("history-empty", "Live alert history is not yet available for this protocol.");
+        return;
+      }
+      loadFirst();
+      moreBtn?.addEventListener("click", loadMore);
+      sevSel?.addEventListener("change", loadFirst);
+      srcSel?.addEventListener("change", loadFirst);
+      setInterval(() => {
+        if (!document.hidden) pollNew();
+      }, REFRESH_MS);
+      document.addEventListener("visibilitychange", () => {
+        if (!document.hidden) pollNew();
+      });
+    }
+
+    start();
   </script>
 </BaseLayout>
 
@@ -336,6 +470,69 @@ const apiProtocol = protocol.apiProtocol ?? "";
   }
   .history-note a {
     color: var(--brand-blue);
+  }
+
+  /* === Filters === */
+  .history-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+  .filter-field {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+  }
+  .filter-field select {
+    appearance: none;
+    -webkit-appearance: none;
+    background-color: color-mix(in srgb, var(--bg-card) 60%, transparent);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%239ca3af' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.55rem center;
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.35rem 1.7rem 0.35rem 0.6rem;
+    font-size: 0.82rem;
+    font-family: inherit;
+    cursor: pointer;
+    transition: border-color 0.15s;
+  }
+  .filter-field select:focus {
+    outline: none;
+    border-color: var(--brand-blue);
+  }
+
+  /* === Load more === */
+  .history-more {
+    display: flex;
+    justify-content: center;
+    margin-top: 1.25rem;
+  }
+  .load-more-btn {
+    padding: 0.55rem 1.3rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--brand-blue);
+    background: color-mix(in srgb, var(--brand-blue) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--brand-blue) 35%, transparent);
+    border-radius: 999px;
+    cursor: pointer;
+    font-family: inherit;
+    transition: background 0.2s, border-color 0.2s, transform 0.2s;
+  }
+  .load-more-btn:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--brand-blue) 18%, transparent);
+    border-color: var(--brand-blue);
+    transform: translateY(-1px);
+  }
+  .load-more-btn:disabled {
+    opacity: 0.6;
+    cursor: default;
   }
 
   @media (max-width: 640px) {

--- a/src/pages/monitoring/[id].astro
+++ b/src/pages/monitoring/[id].astro
@@ -1,0 +1,350 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { protocolIconUrl } from "../../lib/icons";
+import { protocols } from "../../data/monitoring";
+
+export function getStaticPaths() {
+  return protocols.map((p) => ({ params: { id: p.id }, props: { protocol: p } }));
+}
+
+const { protocol } = Astro.props;
+const iconUrl = protocolIconUrl(protocol.defillamaSlug);
+const apiProtocol = protocol.apiProtocol ?? "";
+---
+
+<BaseLayout
+  title={`${protocol.name} Monitoring — Yearn Curation`}
+  description={`Live alert history and monitors for ${protocol.name}, tracked by Yearn Curation.`}
+  ogUrl={`/monitoring/${protocol.id}/`}
+  ogImage="/og/default.png"
+>
+  <a href="/monitoring/" class="back-link">&larr; All monitors</a>
+
+  <div class="detail-header">
+    <div class="icon-wrap">
+      {iconUrl ? (
+        <img
+          src={iconUrl}
+          alt=""
+          width="40"
+          height="40"
+          class="protocol-icon"
+          loading="lazy"
+          onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"
+        />
+      ) : null}
+      <div class="icon-placeholder" style={iconUrl ? "display:none" : ""}>
+        <span>{protocol.name.charAt(0)}</span>
+      </div>
+    </div>
+    <div class="detail-title">
+      <h1>{protocol.name}</h1>
+      <div class="detail-meta">
+        <span class="meta-pill">{protocol.items.length} monitors</span>
+        <span class="meta-pill meta-pill--blue">{protocol.frequency}</span>
+      </div>
+    </div>
+  </div>
+
+  <section class="section">
+    <h2>What we monitor</h2>
+    <ul class="monitor-list">
+      {protocol.items.map((item) => (
+        <li>
+          <span class="monitor-label">{item.label}</span>
+          <span class="monitor-desc">{item.description}</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+
+  <section class="section">
+    <div class="section-head">
+      <h2>Alert history</h2>
+      <span class="history-status" id="history-status"></span>
+    </div>
+    <div class="alert-history" id="alert-history" data-api-protocol={apiProtocol}>
+      <div class="history-empty">Loading recent alerts…</div>
+    </div>
+    <p class="history-note">
+      Alerts are also streamed to
+      <a href="https://t.me/yearn_curation_alerts" target="_blank" rel="noopener noreferrer">Telegram</a>
+      in real time.
+    </p>
+  </section>
+
+  <script>
+    import {
+      fetchAlerts,
+      severityMeta,
+      formatRelativeTime,
+      formatTimestamp,
+      type AlertEvent,
+    } from "../../lib/monitoring";
+
+    const root = document.getElementById("alert-history");
+    const statusEl = document.getElementById("history-status");
+
+    function escapeHtml(value: string): string {
+      return value.replace(/[&<>"']/g, (c) =>
+        ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] as string,
+      );
+    }
+
+    function renderAlert(alert: AlertEvent): string {
+      const meta = severityMeta(alert.severity);
+      return `
+        <li class="alert-row">
+          <span class="alert-dot" style="background:${meta.color}" title="${meta.label}"></span>
+          <div class="alert-body">
+            <p class="alert-message">${escapeHtml(alert.message)}</p>
+            <div class="alert-meta">
+              <span class="alert-sev" style="color:${meta.color}">${meta.emoji} ${meta.label}</span>
+              <span class="alert-sep">·</span>
+              <span>${escapeHtml(alert.source)}</span>
+              <span class="alert-sep">·</span>
+              <time datetime="${escapeHtml(alert.created_at)}" title="${escapeHtml(formatTimestamp(alert.created_at))}">${escapeHtml(formatRelativeTime(alert.created_at))}</time>
+            </div>
+          </div>
+        </li>`;
+    }
+
+    async function load() {
+      if (!root) return;
+      const proto = root.dataset.apiProtocol || "";
+
+      if (!proto) {
+        if (statusEl) statusEl.textContent = "";
+        root.innerHTML =
+          '<div class="history-empty">Live alert history is not yet available for this protocol.</div>';
+        return;
+      }
+
+      try {
+        const resp = await fetchAlerts({ protocol: proto, limit: 20 });
+        if (!resp.data.length) {
+          if (statusEl) statusEl.textContent = "";
+          root.innerHTML =
+            '<div class="history-empty">No alerts recorded yet — this protocol is monitored but has not fired any alerts.</div>';
+          return;
+        }
+        if (statusEl) statusEl.textContent = `${resp.data.length} most recent`;
+        root.innerHTML = `<ul class="alert-list">${resp.data.map(renderAlert).join("")}</ul>`;
+      } catch {
+        if (statusEl) statusEl.textContent = "";
+        root.innerHTML =
+          '<div class="history-error">Couldn\'t load alert history right now. Please try again later.</div>';
+      }
+    }
+
+    load();
+  </script>
+</BaseLayout>
+
+<style>
+  .back-link {
+    display: inline-block;
+    margin-bottom: 1.5rem;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+  }
+
+  /* === Header === */
+  .detail-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .icon-wrap {
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+    position: relative;
+  }
+  .protocol-icon {
+    display: block;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+  }
+  .icon-placeholder {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: var(--bg-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--text-secondary);
+  }
+  .detail-title h1 {
+    font-size: 1.5rem;
+    margin: 0 0 0.4rem;
+    letter-spacing: -0.01em;
+  }
+  .detail-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    font-size: 0.72rem;
+  }
+  .meta-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bg-secondary) 70%, transparent);
+    color: var(--text-secondary);
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+  }
+  .meta-pill--blue {
+    background: color-mix(in srgb, var(--brand-blue) 12%, transparent);
+    color: #7eb4ff;
+    border: 1px solid color-mix(in srgb, var(--brand-blue) 25%, transparent);
+  }
+
+  /* === Sections === */
+  .section {
+    margin-bottom: 2.5rem;
+  }
+  .section-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .section h2 {
+    font-size: 1.2rem;
+    margin: 0;
+  }
+  .section > h2 {
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .history-status {
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  /* === Monitor list (mirrors monitoring.astro) === */
+  .monitor-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .monitor-list li {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.55rem 0;
+    font-size: 0.88rem;
+    line-height: 1.45;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 45%, transparent);
+  }
+  .monitor-list li:last-child {
+    border-bottom: none;
+  }
+  .monitor-label {
+    font-weight: 600;
+    white-space: nowrap;
+    color: var(--text-primary);
+    min-width: 180px;
+    flex-shrink: 0;
+    font-size: 0.85rem;
+  }
+  .monitor-desc {
+    color: var(--text-secondary);
+  }
+
+  /* === Alert history === */
+  .alert-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .alert-row {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.85rem 0;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 45%, transparent);
+  }
+  .alert-row:last-child {
+    border-bottom: none;
+  }
+  .alert-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    margin-top: 0.4rem;
+    flex-shrink: 0;
+  }
+  .alert-body {
+    min-width: 0;
+  }
+  .alert-message {
+    margin: 0 0 0.3rem;
+    font-size: 0.9rem;
+    line-height: 1.45;
+    color: var(--text-primary);
+    word-break: break-word;
+  }
+  .alert-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    font-size: 0.76rem;
+    color: var(--text-secondary);
+  }
+  .alert-sev {
+    font-weight: 600;
+  }
+  .alert-sep {
+    opacity: 0.4;
+  }
+
+  .history-empty,
+  .history-error {
+    padding: 1.5rem;
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    border: 1px dashed var(--border);
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--bg-card) 40%, transparent);
+  }
+  .history-error {
+    color: #fca5a5;
+    border-color: color-mix(in srgb, #ef4444 35%, var(--border));
+  }
+  .history-note {
+    margin-top: 1rem;
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+  }
+  .history-note a {
+    color: var(--brand-blue);
+  }
+
+  @media (max-width: 640px) {
+    .monitor-list li {
+      flex-direction: column;
+      gap: 0.1rem;
+    }
+    .monitor-label {
+      min-width: unset;
+    }
+  }
+</style>

--- a/src/pages/monitoring/[id].astro
+++ b/src/pages/monitoring/[id].astro
@@ -104,6 +104,7 @@ const apiProtocol = protocol.apiProtocol ?? "";
     import {
       fetchAlerts,
       severityMeta,
+      SEVERITY_META,
       formatRelativeTime,
       formatTimestamp,
       escapeHtml,
@@ -137,21 +138,28 @@ const apiProtocol = protocol.apiProtocol ?? "";
 
     function renderAlert(alert: AlertEvent): string {
       const meta = severityMeta(alert.severity);
-      // meta.label is the raw severity for off-enum values, so escape it; color/emoji are from
-      // the trusted severity map.
-      const sev = escapeHtml(meta.label);
+      const known = Boolean(SEVERITY_META[alert.severity]);
+      // Only show parts that carry signal. Most alerts have a null severity and source
+      // "protocol", so rendering those verbatim ("Unknown · protocol") is just noise — show the
+      // severity chip only for a known level, and the source only when it isn't the default.
+      const parts: string[] = [];
+      if (known) {
+        parts.push(
+          `<span class="alert-sev" style="color:${meta.color}">${meta.emoji} ${escapeHtml(meta.label)}</span>`,
+        );
+      }
+      if (alert.source && alert.source !== "protocol") {
+        parts.push(`<span>${escapeHtml(alert.source)}</span>`);
+      }
+      parts.push(
+        `<time datetime="${escapeHtml(alert.created_at)}" title="${escapeHtml(formatTimestamp(alert.created_at))}">${escapeHtml(formatRelativeTime(alert.created_at))}</time>`,
+      );
       return `
         <li class="alert-row">
-          <span class="alert-dot" style="background:${meta.color}" title="${sev}"></span>
+          <span class="alert-dot" style="background:${meta.color}"${known ? ` title="${escapeHtml(meta.label)}"` : ""}></span>
           <div class="alert-body">
             <p class="alert-message">${escapeHtml(alert.message)}</p>
-            <div class="alert-meta">
-              <span class="alert-sev" style="color:${meta.color}">${meta.emoji} ${sev}</span>
-              <span class="alert-sep">·</span>
-              <span>${escapeHtml(alert.source)}</span>
-              <span class="alert-sep">·</span>
-              <time datetime="${escapeHtml(alert.created_at)}" title="${escapeHtml(formatTimestamp(alert.created_at))}">${escapeHtml(formatRelativeTime(alert.created_at))}</time>
-            </div>
+            <div class="alert-meta">${parts.join('<span class="alert-sep">·</span>')}</div>
           </div>
         </li>`;
     }

--- a/src/pages/monitoring/[id].astro
+++ b/src/pages/monitoring/[id].astro
@@ -80,8 +80,6 @@ const apiProtocol = protocol.apiProtocol ?? "";
           <select id="filter-source">
             <option value="">All</option>
             <option value="protocol">protocol</option>
-            <option value="ops_error">ops_error</option>
-            <option value="crash">crash</option>
             <option value="automation_digest">automation_digest</option>
           </select>
         </label>

--- a/src/pages/monitoring/[id].astro
+++ b/src/pages/monitoring/[id].astro
@@ -125,7 +125,6 @@ const apiProtocol = protocol.apiProtocol ?? "";
     let cursor: string | null = null;
     let maxId = 0;
     let generation = 0; // bumped on each (re)load so stale fetches can't write to the DOM
-    let loadingMore = false;
     let listEl: HTMLUListElement | null = null;
 
     function filters(): { protocol: string; severity?: Severity; source?: string } {
@@ -138,13 +137,16 @@ const apiProtocol = protocol.apiProtocol ?? "";
 
     function renderAlert(alert: AlertEvent): string {
       const meta = severityMeta(alert.severity);
+      // meta.label is the raw severity for off-enum values, so escape it; color/emoji are from
+      // the trusted severity map.
+      const sev = escapeHtml(meta.label);
       return `
         <li class="alert-row">
-          <span class="alert-dot" style="background:${meta.color}" title="${meta.label}"></span>
+          <span class="alert-dot" style="background:${meta.color}" title="${sev}"></span>
           <div class="alert-body">
             <p class="alert-message">${escapeHtml(alert.message)}</p>
             <div class="alert-meta">
-              <span class="alert-sev" style="color:${meta.color}">${meta.emoji} ${meta.label}</span>
+              <span class="alert-sev" style="color:${meta.color}">${meta.emoji} ${sev}</span>
               <span class="alert-sep">·</span>
               <span>${escapeHtml(alert.source)}</span>
               <span class="alert-sep">·</span>
@@ -164,6 +166,10 @@ const apiProtocol = protocol.apiProtocol ?? "";
     function setMore(next: string | null) {
       cursor = next;
       if (moreWrap) moreWrap.hidden = !next;
+      if (moreBtn) {
+        moreBtn.disabled = false;
+        moreBtn.textContent = "Load more";
+      }
     }
 
     function showState(cls: string, html: string) {
@@ -206,32 +212,22 @@ const apiProtocol = protocol.apiProtocol ?? "";
     }
 
     async function loadMore() {
-      if (loadingMore || !listEl || !cursor) return;
+      // The disabled button is the re-entrancy guard (loadMore is only fired by its click).
+      if (!moreBtn || moreBtn.disabled || !listEl || !cursor) return;
       const gen = generation;
-      loadingMore = true;
-      if (moreBtn) {
-        moreBtn.disabled = true;
-        moreBtn.textContent = "Loading…";
-      }
+      moreBtn.disabled = true;
+      moreBtn.textContent = "Loading…";
       let resp;
       try {
         resp = await fetchAlerts({ ...filters(), cursor, limit: PAGE });
       } catch {
-        loadingMore = false;
-        if (moreBtn) {
-          moreBtn.textContent = "Couldn't load — retry";
-          moreBtn.disabled = false;
-        }
+        moreBtn.textContent = "Couldn't load — retry";
+        moreBtn.disabled = false;
         return;
       }
-      loadingMore = false;
-      if (gen !== generation || !listEl) return; // filters changed mid-flight
+      if (gen !== generation || !listEl) return; // superseded by a filter change (which resets the button)
       listEl.insertAdjacentHTML("beforeend", resp.data.map(renderAlert).join(""));
-      setMore(resp.next_cursor);
-      if (moreBtn) {
-        moreBtn.disabled = false;
-        moreBtn.textContent = "Load more";
-      }
+      setMore(resp.next_cursor); // re-enables the button
       setStatus();
     }
 

--- a/src/pages/monitoring/status.astro
+++ b/src/pages/monitoring/status.astro
@@ -58,7 +58,7 @@ const siteJson = JSON.stringify(siteProtocols).replace(/</g, "\\u003c");
 
   <section class="section">
     <div class="section-head">
-      <h2>On the site, no backend job</h2>
+      <h2>Paused jobs</h2>
       <span class="status-pill status-pill--muted">{noJob.length}</span>
     </div>
     <p class="section-note">
@@ -90,14 +90,6 @@ const siteJson = JSON.stringify(siteProtocols).replace(/</g, "\\u003c");
     const mapStatus = document.getElementById("map-status");
     const extraBody = document.getElementById("extra-body");
     const extraStatus = document.getElementById("extra-status");
-
-    function crons(entry: ProtocolEntry): string {
-      const seen = new Set<string>();
-      for (const task of entry.tasks) {
-        if (task.cron) seen.add(task.cron);
-      }
-      return Array.from(seen).join(", ") || "—";
-    }
 
     function fail(message: string) {
       const html = `<div class="status-error">${escapeHtml(message)}</div>`;
@@ -136,14 +128,13 @@ const siteJson = JSON.stringify(siteProtocols).replace(/</g, "\\u003c");
             <td><code>${escapeHtml(p.id)}</code></td>
             <td><code>${escapeHtml(p.apiProtocol as string)}</code></td>
             <td>${status}</td>
-            <td class="cron">${entry ? escapeHtml(crons(entry)) : "—"}</td>
           </tr>`;
         })
         .join("");
 
       if (mapBody) {
         mapBody.innerHTML = `<div class="table-wrap"><table class="status-table">
-          <thead><tr><th>Protocol</th><th>Site id</th><th>apiProtocol</th><th>Status</th><th>Cron</th></tr></thead>
+          <thead><tr><th>Protocol</th><th>Site id</th><th>apiProtocol</th><th>Status</th></tr></thead>
           <tbody>${rows}</tbody></table></div>`;
       }
       if (mapStatus) {
@@ -161,13 +152,12 @@ const siteJson = JSON.stringify(siteProtocols).replace(/</g, "\\u003c");
             .map(
               (e) => `<tr>
                 <td><code>${escapeHtml(e.name)}</code></td>
-                <td class="cron">${escapeHtml(crons(e))}</td>
                 <td>${e.tasks.length}</td>
               </tr>`,
             )
             .join("");
           extraBody.innerHTML = `<div class="table-wrap"><table class="status-table">
-            <thead><tr><th>API protocol</th><th>Cron</th><th>Tasks</th></tr></thead>
+            <thead><tr><th>API protocol</th><th>Tasks</th></tr></thead>
             <tbody>${extraRows}</tbody></table></div>`;
         }
       }
@@ -277,10 +267,6 @@ const siteJson = JSON.stringify(siteProtocols).replace(/</g, "\\u003c");
     text-transform: uppercase;
     letter-spacing: 0.04em;
     font-weight: 600;
-  }
-  .status-table .cron {
-    font-variant-numeric: tabular-nums;
-    color: var(--text-secondary);
   }
   .tag {
     display: inline-block;

--- a/src/pages/monitoring/status.astro
+++ b/src/pages/monitoring/status.astro
@@ -1,0 +1,337 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { protocols } from "../../data/monitoring";
+
+// Static snapshot of the site's protocol registry + the API join key. The client compares this
+// against the live GET /v1/protocols to surface drift between the two repos.
+const siteProtocols = protocols.map((p) => ({
+  id: p.id,
+  name: p.name,
+  apiProtocol: p.apiProtocol ?? null,
+}));
+const noJob = siteProtocols.filter((p) => !p.apiProtocol);
+const siteJson = JSON.stringify(siteProtocols);
+---
+
+<BaseLayout
+  title="Monitoring integration status — Yearn Curation"
+  description="Drift between the site's monitored-protocol list and the live alerts API registry."
+  ogUrl="/monitoring/status/"
+  ogImage="/og/default.png"
+>
+  <a href="/monitoring/" class="back-link">&larr; All monitors</a>
+
+  <div class="status-header">
+    <h1>API integration status</h1>
+    <p class="status-sub">
+      Compares the site's monitored-protocol list (<code>src/data/monitoring.ts</code>) against the
+      live registry from <code>GET /v1/protocols</code>. Use it to confirm every protocol's
+      <code>apiProtocol</code> join key resolves to a real backend job.
+    </p>
+  </div>
+
+  <section class="section">
+    <div class="section-head">
+      <h2>Live mapping</h2>
+      <span class="status-pill" id="map-status">Loading…</span>
+    </div>
+    <div id="map-body">
+      <div class="status-empty">Checking the live registry…</div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="section-head">
+      <h2>In the API, not on the site</h2>
+      <span class="status-pill" id="extra-status"></span>
+    </div>
+    <p class="section-note">
+      Backend jobs with no protocol card on <a href="/monitoring/">/monitoring</a>. Expected for
+      cross-cutting jobs (e.g. <code>safe</code>, <code>timelock</code>, <code>stables</code>).
+    </p>
+    <div id="extra-body">
+      <div class="status-empty">Checking the live registry…</div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="section-head">
+      <h2>On the site, no backend job</h2>
+      <span class="status-pill status-pill--muted">{noJob.length}</span>
+    </div>
+    <p class="section-note">
+      Protocol cards with no <code>apiProtocol</code> — monitored elsewhere but not (yet) emitting
+      alerts through the API, so they show static info only.
+    </p>
+    {noJob.length > 0 ? (
+      <ul class="chip-list">
+        {noJob.map((p) => (
+          <li class="chip">{p.name} <span class="chip-id">{p.id}</span></li>
+        ))}
+      </ul>
+    ) : (
+      <div class="status-empty">Every protocol card is mapped to a backend job.</div>
+    )}
+  </section>
+
+  <script type="application/json" id="site-protocols" set:html={siteJson} />
+
+  <script>
+    import { fetchProtocols, escapeHtml, type ProtocolEntry } from "../../lib/monitoring";
+
+    type SiteProtocol = { id: string; name: string; apiProtocol: string | null };
+
+    const raw = document.getElementById("site-protocols")?.textContent || "[]";
+    const site: SiteProtocol[] = JSON.parse(raw);
+
+    const mapBody = document.getElementById("map-body");
+    const mapStatus = document.getElementById("map-status");
+    const extraBody = document.getElementById("extra-body");
+    const extraStatus = document.getElementById("extra-status");
+
+    function crons(entry: ProtocolEntry): string {
+      const seen = new Set<string>();
+      for (const task of entry.tasks) {
+        if (task.cron) seen.add(task.cron);
+      }
+      return Array.from(seen).join(", ") || "—";
+    }
+
+    function fail(message: string) {
+      const html = `<div class="status-error">${escapeHtml(message)}</div>`;
+      if (mapBody) mapBody.innerHTML = html;
+      if (extraBody) extraBody.innerHTML = html;
+      if (mapStatus) mapStatus.textContent = "unavailable";
+      if (extraStatus) extraStatus.textContent = "";
+    }
+
+    async function run() {
+      let resp;
+      try {
+        resp = await fetchProtocols();
+      } catch {
+        fail("Couldn't reach the alerts API. Is MONITORING_API_URL set and the backend deployed?");
+        return;
+      }
+
+      const byName = new Map<string, ProtocolEntry>();
+      for (const entry of resp.data) byName.set(entry.name, entry);
+      const siteApi = new Set(site.filter((p) => p.apiProtocol).map((p) => p.apiProtocol as string));
+
+      // Live mapping table: every mapped site protocol, flagged live vs. drift.
+      const mapped = site.filter((p) => p.apiProtocol);
+      let drift = 0;
+      const rows = mapped
+        .map((p) => {
+          const entry = byName.get(p.apiProtocol as string);
+          const live = Boolean(entry);
+          if (!live) drift++;
+          const status = live
+            ? '<span class="tag tag--ok">live</span>'
+            : '<span class="tag tag--bad">drift</span>';
+          return `<tr>
+            <td>${escapeHtml(p.name)}</td>
+            <td><code>${escapeHtml(p.id)}</code></td>
+            <td><code>${escapeHtml(p.apiProtocol as string)}</code></td>
+            <td>${status}</td>
+            <td class="cron">${entry ? escapeHtml(crons(entry)) : "—"}</td>
+          </tr>`;
+        })
+        .join("");
+
+      if (mapBody) {
+        mapBody.innerHTML = `<div class="table-wrap"><table class="status-table">
+          <thead><tr><th>Protocol</th><th>Site id</th><th>apiProtocol</th><th>Status</th><th>Cron</th></tr></thead>
+          <tbody>${rows}</tbody></table></div>`;
+      }
+      if (mapStatus) {
+        mapStatus.textContent = drift ? `${drift} drift` : `${mapped.length} mapped`;
+        mapStatus.className = `status-pill ${drift ? "status-pill--bad" : "status-pill--ok"}`;
+      }
+
+      // API protocols with no site card.
+      const extra = resp.data.filter((e) => !siteApi.has(e.name));
+      if (extraBody) {
+        if (!extra.length) {
+          extraBody.innerHTML = '<div class="status-empty">Every API protocol has a site card.</div>';
+        } else {
+          const extraRows = extra
+            .map(
+              (e) => `<tr>
+                <td><code>${escapeHtml(e.name)}</code></td>
+                <td class="cron">${escapeHtml(crons(e))}</td>
+                <td>${e.tasks.length}</td>
+              </tr>`,
+            )
+            .join("");
+          extraBody.innerHTML = `<div class="table-wrap"><table class="status-table">
+            <thead><tr><th>API protocol</th><th>Cron</th><th>Tasks</th></tr></thead>
+            <tbody>${extraRows}</tbody></table></div>`;
+        }
+      }
+      if (extraStatus) extraStatus.textContent = extra.length ? `${extra.length}` : "0";
+    }
+
+    run();
+  </script>
+</BaseLayout>
+
+<style>
+  .back-link {
+    display: inline-block;
+    margin-bottom: 1.5rem;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+  }
+  .status-header {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .status-header h1 {
+    font-size: 1.5rem;
+    margin: 0 0 0.5rem;
+    letter-spacing: -0.01em;
+  }
+  .status-sub {
+    color: var(--text-secondary);
+    font-size: 0.92rem;
+    line-height: 1.55;
+    max-width: 70ch;
+    margin: 0;
+  }
+  code {
+    background: var(--bg-secondary);
+    padding: 0.1rem 0.35rem;
+    border-radius: 4px;
+    font-size: 0.85em;
+  }
+
+  .section {
+    margin-bottom: 2.5rem;
+  }
+  .section-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .section-head h2 {
+    font-size: 1.15rem;
+    margin: 0;
+  }
+  .section-note {
+    color: var(--text-secondary);
+    font-size: 0.84rem;
+    line-height: 1.5;
+    margin: 0 0 1rem;
+  }
+  .section-note a {
+    color: var(--brand-blue);
+  }
+
+  .status-pill {
+    font-size: 0.76rem;
+    color: var(--text-secondary);
+    padding: 0.2rem 0.6rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+  .status-pill--ok {
+    color: #86efac;
+    border-color: color-mix(in srgb, #22c55e 40%, var(--border));
+  }
+  .status-pill--bad {
+    color: #fca5a5;
+    border-color: color-mix(in srgb, #ef4444 40%, var(--border));
+  }
+  .status-pill--muted {
+    opacity: 0.8;
+  }
+
+  .table-wrap {
+    overflow-x: auto;
+  }
+  .status-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+  }
+  .status-table th,
+  .status-table td {
+    padding: 0.5rem 0.7rem;
+    text-align: left;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+    white-space: nowrap;
+  }
+  .status-table th {
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+  }
+  .status-table .cron {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-secondary);
+  }
+  .tag {
+    display: inline-block;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 600;
+  }
+  .tag--ok {
+    color: #86efac;
+    background: color-mix(in srgb, #22c55e 14%, transparent);
+  }
+  .tag--bad {
+    color: #fca5a5;
+    background: color-mix(in srgb, #ef4444 16%, transparent);
+  }
+
+  .chip-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: color-mix(in srgb, var(--bg-card) 50%, transparent);
+    font-size: 0.84rem;
+  }
+  .chip-id {
+    color: var(--text-secondary);
+    font-size: 0.74rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+
+  .status-empty,
+  .status-error {
+    padding: 1.25rem;
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 0.88rem;
+    border: 1px dashed var(--border);
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--bg-card) 40%, transparent);
+  }
+  .status-error {
+    color: #fca5a5;
+    border-color: color-mix(in srgb, #ef4444 35%, var(--border));
+  }
+</style>

--- a/src/pages/monitoring/status.astro
+++ b/src/pages/monitoring/status.astro
@@ -10,7 +10,9 @@ const siteProtocols = protocols.map((p) => ({
   apiProtocol: p.apiProtocol ?? null,
 }));
 const noJob = siteProtocols.filter((p) => !p.apiProtocol);
-const siteJson = JSON.stringify(siteProtocols);
+// Escape `<` so a future protocol name/id containing `</script>` can't break out of the
+// embedded JSON block below. The `<` escape parses back to `<` via JSON.parse.
+const siteJson = JSON.stringify(siteProtocols).replace(/</g, "\\u003c");
 ---
 
 <BaseLayout

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,10 @@
     {
       "source": "/api/cdn/:path*",
       "destination": "/api/cdn"
+    },
+    {
+      "source": "/api/monitoring/:path*",
+      "destination": "/api/monitoring"
     }
   ],
   "installCommand": "npm ci"


### PR DESCRIPTION
## Summary

Draft planning doc for wiring the `/monitoring` page to the new `monitoring-scripts-py` alerts API (PR yearn/monitoring#273) and adding per-protocol alert-history pages. **Doc only — no implementation yet.**

Plan: `proposals/monitoring-api-integration.md`

### Approach
- **Vercel Edge proxy** (`api/monitoring.ts`, reusing the `api/cdn.ts` pattern) — the backend API binds to `127.0.0.1`, sets no CORS and `Cache-Control: no-store`, so the browser can't call it directly. The proxy injects CORS + caching and whitelists params.
- **Per-protocol detail pages** at `/monitoring/[id]` via `getStaticPaths` (same pattern as `report/[slug].astro`), each client-fetching its own alert history.
- **Protocol id mapping** — site ids (`aave-v3`, `maker-dao`, `superstate-ustb`) differ from API dir names (`aave`, `maker`, `ustb`); add an optional `apiProtocol` field to `src/data/monitoring.ts`.
- **MVP first:** Phase 1 = proxy + recent-alert badges. Phase 2 = full history, filters, pagination.

### Backend endpoints consumed
- `GET /v1/protocols` — registry + cron cadence
- `GET /v1/alerts?protocol=&severity=&source=&from=&to=&cursor=&limit=` — cursor-paginated history
- `GET /v1/alerts/{id}` — single alert (Phase 2)

### Next steps
Review the plan; on approval, implement Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)