### PR TITLE
Add D2 HYPE++ risk report

### DIFF
--- a/reports/graph/d2-hypeplus.yaml
+++ b/reports/graph/d2-hypeplus.yaml
@@ -1,0 +1,133 @@
+slug: d2-hypeplus
+title: D2 Finance HYPE++ - Contract Dependency Graph
+chain: arbitrum
+
+categories:
+  - id: vault
+    label: Vault / Token
+  - id: strategy
+    label: Strategy
+  - id: governance
+    label: Governance
+  - id: infra
+    label: Protocol Infra
+  - id: dependency
+    label: External Dependency
+
+nodes:
+  - id: hypeplus-vault
+    label: HYPE++ Vault
+    address: "0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004"
+    category: vault
+    note: VaultV1Whitelisted; ERC-4626-style USDC vault
+  - id: hypeplus-trader
+    label: HYPE++ Trader OMS
+    address: "0x8CaBD8b787e8c69C5f24091cFDA197fF570345B3"
+    category: strategy
+    note: Strategy selector router; funds custodied here during epochs
+  - id: dgnhype-vault
+    label: dgnHYPE Vault
+    address: "0x64167cd42859F64cfF2Aa4B63c3175cceF9659dd"
+    category: strategy
+    note: Nested D2 strategy held by HYPE++ trader
+  - id: dgnhype-trader
+    label: dgnHYPE Custody Safe
+    address: "0x155d0B27B754ebC664aeD565945C1AaEa91966fb"
+    category: strategy
+    note: Nested 3-of-5 Safe; only part of reported backing observed as real USDC
+  - id: usdc
+    label: Arbitrum USDC
+    address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+    category: dependency
+  - id: allowed-defi
+    label: Allowed DeFi Venues
+    category: dependency
+    note: 32 allowed tokens and 30 allowed spender/protocol addresses
+  - id: arbitrum
+    label: Arbitrum One
+    category: dependency
+    note: Stage 1 optimistic rollup per L2BEAT
+
+  - id: vault-owner-eoa
+    label: Vault Owner EOA
+    address: "0x0E8c0470773c65498F438cac380648B314399A46"
+    category: governance
+    note: Owns HYPE++ vault; can set epochs, deposit caps, and whitelist parameters
+  - id: trader-role-eoa
+    label: Trader Role EOA
+    address: "0x7ab129978091DEE65A319c5FC728818D73221999"
+    category: governance
+    note: DEFAULT_ADMIN_ROLE + EXECUTOR_ROLE; fee receiver
+  - id: vault-ms
+    label: D2 Vault MS (4/7)
+    address: "0xB2fEDed045F3fd9FcCCF8E7e95729c4182916CE0"
+    category: governance
+    note: D2-documented Vault MS; Safe threshold 4 of 7
+  - id: vault-factory
+    label: Vault Factory
+    address: "0xb5B272EF918835651375f84D463b1Ba7B61eF028"
+    category: infra
+  - id: strategy-factory
+    label: Strategy Factory
+    address: "0x2AA01FdE174aB160b4e4F49F152C20d6Ec029d67"
+    category: infra
+
+edges:
+  - from: vault-factory
+    to: hypeplus-vault
+    kind: deploys
+    label: deployed Nov 19 2024
+  - from: strategy-factory
+    to: hypeplus-trader
+    kind: deploys
+    label: deployed Nov 19 2024
+
+  - from: vault-owner-eoa
+    to: hypeplus-vault
+    kind: controls
+    label: owner
+  - from: vault-ms
+    to: hypeplus-trader
+    kind: holds-role
+    label: DEFAULT_ADMIN_ROLE + EXECUTOR_ROLE
+  - from: trader-role-eoa
+    to: hypeplus-trader
+    kind: holds-role
+    label: DEFAULT_ADMIN_ROLE + EXECUTOR_ROLE
+  - from: hypeplus-trader
+    to: trader-role-eoa
+    kind: routes-fees-to
+    label: feeReceiver
+
+  - from: hypeplus-vault
+    to: hypeplus-trader
+    kind: allocates-to
+    label: "100%"
+  - from: hypeplus-trader
+    to: usdc
+    kind: deposits-into
+    label: direct USDC
+  - from: hypeplus-trader
+    to: dgnhype-vault
+    kind: deposits-into
+    label: dgnHYPE shares
+  - from: dgnhype-vault
+    to: dgnhype-trader
+    kind: allocates-to
+    label: "100%"
+  - from: dgnhype-trader
+    to: usdc
+    kind: deposits-into
+    label: direct USDC
+  - from: hypeplus-trader
+    to: allowed-defi
+    kind: deposits-into
+    label: allowed modules
+  - from: dgnhype-trader
+    to: allowed-defi
+    kind: deposits-into
+    label: nested strategy
+  - from: allowed-defi
+    to: arbitrum
+    kind: routes-through
+    label: Arbitrum execution

--- a/reports/graph/d2-hypeplus.yaml
+++ b/reports/graph/d2-hypeplus.yaml
@@ -19,12 +19,12 @@ nodes:
     label: HYPE++ Vault
     address: "0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004"
     category: vault
-    note: VaultV1Whitelisted; ERC-4626-style USDC vault
+    note: VaultV1Whitelisted; ERC-4626-style USDC vault; non-upgradeable (no proxy)
   - id: hypeplus-trader
     label: HYPE++ Trader OMS
     address: "0x8CaBD8b787e8c69C5f24091cFDA197fF570345B3"
     category: strategy
-    note: Strategy selector router; funds custodied here during epochs
+    note: Non-proxy selector router (~4.2KB code); delegatecalls modules; funds custodied here during epochs
   - id: dgnhype-vault
     label: dgnHYPE Vault
     address: "0x64167cd42859F64cfF2Aa4B63c3175cceF9659dd"
@@ -42,7 +42,7 @@ nodes:
   - id: allowed-defi
     label: Allowed DeFi Venues
     category: dependency
-    note: 32 allowed tokens and 30 allowed spender/protocol addresses
+    note: 32 allowed tokens (incl. WETH, WBTC, ARB, GMX, GRAIL, PENDLE, LINK, wstETH, USDC.e) and 30 allowed spender/protocol addresses
   - id: arbitrum
     label: Arbitrum One
     category: dependency
@@ -52,7 +52,7 @@ nodes:
     label: Vault Owner EOA
     address: "0x0E8c0470773c65498F438cac380648B314399A46"
     category: governance
-    note: Owns HYPE++ vault; can set epochs, deposit caps, and whitelist parameters
+    note: EOA; owns BOTH HYPE++ vault and dgnHYPE vault; can set epochs, deposit caps, and whitelist parameters
   - id: trader-role-eoa
     label: Trader Role EOA
     address: "0x7ab129978091DEE65A319c5FC728818D73221999"
@@ -86,6 +86,10 @@ edges:
     to: hypeplus-vault
     kind: controls
     label: owner
+  - from: vault-owner-eoa
+    to: dgnhype-vault
+    kind: controls
+    label: owner (same EOA)
   - from: vault-ms
     to: hypeplus-trader
     kind: holds-role

--- a/reports/graph/d2-hypeplus.yaml
+++ b/reports/graph/d2-hypeplus.yaml
@@ -52,7 +52,7 @@ nodes:
     label: Vault Owner EOA
     address: "0x0E8c0470773c65498F438cac380648B314399A46"
     category: governance
-    note: EOA; owns BOTH HYPE++ vault and dgnHYPE vault; can set epochs, deposit caps, and whitelist parameters
+    note: EOA; owns BOTH vaults; can blacklist users or set infinite whitelistBalance to block all withdraw+deposit on both HYPE++ and dgnHYPE
   - id: trader-role-eoa
     label: Trader Role EOA
     address: "0x7ab129978091DEE65A319c5FC728818D73221999"

--- a/reports/graph/d2-hypeplus.yaml
+++ b/reports/graph/d2-hypeplus.yaml
@@ -34,7 +34,31 @@ nodes:
     label: dgnHYPE Custody Safe
     address: "0x155d0B27B754ebC664aeD565945C1AaEa91966fb"
     category: strategy
-    note: Nested 3-of-5 Safe; only part of reported backing observed as real USDC
+    note: Nested 3-of-5 unrestricted custody Safe; routes capital through operational EOAs
+  - id: hyperliquid-operator-1
+    label: Hyperliquid Operator EOA 1
+    address: "0x0C684f333A7e120bce61383DA670bbB0157e82d0"
+    category: strategy
+    note: Received 5.0M USDC from dgnHYPE Safe in July 2026 before Bridge2 deposits
+  - id: hyperliquid-operator-2
+    label: Hyperliquid Operator EOA 2
+    address: "0x11A691612BD108e57cC04ea42B006C9CB1ff006A"
+    category: strategy
+    note: Received 400k USDC from dgnHYPE Safe in August 2026; uses Bridge2 and Circle CCTP
+  - id: hyperliquid-bridge
+    label: Hyperliquid Bridge2
+    address: "0x2Df1c51E09aECF9cacB7bc98cB1742757f163dF7"
+    category: dependency
+    note: Verified Arbitrum bridge contract; final bridge is not an EOA
+  - id: hypercore-cctp
+    label: Circle HyperCore CCTP
+    address: "0xA95d9c1F655341597C94393fDdc30cf3c08E4fcE"
+    category: dependency
+    note: Circle-documented Arbitrum extension for USDC transfers to HyperCore
+  - id: hypercore
+    label: HyperCore Trading
+    category: dependency
+    note: Hyperliquid spot and derivatives execution destination
   - id: usdc
     label: Arbitrum USDC
     address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
@@ -52,7 +76,7 @@ nodes:
     label: Vault Owner EOA
     address: "0x0E8c0470773c65498F438cac380648B314399A46"
     category: governance
-    note: EOA; owns BOTH vaults; can blacklist users or set infinite whitelistBalance to block all withdraw+deposit on both HYPE++ and dgnHYPE
+    note: EOA owns both vaults; HYPE++ has blacklist and balance-gate paths, while dgnHYPE VaultV0 has the blacklist path only
   - id: trader-role-eoa
     label: Trader Role EOA
     address: "0x7ab129978091DEE65A319c5FC728818D73221999"
@@ -123,6 +147,34 @@ edges:
     to: usdc
     kind: deposits-into
     label: direct USDC
+  - from: dgnhype-trader
+    to: hyperliquid-operator-1
+    kind: deposits-into
+    label: 5.0M USDC (Jul 2026)
+  - from: dgnhype-trader
+    to: hyperliquid-operator-2
+    kind: deposits-into
+    label: 400k USDC (Aug 2026)
+  - from: hyperliquid-operator-1
+    to: hyperliquid-bridge
+    kind: deposits-into
+    label: USDC bridge deposits
+  - from: hyperliquid-operator-2
+    to: hyperliquid-bridge
+    kind: deposits-into
+    label: USDC bridge deposits
+  - from: hyperliquid-operator-2
+    to: hypercore-cctp
+    kind: deposits-into
+    label: USDC via CCTP
+  - from: hyperliquid-bridge
+    to: hypercore
+    kind: routes-through
+    label: HyperCore credit
+  - from: hypercore-cctp
+    to: hypercore
+    kind: routes-through
+    label: HyperCore credit
   - from: hypeplus-trader
     to: allowed-defi
     kind: deposits-into

--- a/reports/report/d2-hypeplus.md
+++ b/reports/report/d2-hypeplus.md
@@ -4,7 +4,7 @@
 - **Token:** HYPE++
 - **Chain:** Arbitrum
 - **Token Address:** [`0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004`](https://arbiscan.io/address/0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004)
-- **Final Score: 3.74/5.0**
+- **Final Score: 3.73/5.0**
 
 ## Overview + Links
 
@@ -444,7 +444,7 @@ The total-centralization gate is not marked because the D2 Vault MS also holds t
 | Funds Management | 4.25 | 30% | 1.28 |
 | Liquidity Risk | 4.00 | 15% | 0.60 |
 | Operational Risk | 3.00 | 5% | 0.15 |
-| **Final Score** | | | **3.74/5.0** |
+| **Final Score** | | | **3.73/5.0** |
 
 ### Risk Tier
 

--- a/reports/report/d2-hypeplus.md
+++ b/reports/report/d2-hypeplus.md
@@ -4,7 +4,7 @@
 - **Token:** HYPE++
 - **Chain:** Arbitrum
 - **Token Address:** [`0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004`](https://arbiscan.io/address/0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004)
-- **Final Score: 3.73/5.0**
+- **Final Score: 3.85/5.0**
 
 ## Overview + Links
 
@@ -396,7 +396,7 @@ The total-centralization gate is not marked because the D2 Vault MS also holds t
 | **4** | Many or newer protocol dependencies | Critical functionality depends on them |
 | **5** | Single point of failure dependency | Failure breaks entire protocol |
 
-**Centralization Score = (4.5 + 4.0 + 4.0) / 3 = 4.17/5** - EOA owner and EOA trader admin/executor roles, no timelock, broad manual trading, nested D2 strategy exposure, and many allowed external venues.
+**Centralization Score = (5.0 + 4.0 + 4.0) / 3 = 4.33/5** - Governance raised to 5.0: EOA owner can block all withdrawals via `setWhitelistBalance(uint256.max)` in one transaction with no recovery path; dgnHYPE Safe (unrestricted Gnosis Safe) is a separate custody trust surface for 55.6% of assets with no on-chain guardrails. No timelock, broad manual trading, and many allowed external venues.
 
 #### Category 3: Funds Management (Weight: 30%)
 
@@ -420,7 +420,7 @@ The total-centralization gate is not marked because the D2 Vault MS also holds t
 | **4** | Primarily offchain | Infrequent reporting | Self-reported only |
 | **5** | Opaque, cannot verify | No reporting | No verification |
 
-**Funds Management Score = (4.0 + 4.5) / 2 = 4.25/5** - Top-level balances reconcile, but funds are custodied during active trading, `totalAssets()` is not a live full-position valuation while custodied, and nested dgnHYPE backing is only partially visible from ERC-20 balances.
+**Funds Management Score = (4.5 + 4.5) / 2 = 4.50/5** - Collateralization raised to 4.5: dgnHYPE Safe (55.6% of assets) is a standard Gnosis Safe with unrestricted custody — signers can transfer funds to any address with no on-chain guardrails. Top-level balances reconcile, but `totalAssets()` is not a live full-position valuation while custodied, and nested dgnHYPE backing is only partially visible from ERC-20 balances.
 
 #### Category 4: Liquidity Risk (Weight: 15%)
 
@@ -451,11 +451,11 @@ The total-centralization gate is not marked because the D2 Vault MS also holds t
 | Category | Score | Weight | Weighted |
 |----------|-------|--------|----------|
 | Audits & Historical | 2.25 | 20% | 0.45 |
-| Centralization & Control | 4.17 | 30% | 1.25 |
-| Funds Management | 4.25 | 30% | 1.28 |
+| Centralization & Control | 4.33 | 30% | 1.30 |
+| Funds Management | 4.50 | 30% | 1.35 |
 | Liquidity Risk | 4.00 | 15% | 0.60 |
 | Operational Risk | 3.00 | 5% | 0.15 |
-| **Final Score** | | | **3.73/5.0** |
+| **Final Score** | | | **3.85/5.0** |
 
 ### Risk Tier
 

--- a/reports/report/d2-hypeplus.md
+++ b/reports/report/d2-hypeplus.md
@@ -137,7 +137,7 @@ HYPE++ is not overcollateralized. It is a share token over an actively managed U
 - The verified source comments on `returnFunds()` state that losses may be sustained during trading and investors suffer the loss.
 - HYPE++ currently depends on dgnHYPE for ~55.6% of reported assets by value, creating recursive D2 strategy exposure.
 - The trader's allowed token list contains 32 tokens (including volatile assets: WETH [`0x82aF49447D8a07e3bd95BD0d56f35241523fBab1`](https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1), WBTC [`0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f`](https://arbiscan.io/address/0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f), ARB, GMX, GRAIL, PENDLE, LINK, wstETH, and old bridged USDC.e [`0xFF970A61A04b1cA14834A43f5dE4533eDBBD5CC8`](https://arbiscan.io/address/0xFF970A61A04b1cA14834A43f5dE4533eDBBD5CC8)) and the allowed spender list contains 30 addresses, including major Arbitrum DeFi venues and D2 strategy vaults.
-- dgnHYPE's `trader()` is a 3-of-5 Safe; only ~1.0M real USDC was directly observed there versus ~6.90M reported `totalAssets()`.
+- dgnHYPE's `trader()` is a 3-of-5 Safe; only ~1.0M real USDC was directly observed there versus ~6.90M reported `totalAssets()`. **The Safe is a standard Gnosis Safe with no on-chain guardrails** — 3-of-5 signers can call `execTransaction` to send assets to any address. Unlike the HYPE++ trader OMS (constrained to 32 pre-approved tokens and 30 venues), the dgnHYPE Safe has unrestricted custody over 55.6% of HYPE++ assets.
 
 ### Provability
 
@@ -308,7 +308,7 @@ Governance / control:
 - Trader admin/executor authority includes an EOA with no timelock.
 - The trader's allowed token list includes volatile assets (WETH, WBTC, ARB, GMX, GRAIL, PENDLE, LINK, wstETH) and old bridged USDC.e, expanding the strategy risk surface.
 - Funds are actively custodied by the trader during epochs; users cannot withdraw while custodied.
-- HYPE++ currently has large nested exposure to dgnHYPE (~55.6% of assets), another D2 active strategy controlled by the same EOA owner.
+- HYPE++ currently has large nested exposure to dgnHYPE (~55.6% of assets), another D2 active strategy controlled by the same EOA owner. The dgnHYPE custody Safe has no on-chain guardrails (standard Gnosis Safe, not a constrained OMS) — a separate trust surface for the majority of HYPE++ capital.
 - End-to-end backing is not a simple live reserve balance; it depends on D2 trader execution and return of funds.
 
 ### Critical Risks
@@ -318,6 +318,7 @@ Governance / control:
   2. **Balance gate:** `setWhitelistBalance(type(uint256).max)` — no user can satisfy `whitelistAsset.balanceOf(user) >= uint256.max`, so every `withdraw()` and `redeem()` reverts. One transaction, no enumeration needed, blocks every shareholder indiscriminately.
   Both paths work because the `onlyWhitelisted()` modifier gates `withdraw()` and `redeem()` — not just `deposit()` and `mint()` — confirmed via bytecode analysis on June 24, 2026. There is no onchain bypass. The same attack applies to dgnHYPE (also `VaultV1Whitelisted`, same owner EOA, identical bytecode pattern), where the HYPE++ trader is the sole dgnHYPE holder — blocking dgnHYPE redemptions traps $6.90M (55.6% of HYPE++ assets). The vault holds zero USDC while custodied, so the trader must return funds before blocked users could even attempt an exit, but even after `returnFunds()` the gated `withdraw`/`redeem` would revert. Combined with `transferOwnership()`, a hacked EOA can transfer this power to a new attacker address, making the block permanent.
 - A compromised or malicious trader executor can interact with a broad allowed DeFi surface (32 tokens, 30 spenders) and cause trading losses before funds are returned.
+- **The dgnHYPE Safe (3-of-5) can steal $6.90M with no guardrails.** Unlike the HYPE++ trader OMS, which is constrained to pre-approved tokens and venues, the dgnHYPE custody Safe is a standard Gnosis Safe. 3-of-5 signers can call `execTransaction` to execute `USDC.transfer(attacker, amount)` — or any other arbitrary call — with no on-chain restriction. The Safe currently holds $1.00M in direct USDC and controls deployed positions worth ~$5.90M. Neither the dgnHYPE vault, the HYPE++ vault, nor the HYPE++ trader has any mechanism to constrain or override the Safe signers. This is a fundamentally different custody model from the HYPE++ OMS: restricted smart-contract execution vs unrestricted multisig custody. The Safe signers (5 addresses distinct from the HYPE++ trader roles) represent a separate trust surface for 55.6% of HYPE++ assets.
 - A compromised or malicious vault owner can manipulate epoch timing, transfer ownership, and change access controls for BOTH vaults, delaying exits or changing who can deposit/redeem.
 
 ---

--- a/reports/report/d2-hypeplus.md
+++ b/reports/report/d2-hypeplus.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: D2 Finance HYPE++
 
-- **Assessment Date:** June 23, 2026
+- **Assessment Date:** June 24, 2026
 - **Token:** HYPE++
 - **Chain:** Arbitrum
 - **Token Address:** [`0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004`](https://arbiscan.io/address/0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004)
@@ -75,7 +75,7 @@ No active Immunefi, Sherlock, Cantina, HackerOne, Code4rena, or Safe Harbor prog
 
 ## Historical Track Record
 
-HYPE++ was deployed on November 19, 2024, giving the scoped vault roughly 19 months of onchain history at the June 23, 2026 assessment date. Current scoped TVL is approximately $12.42M based on `totalAssets()` in USDC terms.
+HYPE++ was deployed on November 19, 2024, giving the scoped vault roughly 19 months of onchain history at the June 24, 2026 assessment date. Current scoped TVL is approximately $12.42M based on `totalAssets()` in USDC terms.
 
 D2 documentation describes a broader multi-year strategy record and states that the team combines DeFi-native and traditional finance derivatives experience. This is useful context, but the report scores the onchain HYPE++ vault rather than offchain performance history.
 
@@ -101,13 +101,13 @@ Current reserve reconciliation, verified June 23, 2026:
 
 The HYPE++ top-level arithmetic reconciles: direct USDC (~5.52M) plus dgnHYPE reported assets (~6.90M) equals HYPE++ `totalAssets()` (~12.42M). However, dgnHYPE itself is a nested active D2 strategy with custodied funds. Its `trader()` is a 3-of-5 Safe, and dgnHYPE uses the same custodied accounting pattern: while custodied, `totalAssets()` returns the stored `custodiedAmount` rather than live token balances. Only ~1.0M real Arbitrum USDC was found at the dgnHYPE Safe during this pass; the remaining dgnHYPE reported assets are therefore not fully verifiable from simple ERC-20 balances. Recent dgnHYPE Safe token-transfer history also includes a non-USDC token with a visually confusable symbol (`0xd13CEB6071cAe7d0A880059A022c1750E096D3ED`), which was not counted as backing.
 
-**Control concentration:** The dgnHYPE vault's `owner()` is the same EOA ([`0x0E8c0470773c65498F438cac380648B314399A46`](https://arbiscan.io/address/0x0E8c0470773c65498F438cac380648B314399A46)) that owns the HYPE++ vault, concentrating control of both vaults in a single EOA. dgnHYPE is also a `VaultV1Whitelisted` with the same whitelist-gated `withdraw`/`redeem` pattern confirmed via bytecode analysis — the same blacklist and balance-gate attacks apply to both vaults. The HYPE++ trader holds 100% of dgnHYPE supply, so blocking dgnHYPE redemptions would trap ~55.6% of HYPE++ assets (~$6.90M) inside the nested strategy.
+**Control concentration:** The dgnHYPE vault's `owner()` is the same EOA ([`0x0E8c0470773c65498F438cac380648B314399A46`](https://arbiscan.io/address/0x0E8c0470773c65498F438cac380648B314399A46)) that owns the HYPE++ vault, concentrating control of both vaults in a single EOA. dgnHYPE is a different contract — its verified source is `VaultV0` (distinct bytecode/codehash from the HYPE++ `VaultV1Whitelisted` vault), and its `whitelistBalance()`/`whitelistAsset()` do not exist (they revert). Its `withdraw`/`redeem` are still gated by `onlyWhitelisted`, but VaultV0's modifier is a pure `require(whitelisted[msg.sender])` with no holder-balance branch. So the **blacklist path applies to dgnHYPE** (the owner can remove its sole holder, the HYPE++ trader), but the `setWhitelistBalance(uint256.max)` balance-gate path does **not** exist there. The HYPE++ trader holds 100% of dgnHYPE supply, so blocking dgnHYPE redemptions would trap ~55.6% of HYPE++ assets (~$6.90M) inside the nested strategy.
 
 ### Accessibility
 
 - Deposit and mint are available only during the funding phase, only while not custodied, and only for whitelisted users or users holding more than `whitelistBalance` of `whitelistAsset`.
 - Current `whitelistAsset` is USDC and `whitelistBalance` is `1,000,000` base units (1 USDC), meaning users with more than 1 USDC can satisfy the holder branch of `onlyWhitelisted()`.
-- **Withdraw and redeem are also gated by `onlyWhitelisted()`** — verified via bytecode analysis on June 24, 2026. All four functions (`deposit`, `mint`, `withdraw`, `redeem`) share the same whitelist modifier. A user blacklisted via `setWhitelistStatus(user, false)` cannot withdraw shares even when the vault is not custodied and not in an active epoch. See § Critical Risks.
+- **Withdraw and redeem are also gated by `onlyWhitelisted()`** — verified against the verified source on June 24, 2026. All four functions (`deposit`, `mint`, `withdraw`, `redeem`) share the same modifier, which is `require(whitelisted[msg.sender] || IERC20(whitelistAsset).balanceOf(msg.sender) > whitelistBalance)`. Because of the holder branch, `setWhitelistStatus(user, false)` alone does **not** block a user who still holds more than `whitelistBalance` (currently >1 USDC) of `whitelistAsset` — they continue to satisfy the modifier and can withdraw. The reliable block is `setWhitelistBalance(type(uint256).max)`, which disables the holder branch for everyone. See § Critical Risks.
 - Withdrawals are also blocked while custodied or during an active epoch.
 - Current `maxDeposits` is 12,500,000 USDC, and current `totalDeposits` is 12,417,628.982186 USDC.
 
@@ -163,15 +163,15 @@ The largest risk is centralization:
 - HYPE++ vault owner is an EOA, not the documented D2 Vault MS.
 - The owner EOA can call `startEpoch()`, `setMaxDeposits()`, `setWhitelistAsset()`, `setWhitelistBalance()`, `transferOwnership()`, `setWhitelistStatus()`, `setWhitelistStatuses()`, and `renounceOwnership()`.
 - **Critical:** The owner can block all withdrawals via two one-transaction paths verified on June 24, 2026:
-  1. `setWhitelistStatus(user, false)` / `setWhitelistStatuses([...], [false,...])` — blacklists specific users from `withdraw`/`redeem` (not just `deposit`/`mint`).
-  2. `setWhitelistBalance(type(uint256).max)` — no user can hold `uint256.max` tokens, so every `withdraw()` and `redeem()` reverts. One transaction, zero enumeration, blocks every shareholder indiscriminately.
-  The same `onlyWhitelisted()` modifier is applied to all four functions (`deposit`, `mint`, `withdraw`, `redeem`) — confirmed via bytecode analysis on both the HYPE++ and dgnHYPE vaults.
+  1. `setWhitelistStatus(user, false)` / `setWhitelistStatuses([...], [false,...])` — removes specific users from the whitelist mapping for `withdraw`/`redeem` (not just `deposit`/`mint`). On HYPE++ this only bites users who do not independently satisfy the holder branch, so to block a target it must be paired with a raised `whitelistBalance`; on dgnHYPE (`VaultV0`, no holder branch) it is fully effective on its own.
+  2. `setWhitelistBalance(type(uint256).max)` — no user can hold more than `uint256.max` tokens, so the holder branch can never pass and every non-whitelisted `withdraw()`/`redeem()` reverts. One transaction, zero enumeration, blocks every shareholder indiscriminately. (This selector exists on the HYPE++ `VaultV1Whitelisted` vault, not on the dgnHYPE `VaultV0`.)
+  The `onlyWhitelisted()` modifier gates all four functions (`deposit`, `mint`, `withdraw`, `redeem`) on both vaults — verified against verified source. On HYPE++ (`VaultV1Whitelisted`) the modifier includes the `balanceOf > whitelistBalance` holder branch; on dgnHYPE (`VaultV0`) it is a pure `whitelisted[msg.sender]` mapping check.
 - The HYPE++ vault is NOT behind a proxy (EIP-1967/beacon/transparent proxy slots verified zero). This means the vault logic cannot be upgraded, but ownership can be transferred at any time via `transferOwnership()`.
 - HYPE++ trader `DEFAULT_ADMIN_ROLE` holders are the D2 Vault MS and an EOA.
 - HYPE++ trader `EXECUTOR_ROLE` holders are the D2 Vault MS and the same EOA.
 - The EOA also receives trader fees via `feeReceiver()`.
 - The D2 Vault MS is a 4-of-7 Safe, matching D2's documented vault multisig address, but there is no onchain timelock on trader role changes or vault owner actions.
-- dgnHYPE vault has the same EOA owner as HYPE++, further concentrating control. dgnHYPE is also `VaultV1Whitelisted` with identical whitelist-gated `withdraw`/`redeem` — confirmed via bytecode analysis. The HYPE++ trader holds 100% of dgnHYPE supply, so a dgnHYPE-level block would trap ~55.6% of HYPE++ assets (~$6.90M).
+- dgnHYPE vault has the same EOA owner as HYPE++, further concentrating control. dgnHYPE is a `VaultV0` (distinct bytecode) whose `withdraw`/`redeem` are also `onlyWhitelisted`, but with no holder-balance branch — so blacklisting its sole holder (the HYPE++ trader) via `setWhitelistStatus` blocks redemptions; the `setWhitelistBalance(uint256.max)` path does not exist on VaultV0. The HYPE++ trader holds 100% of dgnHYPE supply, so a dgnHYPE-level block would trap ~55.6% of HYPE++ assets (~$6.90M).
 
 The trader contract is a standalone selector router (code size ~4.2KB; EIP-1967/beacon/transparent proxy slots all zero) that delegatecalls modules based on `msg.sig`. The constructor wires selectors to module targets. The trader uses OpenZeppelin `AccessControl` (not `AccessControlEnumerable`), so `getRoleMemberCount` and `getRoleMember` are not available — role-holder enumeration requires scanning `RoleGranted`/`RoleRevoked` events. Operationally, this gives the executor a broad DeFi action surface, bounded by the strategy's allowed tokens/spenders/modules, but still much more discretionary than a passive vault.
 
@@ -272,7 +272,7 @@ User USDC
    +--> [dgnHYPE Vault shares] (~5.27M shares = 100% of supply)
           |
           v
-        [dgnHYPE Vault / VaultV1Whitelisted]  (non-upgradeable, no proxy)
+        [dgnHYPE Vault / VaultV0]  (non-upgradeable, no proxy)
           - owner: EOA 0x0E8c... (same EOA as HYPE++ vault owner)
           - trader: 3-of-5 Safe 0x155d...
           |
@@ -304,7 +304,7 @@ Governance / control:
 
 ### Key Risks
 
-- HYPE++ vault owner is an EOA with direct control over epoch scheduling, deposit caps, and whitelist settings — including the ability to block all users from **withdrawing** (not just depositing) via either blacklist or `setWhitelistBalance(uint256.max)`. The same EOA also owns the dgnHYPE vault, which has the identical vulnerability (confirmed via bytecode).
+- HYPE++ vault owner is an EOA with direct control over epoch scheduling, deposit caps, and whitelist settings — including the ability to block all users from **withdrawing** (not just depositing) via either blacklist (paired with a raised `whitelistBalance`) or `setWhitelistBalance(uint256.max)`. The same EOA also owns the dgnHYPE vault (a `VaultV0`), which is exposed to the blacklist path only — its `onlyWhitelisted` has no balance-gate branch.
 - Trader admin/executor authority includes an EOA with no timelock.
 - The trader's allowed token list includes volatile assets (WETH, WBTC, ARB, GMX, GRAIL, PENDLE, LINK, wstETH) and old bridged USDC.e, expanding the strategy risk surface.
 - Funds are actively custodied by the trader during epochs; users cannot withdraw while custodied.
@@ -314,9 +314,9 @@ Governance / control:
 ### Critical Risks
 
 - **A compromised vault owner EOA can permanently block all users from withdrawing** via two independent one-transaction paths:
-  1. **Blacklist:** `setWhitelistStatus(victim, false)` or `setWhitelistStatuses([...], [false,...])` — batch-blacklists specific users. Requires enumerating shareholder addresses but can be done at scale via the batch function.
-  2. **Balance gate:** `setWhitelistBalance(type(uint256).max)` — no user can satisfy `whitelistAsset.balanceOf(user) >= uint256.max`, so every `withdraw()` and `redeem()` reverts. One transaction, no enumeration needed, blocks every shareholder indiscriminately.
-  Both paths work because the `onlyWhitelisted()` modifier gates `withdraw()` and `redeem()` — not just `deposit()` and `mint()` — confirmed via bytecode analysis on June 24, 2026. There is no onchain bypass. The same attack applies to dgnHYPE (also `VaultV1Whitelisted`, same owner EOA, identical bytecode pattern), where the HYPE++ trader is the sole dgnHYPE holder — blocking dgnHYPE redemptions traps $6.90M (55.6% of HYPE++ assets). The vault holds zero USDC while custodied, so the trader must return funds before blocked users could even attempt an exit, but even after `returnFunds()` the gated `withdraw`/`redeem` would revert. Combined with `transferOwnership()`, a hacked EOA can transfer this power to a new attacker address, making the block permanent.
+  1. **Blacklist:** `setWhitelistStatus(victim, false)` or `setWhitelistStatuses([...], [false,...])` — removes specific users from the whitelist mapping. On HYPE++ this is not sufficient on its own: the `onlyWhitelisted()` holder branch still lets a removed user withdraw as long as they hold more than `whitelistBalance` (currently >1 USDC) of `whitelistAsset`, so this path must be paired with a raised `whitelistBalance` to bite. (On the dgnHYPE `VaultV0`, which has no holder branch, the blacklist path is fully effective on its own.)
+  2. **Balance gate:** `setWhitelistBalance(type(uint256).max)` — no user can satisfy `whitelistAsset.balanceOf(user) > uint256.max`, so the holder branch can never pass and every non-whitelisted `withdraw()` and `redeem()` reverts. One transaction, no enumeration needed, blocks every shareholder indiscriminately. This is the reliable single-transaction block on HYPE++.
+  Both paths work because the `onlyWhitelisted()` modifier gates `withdraw()` and `redeem()` — not just `deposit()` and `mint()` — verified against the verified `VaultV1Whitelisted` source on June 24, 2026. There is no onchain bypass. The blacklist path also applies to dgnHYPE, a separate `VaultV0` contract (distinct bytecode; `whitelistBalance`/`whitelistAsset` do not exist there), where the HYPE++ trader is the sole dgnHYPE holder — blacklisting it traps $6.90M (55.6% of HYPE++ assets). The vault holds zero USDC while custodied, so the trader must return funds before blocked users could even attempt an exit, but even after `returnFunds()` the gated `withdraw`/`redeem` would revert. Combined with `transferOwnership()`, a hacked EOA can transfer this power to a new attacker address, making the block permanent.
 - A compromised or malicious trader executor can interact with a broad allowed DeFi surface (32 tokens, 30 spenders) and cause trading losses before funds are returned.
 - **The dgnHYPE Safe (3-of-5) can steal $6.90M with no guardrails.** Unlike the HYPE++ trader OMS, which is constrained to pre-approved tokens and venues, the dgnHYPE custody Safe is a standard Gnosis Safe. 3-of-5 signers can call `execTransaction` to execute `USDC.transfer(attacker, amount)` — or any other arbitrary call — with no on-chain restriction. The Safe currently holds $1.00M in direct USDC and controls deployed positions worth ~$5.90M. Neither the dgnHYPE vault, the HYPE++ vault, nor the HYPE++ trader has any mechanism to constrain or override the Safe signers. This is a fundamentally different custody model from the HYPE++ OMS: restricted smart-contract execution vs unrestricted multisig custody. The Safe signers (5 addresses distinct from the HYPE++ trader roles) represent a separate trust surface for 55.6% of HYPE++ assets.
 - A compromised or malicious vault owner can manipulate epoch timing, transfer ownership, and change access controls for BOTH vaults, delaying exits or changing who can deposit/redeem.

--- a/reports/report/d2-hypeplus.md
+++ b/reports/report/d2-hypeplus.md
@@ -101,13 +101,14 @@ Current reserve reconciliation, verified June 23, 2026:
 
 The HYPE++ top-level arithmetic reconciles: direct USDC (~5.52M) plus dgnHYPE reported assets (~6.90M) equals HYPE++ `totalAssets()` (~12.42M). However, dgnHYPE itself is a nested active D2 strategy with custodied funds. Its `trader()` is a 3-of-5 Safe, and dgnHYPE uses the same custodied accounting pattern: while custodied, `totalAssets()` returns the stored `custodiedAmount` rather than live token balances. Only ~1.0M real Arbitrum USDC was found at the dgnHYPE Safe during this pass; the remaining dgnHYPE reported assets are therefore not fully verifiable from simple ERC-20 balances. Recent dgnHYPE Safe token-transfer history also includes a non-USDC token with a visually confusable symbol (`0xd13CEB6071cAe7d0A880059A022c1750E096D3ED`), which was not counted as backing.
 
-**Control concentration:** The dgnHYPE vault's `owner()` is the same EOA ([`0x0E8c0470773c65498F438cac380648B314399A46`](https://arbiscan.io/address/0x0E8c0470773c65498F438cac380648B314399A46)) that owns the HYPE++ vault, concentrating control of both vaults in a single EOA.
+**Control concentration:** The dgnHYPE vault's `owner()` is the same EOA ([`0x0E8c0470773c65498F438cac380648B314399A46`](https://arbiscan.io/address/0x0E8c0470773c65498F438cac380648B314399A46)) that owns the HYPE++ vault, concentrating control of both vaults in a single EOA. dgnHYPE is also a `VaultV1Whitelisted` with the same whitelist-gated `withdraw`/`redeem` pattern confirmed via bytecode analysis — the same blacklist and balance-gate attacks apply to both vaults. The HYPE++ trader holds 100% of dgnHYPE supply, so blocking dgnHYPE redemptions would trap ~55.6% of HYPE++ assets (~$6.90M) inside the nested strategy.
 
 ### Accessibility
 
 - Deposit and mint are available only during the funding phase, only while not custodied, and only for whitelisted users or users holding more than `whitelistBalance` of `whitelistAsset`.
 - Current `whitelistAsset` is USDC and `whitelistBalance` is `1,000,000` base units (1 USDC), meaning users with more than 1 USDC can satisfy the holder branch of `onlyWhitelisted()`.
-- Withdraw and redeem are available only while not custodied and not during an active epoch.
+- **Withdraw and redeem are also gated by `onlyWhitelisted()`** — verified via bytecode analysis on June 24, 2026. All four functions (`deposit`, `mint`, `withdraw`, `redeem`) share the same whitelist modifier. A user blacklisted via `setWhitelistStatus(user, false)` cannot withdraw shares even when the vault is not custodied and not in an active epoch. See § Critical Risks.
+- Withdrawals are also blocked while custodied or during an active epoch.
 - Current `maxDeposits` is 12,500,000 USDC, and current `totalDeposits` is 12,417,628.982186 USDC.
 
 ### Token Mint Authority
@@ -160,13 +161,17 @@ No meaningful onchain DEX liquidity for HYPE++ was identified in this pass. The 
 The largest risk is centralization:
 
 - HYPE++ vault owner is an EOA, not the documented D2 Vault MS.
-- The owner EOA can call `startEpoch()`, `setMaxDeposits()`, `setWhitelistAsset()`, `setWhitelistBalance()`, `transferOwnership()`, and whitelist status functions.
+- The owner EOA can call `startEpoch()`, `setMaxDeposits()`, `setWhitelistAsset()`, `setWhitelistBalance()`, `transferOwnership()`, `setWhitelistStatus()`, `setWhitelistStatuses()`, and `renounceOwnership()`.
+- **Critical:** The owner can block all withdrawals via two one-transaction paths verified on June 24, 2026:
+  1. `setWhitelistStatus(user, false)` / `setWhitelistStatuses([...], [false,...])` — blacklists specific users from `withdraw`/`redeem` (not just `deposit`/`mint`).
+  2. `setWhitelistBalance(type(uint256).max)` — no user can hold `uint256.max` tokens, so every `withdraw()` and `redeem()` reverts. One transaction, zero enumeration, blocks every shareholder indiscriminately.
+  The same `onlyWhitelisted()` modifier is applied to all four functions (`deposit`, `mint`, `withdraw`, `redeem`) — confirmed via bytecode analysis on both the HYPE++ and dgnHYPE vaults.
 - The HYPE++ vault is NOT behind a proxy (EIP-1967/beacon/transparent proxy slots verified zero). This means the vault logic cannot be upgraded, but ownership can be transferred at any time via `transferOwnership()`.
 - HYPE++ trader `DEFAULT_ADMIN_ROLE` holders are the D2 Vault MS and an EOA.
 - HYPE++ trader `EXECUTOR_ROLE` holders are the D2 Vault MS and the same EOA.
 - The EOA also receives trader fees via `feeReceiver()`.
 - The D2 Vault MS is a 4-of-7 Safe, matching D2's documented vault multisig address, but there is no onchain timelock on trader role changes or vault owner actions.
-- dgnHYPE vault has the same EOA owner as HYPE++, further concentrating control.
+- dgnHYPE vault has the same EOA owner as HYPE++, further concentrating control. dgnHYPE is also `VaultV1Whitelisted` with identical whitelist-gated `withdraw`/`redeem` — confirmed via bytecode analysis. The HYPE++ trader holds 100% of dgnHYPE supply, so a dgnHYPE-level block would trap ~55.6% of HYPE++ assets (~$6.90M).
 
 The trader contract is a standalone selector router (code size ~4.2KB; EIP-1967/beacon/transparent proxy slots all zero) that delegatecalls modules based on `msg.sig`. The constructor wires selectors to module targets. The trader uses OpenZeppelin `AccessControl` (not `AccessControlEnumerable`), so `getRoleMemberCount` and `getRoleMember` are not available — role-holder enumeration requires scanning `RoleGranted`/`RoleRevoked` events. Operationally, this gives the executor a broad DeFi action surface, bounded by the strategy's allowed tokens/spenders/modules, but still much more discretionary than a passive vault.
 
@@ -233,6 +238,7 @@ Monitor these contracts and values:
 Suggested alert thresholds:
 
 - Any vault `OwnershipTransferred` event.
+- Any `NewWhitelistStatus` event — especially `setWhitelistStatus(addr, false)` targeting a non-zero share holder (indicates blacklisting of existing depositors blocking withdrawal).
 - Any trader `RoleGranted` or `RoleRevoked` event.
 - Any `setMaxDeposits()` change greater than 10%.
 - Any new epoch with an end timestamp materially longer than 30 days.
@@ -298,7 +304,7 @@ Governance / control:
 
 ### Key Risks
 
-- HYPE++ vault owner is an EOA with direct control over epoch scheduling, deposit caps, and whitelist settings. The same EOA also owns the dgnHYPE vault.
+- HYPE++ vault owner is an EOA with direct control over epoch scheduling, deposit caps, and whitelist settings — including the ability to block all users from **withdrawing** (not just depositing) via either blacklist or `setWhitelistBalance(uint256.max)`. The same EOA also owns the dgnHYPE vault, which has the identical vulnerability (confirmed via bytecode).
 - Trader admin/executor authority includes an EOA with no timelock.
 - The trader's allowed token list includes volatile assets (WETH, WBTC, ARB, GMX, GRAIL, PENDLE, LINK, wstETH) and old bridged USDC.e, expanding the strategy risk surface.
 - Funds are actively custodied by the trader during epochs; users cannot withdraw while custodied.
@@ -307,6 +313,10 @@ Governance / control:
 
 ### Critical Risks
 
+- **A compromised vault owner EOA can permanently block all users from withdrawing** via two independent one-transaction paths:
+  1. **Blacklist:** `setWhitelistStatus(victim, false)` or `setWhitelistStatuses([...], [false,...])` — batch-blacklists specific users. Requires enumerating shareholder addresses but can be done at scale via the batch function.
+  2. **Balance gate:** `setWhitelistBalance(type(uint256).max)` — no user can satisfy `whitelistAsset.balanceOf(user) >= uint256.max`, so every `withdraw()` and `redeem()` reverts. One transaction, no enumeration needed, blocks every shareholder indiscriminately.
+  Both paths work because the `onlyWhitelisted()` modifier gates `withdraw()` and `redeem()` — not just `deposit()` and `mint()` — confirmed via bytecode analysis on June 24, 2026. There is no onchain bypass. The same attack applies to dgnHYPE (also `VaultV1Whitelisted`, same owner EOA, identical bytecode pattern), where the HYPE++ trader is the sole dgnHYPE holder — blocking dgnHYPE redemptions traps $6.90M (55.6% of HYPE++ assets). The vault holds zero USDC while custodied, so the trader must return funds before blocked users could even attempt an exit, but even after `returnFunds()` the gated `withdraw`/`redeem` would revert. Combined with `transferOwnership()`, a hacked EOA can transfer this power to a new attacker address, making the block permanent.
 - A compromised or malicious trader executor can interact with a broad allowed DeFi surface (32 tokens, 30 spenders) and cause trading losses before funds are returned.
 - A compromised or malicious vault owner can manipulate epoch timing, transfer ownership, and change access controls for BOTH vaults, delaying exits or changing who can deposit/redeem.
 

--- a/reports/report/d2-hypeplus.md
+++ b/reports/report/d2-hypeplus.md
@@ -1,0 +1,446 @@
+# Protocol Risk Assessment: D2 Finance HYPE++
+
+- **Assessment Date:** June 23, 2026
+- **Token:** HYPE++
+- **Chain:** Arbitrum
+- **Token Address:** [`0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004`](https://arbiscan.io/address/0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004)
+- **Final Score: 3.74/5.0**
+
+## Overview + Links
+
+D2 Finance offers actively managed ERC-4626 strategy vaults. The scoped asset is the HYPE++ vault on Arbitrum, a USDC-denominated strategy vault whose funds are moved from the vault into a D2 trader/OMS contract during trading epochs. D2 docs describe each strategy as a standalone vault + trader contract + trader OMS; users deposit during a funding phase, funds are custodied by the trader during the trading phase, and funds are returned to the vault at the end of an epoch for withdrawal or rollover.
+
+The HYPE++ vault is currently in epoch 20. Onchain state verified on June 23, 2026:
+
+- Current epoch funding start: June 6, 2026 02:10 UTC.
+- Current epoch trading start: June 8, 2026 13:00 UTC.
+- Current epoch end: July 3, 2026 08:00 UTC.
+- `custodied() = true`; direct user withdrawals are disabled while custodied.
+- `totalAssets() = 12,417,628.982186 USDC`; `totalSupply() = 8,379,842.251215 HYPE++`.
+- HYPE++ trader holds ~5.52M USDC directly and all outstanding dgnHYPE shares; dgnHYPE reports ~6.90M USDC `totalAssets()`. This reconciles to HYPE++ `totalAssets()`, but deeper dgnHYPE positions remain a nested D2 strategy dependency.
+
+**Links:**
+
+- [Protocol Documentation](https://gitbook.d2.finance/)
+- [D2 HYPE++ Strategy Page](https://d2.finance/strategies/0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004)
+- [Architecture Docs](https://gitbook.d2.finance/protocol/architecture)
+- [Trading Strategy Docs](https://gitbook.d2.finance/protocol/trading-strategies)
+- [Smart Contract Audits](https://gitbook.d2.finance/security-and-contracts/smart-contract-audits)
+- [Strategy Contract List](https://gitbook.d2.finance/security-and-contracts/smart-contracts/strategy-contracts)
+- [D2 Multisig List](https://gitbook.d2.finance/security-and-contracts/smart-contracts/d2-multi-sigs)
+- [Paladin D2 Audit Page](https://paladinsec.co/projects/d2/)
+- [Cyfrin D2 v2.1 Audit PDF](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-02-24-cyfrin-d2-v2.1.pdf)
+- [Cyfrin D2 HYPE CoreWriter v2.0 Audit PDF](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-10-16-cyfrin-d2-hype-corewriter-v2.0.pdf)
+- [Arbitrum L2BEAT Risk Page](https://l2beat.com/scaling/projects/arbitrum)
+
+## Contract Addresses
+
+| Contract | Address | Type |
+|----------|---------|------|
+| HYPE++ Vault | [`0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004`](https://arbiscan.io/address/0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004) | `VaultV1Whitelisted`, ERC-4626-style vault |
+| HYPE++ Trader / OMS | [`0x8CaBD8b787e8c69C5f24091cFDA197fF570345B3`](https://arbiscan.io/address/0x8CaBD8b787e8c69C5f24091cFDA197fF570345B3) | Verified `Strategy` proxy / selector router |
+| Trader Implementation | [`0xc8071ad5560904b3b721e7e5d29742f523a69111`](https://arbiscan.io/address/0xc8071ad5560904b3b721e7e5d29742f523a69111) | Strategy implementation |
+| Vault Owner | [`0x0E8c0470773c65498F438cac380648B314399A46`](https://arbiscan.io/address/0x0E8c0470773c65498F438cac380648B314399A46) | EOA, owns HYPE++ vault |
+| Trader Admin / Executor / Fee Receiver | [`0x7ab129978091DEE65A319c5FC728818D73221999`](https://arbiscan.io/address/0x7ab129978091DEE65A319c5FC728818D73221999) | EOA with `DEFAULT_ADMIN_ROLE` and `EXECUTOR_ROLE` on trader |
+| D2 Vault Multisig | [`0xB2fEDed045F3fd9FcCCF8E7e95729c4182916CE0`](https://arbiscan.io/address/0xB2fEDed045F3fd9FcCCF8E7e95729c4182916CE0) | Safe, 4-of-7; also trader admin/executor |
+| dgnHYPE Vault | [`0x64167cd42859F64cfF2Aa4B63c3175cceF9659dd`](https://arbiscan.io/address/0x64167cd42859F64cfF2Aa4B63c3175cceF9659dd) | Nested D2 ERC-4626 vault held by HYPE++ trader |
+| dgnHYPE Trader / Custody Safe | [`0x155d0B27B754ebC664aeD565945C1AaEa91966fb`](https://arbiscan.io/address/0x155d0B27B754ebC664aeD565945C1AaEa91966fb) | Nested D2 custody Safe, 3-of-5 |
+| USDC | [`0xaf88d065e77c8cC2239327C5EDb3A432268e5831`](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831) | Underlying asset |
+| Vault Factory | [`0xb5B272EF918835651375f84D463b1Ba7B61eF028`](https://arbiscan.io/address/0xb5B272EF918835651375f84D463b1Ba7B61eF028) | Deployed HYPE++ vault |
+| Strategy Factory | [`0x2AA01FdE174aB160b4e4F49F152C20d6Ec029d67`](https://arbiscan.io/address/0x2AA01FdE174aB160b4e4F49F152C20d6Ec029d67) | Deployed HYPE++ trader |
+
+Deployment metadata:
+
+- HYPE++ vault and trader were deployed in transaction [`0xf5642a6a...6265e`](https://arbiscan.io/tx/0xf5642a6afa068616ac286c0c26ef32f46bc43333edf79fe071ff3f60b346265e) at Arbitrum block `276124793` on November 19, 2024.
+- Trader implementation was deployed in transaction [`0xe432dabc...8675`](https://arbiscan.io/tx/0xe432dabfc9572c103e858399f29530b458fdbb882b4ab0e94245eeae553a8675) at block `218684412`.
+
+## Audits and Due Diligence Disclosures
+
+D2 publicly lists three audit links: Paladin, Cyfrin D2 v2.1, and Cyfrin Hyperliquid CoreWriter. The most directly relevant audit lineage is:
+
+| Date | Firm | Scope | Link |
+|------|------|-------|------|
+| Mar 23, 2023 | Paladin | D2 staking contracts | [Paladin D2](https://paladinsec.co/projects/d2/) |
+| Sep 27, 2023 | Paladin | D2 strategy stack including `VaultV1`, `TraderV0`, StrategyETH, AccessControl, and DeFi modules | [Paladin D2](https://paladinsec.co/projects/d2/) |
+| Feb 24, 2025 | Cyfrin | D2 v2.1 | [PDF](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-02-24-cyfrin-d2-v2.1.pdf) |
+| Oct 16, 2025 | Cyfrin | D2 HYPE CoreWriter v2.0 | [PDF](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-10-16-cyfrin-d2-hype-corewriter-v2.0.pdf) |
+
+Paladin's public page lists the September 2023 strategy audit as completed with 85 total issues: 18 governance, 3 high, 8 medium, 23 low, and 33 informational. Paladin's page also cautions users to confirm they are interacting with audited contracts. HYPE++ was deployed later, in November 2024, but the verified source identifies the vault as `VaultV1Whitelisted` and the trader as D2's `Strategy` router/OMS architecture.
+
+### Bug Bounty
+
+No active Immunefi, Sherlock, Cantina, HackerOne, Code4rena, or Safe Harbor program was found in the D2 docs reviewed for this assessment, and targeted searches for D2 Finance on Immunefi and Safe Harbor did not return a listed program. D2 publishes audit links and security process statements, but no public bounty with payout terms was verified.
+
+## Historical Track Record
+
+HYPE++ was deployed on November 19, 2024, giving the scoped vault roughly 19 months of onchain history at the June 23, 2026 assessment date. Current scoped TVL is approximately $12.42M based on `totalAssets()` in USDC terms.
+
+D2 documentation describes a broader multi-year strategy record and states that the team combines DeFi-native and traditional finance derivatives experience. This is useful context, but the report scores the onchain HYPE++ vault rather than offchain performance history.
+
+No public exploit specific to the HYPE++ vault was identified in this pass. The main historical concern is not a known loss event; it is the intentionally active-managed design, where funds are transferred out of the vault into a trader contract and can be exposed to a broad set of trading modules, allowed tokens, nested D2 vault tokens, and external DeFi venues.
+
+## Funds Management
+
+HYPE++ is an ERC-4626-compatible USDC vault. Users deposit USDC during funding windows and receive HYPE++ shares. During the trading phase, the trader contract calls `custodyFunds()` on the vault and receives the vault's USDC. While `custodied = true`, `totalAssets()` returns the last `custodiedAmount` rather than current vault-held USDC.
+
+Current reserve reconciliation, verified June 23, 2026:
+
+| Component | Value |
+|-----------|-------|
+| HYPE++ `totalAssets()` | 12,417,628.982186 USDC |
+| HYPE++ `totalSupply()` | 8,379,842.251215 shares |
+| HYPE++ vault USDC balance | 0 USDC |
+| HYPE++ trader direct USDC balance | 5,517,527.061191 USDC |
+| HYPE++ trader dgnHYPE balance | 5,266,942.856401 dgnHYPE shares |
+| dgnHYPE `totalSupply()` | 5,266,942.856401 shares |
+| dgnHYPE `totalAssets()` | 6,900,278.503957 USDC |
+| dgnHYPE trader direct USDC balance found | 1,000,278.503957 USDC |
+| dgnHYPE trader custody type | 3-of-5 Safe |
+
+The HYPE++ top-level arithmetic reconciles: direct USDC (~5.52M) plus dgnHYPE reported assets (~6.90M) equals HYPE++ `totalAssets()` (~12.42M). However, dgnHYPE itself is a nested active D2 strategy with custodied funds. Its `trader()` is a 3-of-5 Safe, and dgnHYPE uses the same custodied accounting pattern: while custodied, `totalAssets()` returns the stored `custodiedAmount` rather than live token balances. Only ~1.0M real Arbitrum USDC was found at the dgnHYPE Safe during this pass; the remaining dgnHYPE reported assets are therefore not fully verifiable from simple ERC-20 balances. Recent dgnHYPE Safe token-transfer history also includes a non-USDC token with a visually confusable symbol (`0xd13CEB6071cAe7d0A880059A022c1750E096D3ED`), which was not counted as backing.
+
+### Accessibility
+
+- Deposit and mint are available only during the funding phase, only while not custodied, and only for whitelisted users or users holding more than `whitelistBalance` of `whitelistAsset`.
+- Current `whitelistAsset` is USDC and `whitelistBalance` is `1,000,000` base units (1 USDC), meaning users with more than 1 USDC can satisfy the holder branch of `onlyWhitelisted()`.
+- Withdraw and redeem are available only while not custodied and not during an active epoch.
+- Current `maxDeposits` is 12,500,000 USDC, and current `totalDeposits` is 12,417,628.982186 USDC.
+
+### Token Mint Authority
+
+**Mint mechanism:** ERC-4626 deposit/mint. HYPE++ shares are minted by `deposit()` or `mint()` only when USDC is transferred into the vault. There is no privileged `MINTER_ROLE` on the HYPE++ vault.
+
+**Mint requires backing:** Yes at the HYPE++ vault level. `deposit()` and `mint()` route through OpenZeppelin ERC-4626 mechanics and require underlying asset transfer in the same transaction. This does not remove trading-loss risk after funds are custodied.
+
+**Per-address mint authority** (verified onchain on June 23, 2026, from token contract `0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004`):
+
+| Address | Can Mint | Can Burn | Role / Mechanism | Notes |
+|---------|:--------:|:--------:|------------------|-------|
+| Any user satisfying `onlyWhitelisted()` during funding | Yes | Yes, via redeem/withdraw after epoch | ERC-4626 deposit/redeem | Requires USDC transfer for mint; redeem is blocked while custodied or during epoch |
+| [`0x0E8c0470773c65498F438cac380648B314399A46`](https://arbiscan.io/address/0x0E8c0470773c65498F438cac380648B314399A46) | No direct unbacked mint | No | Vault owner | EOA can set whitelist parameters, deposit caps, and epoch schedule |
+| [`0x8CaBD8b787e8c69C5f24091cFDA197fF570345B3`](https://arbiscan.io/address/0x8CaBD8b787e8c69C5f24091cFDA197fF570345B3) | No direct unbacked mint | No | Trader | Can custody and return funds; trading losses are borne by vault users |
+
+**Rate limits / supply caps:** Current `maxDeposits` is 12,500,000 USDC.
+
+**Backing check at mint time:** Atomic at the HYPE++ vault level. Collateral must transfer into the vault on mint/deposit.
+
+### Collateralization
+
+HYPE++ is not overcollateralized. It is a share token over an actively managed USDC strategy. The top-level HYPE++ accounting reconciles to direct USDC plus dgnHYPE shares, but the system is not equivalent to a passive collateral vault:
+
+- While custodied, the vault's `totalAssets()` is the stored `custodiedAmount`, not a live mark-to-market of all current trader positions.
+- The verified source comments on `returnFunds()` state that losses may be sustained during trading and investors suffer the loss.
+- HYPE++ currently depends on dgnHYPE for ~55.6% of reported assets by value, creating recursive D2 strategy exposure.
+- The trader's allowed token list contains 32 tokens and the allowed spender list contains 30 addresses, including major Arbitrum DeFi venues and D2 strategy vaults.
+- dgnHYPE's `trader()` is a 3-of-5 Safe; only ~1.0M real USDC was directly observed there versus ~6.90M reported `totalAssets()`.
+
+### Provability
+
+Top-level HYPE++ accounting is partially provable:
+
+- `totalAssets()`, `custodiedAmount()`, direct USDC balances, dgnHYPE balances, and dgnHYPE `totalAssets()` are onchain.
+- HYPE++ does not need an offchain price oracle for the top-level USDC + dgnHYPE share accounting observed in this pass.
+- End-to-end position risk is not fully transparent from a single call because nested dgnHYPE is itself custodied by a Safe and reports stored custodied accounting while active.
+- D2 docs state positions are generally onchain-verifiable but disclose exceptions for Flowdesk OTC trades and partial verifiability of Flowdesk collateral. No Flowdesk exposure was proven for HYPE++ in this pass, but the disclosure is relevant to D2's strategy model.
+
+## Liquidity Risk
+
+Exit liquidity is restricted by epoch state rather than by a normal liquid secondary market. Current HYPE++ withdrawals/redeems are unavailable because `custodied() = true` and the current epoch ends on July 3, 2026. Users can only redeem after the trader returns funds and the vault is out of epoch.
+
+No meaningful onchain DEX liquidity for HYPE++ was identified in this pass. The primary exit path is vault redemption after epoch completion, subject to returned assets and any trading PnL. Large holders should assume exit timing is governed by the epoch schedule and D2's trader returning funds, not by instant secondary-market liquidity.
+
+## Centralization & Control Risks
+
+### Governance
+
+The largest risk is centralization:
+
+- HYPE++ vault owner is an EOA, not the documented D2 Vault MS.
+- The owner EOA can call `startEpoch()`, `setMaxDeposits()`, `setWhitelistAsset()`, `setWhitelistBalance()`, and whitelist status functions.
+- HYPE++ trader `DEFAULT_ADMIN_ROLE` holders are the D2 Vault MS and an EOA.
+- HYPE++ trader `EXECUTOR_ROLE` holders are the D2 Vault MS and the same EOA.
+- The EOA also receives trader fees via `feeReceiver()`.
+- The D2 Vault MS is a 4-of-7 Safe, matching D2's documented vault multisig address, but there is no onchain timelock on trader role changes or vault owner actions.
+
+The trader contract is a selector router that delegatecalls modules based on `msg.sig`. The constructor wires many selectors to module targets. Operationally, this gives the executor a broad DeFi action surface, bounded by the strategy's allowed tokens/spenders/modules, but still much more discretionary than a passive vault.
+
+### Programmability
+
+The strategy is hybrid/manual:
+
+- Vault deposit/withdraw rules are programmatic.
+- Trading execution is manual or offchain-directed through executor role calls into the trader OMS.
+- Epoch start/end scheduling is owner-controlled.
+- PnL crystallizes when the trader returns funds to the vault.
+
+The design is appropriate for an active derivatives/managed strategy product, but it scores poorly under a Yearn-style risk framework because users rely on D2 operators to trade safely and return funds.
+
+### External Dependencies
+
+Dependencies include:
+
+- Arbitrum One as the execution chain. L2BEAT lists Arbitrum One as a Stage 1 optimistic rollup and notes upgrade/security-council and sequencer-related trust assumptions.
+- Circle/Arbitrum USDC as the base asset.
+- D2's nested dgnHYPE strategy.
+- Broad Arbitrum DeFi venues approved in the trader's allowed spender list, including Aave, 1inch, GMX/Camelot-style modules, and D2 strategy contracts.
+- Offchain operator process for strategy decisions.
+
+## Operational Risk
+
+D2 documentation is materially better than many active-manager vaults: it describes architecture, epochs, security process, strategy philosophy, multisigs, and audit links. D2 also discloses BVI approved asset manager language and a Marshall Islands DAO for frontend hosting.
+
+Operational gaps remain:
+
+- The current HYPE++ vault owner is an EOA, not the documented Vault MS; no D2 documentation reviewed explains this vault-specific ownership choice or states whether ownership will be transferred.
+- The EOA with trader admin/executor/fee-receiver roles is not identified in the docs reviewed.
+- No public bug bounty with payout terms was found.
+- Nested dgnHYPE backing is only partially transparent from ERC-20 balances: the dgnHYPE Safe directly held ~1.0M real USDC against ~6.90M reported `totalAssets()`.
+
+## Monitoring
+
+Recommended monitoring frequency: hourly during active epochs, daily outside active epochs.
+
+Monitor these contracts and values:
+
+- HYPE++ vault [`0x7528...5004`](https://arbiscan.io/address/0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004)
+  - `custodied()`, `custodiedAmount()`, `totalAssets()`, `totalSupply()`, `totalDeposits()`, `maxDeposits()`, `getCurrentEpochInfo()`
+  - Events: `EpochStarted`, `FundsCustodied`, `FundsReturned`, `NewMaxDeposits`, `NewWhitelistStatus`, `OwnershipTransferred`
+- HYPE++ trader [`0x8CaB...45B3`](https://arbiscan.io/address/0x8CaBD8b787e8c69C5f24091cFDA197fF570345B3)
+  - `hasRole(DEFAULT_ADMIN_ROLE, account)` and `hasRole(EXECUTOR_ROLE, account)` for known holders
+  - Events: `RoleGranted`, `RoleRevoked`
+  - `getAllowedTokens()`, `getAllowedSpenders()`, `feeReceiver()`, `performanceFeeRate()`, `managementFeeRate()`
+- Vault owner EOA [`0x0E8c...9A46`](https://arbiscan.io/address/0x0E8c0470773c65498F438cac380648B314399A46)
+  - All outbound transactions to the HYPE++ vault.
+- Trader role EOA [`0x7ab1...1999`](https://arbiscan.io/address/0x7ab129978091DEE65A319c5FC728818D73221999)
+  - All role/admin/trading transactions.
+- D2 Vault MS [`0xB2fE...6CE0`](https://arbiscan.io/address/0xB2fEDed045F3fd9FcCCF8E7e95729c4182916CE0)
+  - Safe threshold/owner changes and trader role changes.
+- dgnHYPE vault [`0x6416...59dd`](https://arbiscan.io/address/0x64167cd42859F64cfF2Aa4B63c3175cceF9659dd)
+  - `totalAssets()`, `totalSupply()`, `custodied()`, `trader()`
+
+Suggested alert thresholds:
+
+- Any vault `OwnershipTransferred` event.
+- Any trader `RoleGranted` or `RoleRevoked` event.
+- Any `setMaxDeposits()` change greater than 10%.
+- Any new epoch with an end timestamp materially longer than 30 days.
+- Any mismatch where direct HYPE++ trader assets plus dgnHYPE-derived assets fail to reconcile to HYPE++ `totalAssets()` by more than 1%.
+- Any dgnHYPE `totalAssets()` drop greater than 2% between checks.
+
+## Appendix: Contract Architecture
+
+```
+User USDC
+   |
+   v
+[HYPE++ Vault / VaultV1Whitelisted]
+   - ERC-4626 share token
+   - owner: EOA 0x0E8c...
+   - deposits only during funding window
+   - withdrawals only after epoch and when not custodied
+   |
+   | custodyFunds() during epoch
+   v
+[HYPE++ Trader / Strategy OMS]
+   - DEFAULT_ADMIN_ROLE: Vault MS + EOA 0x7ab1...
+   - EXECUTOR_ROLE: Vault MS + EOA 0x7ab1...
+   - fee receiver: EOA 0x7ab1...
+   - allowed tokens/spenders define trading surface
+   |
+   +--> Direct USDC balance (~5.52M)
+   |
+   +--> [dgnHYPE Vault shares] (~5.27M shares)
+          |
+          v
+        [dgnHYPE Trader / nested D2 strategy]
+          - reports ~6.90M USDC totalAssets
+          - 3-of-5 custody Safe; ~1.0M real USDC directly observed
+
+Governance / control:
+
+[EOA 0x0E8c...] ----controls----> [HYPE++ Vault]
+[Vault MS 4/7] ----roles-------> [HYPE++ Trader]
+[EOA 0x7ab1...] ----roles------> [HYPE++ Trader]
+```
+
+---
+
+## Risk Summary
+
+### Key Strengths
+
+- HYPE++ share minting requires USDC deposit; no privileged unbacked share minter was found.
+- Top-level HYPE++ assets reconcile to direct USDC plus dgnHYPE shares.
+- D2 publishes architecture docs, multisig docs, contract lists, and audit links.
+- The D2 Vault MS is a 4-of-7 Safe and holds trader admin/executor roles alongside the EOA.
+
+### Key Risks
+
+- HYPE++ vault owner is an EOA with direct control over epoch scheduling, deposit caps, and whitelist settings.
+- Trader admin/executor authority includes an EOA with no timelock.
+- Funds are actively custodied by the trader during epochs; users cannot withdraw while custodied.
+- HYPE++ currently has large nested exposure to dgnHYPE, another D2 active strategy.
+- End-to-end backing is not a simple live reserve balance; it depends on D2 trader execution and return of funds.
+
+### Critical Risks
+
+- A compromised or malicious trader executor can interact with a broad allowed DeFi surface and cause trading losses before funds are returned.
+- A compromised or malicious vault owner can manipulate epoch timing and access controls, delaying exits or changing who can deposit/redeem.
+
+---
+
+## Risk Score Assessment
+
+**Scoring Guidelines:**
+- Be conservative: when uncertain between two scores, choose the higher (riskier) one.
+- Use decimals when a subcategory falls between scores.
+- Prioritize onchain evidence over documentation claims.
+
+### Critical Risk Gates
+
+- [ ] **No audit** - Protocol has not been audited by reputable firms
+- [ ] **Unverifiable reserves** - Reserves cannot be verified onchain or through transparent attestation
+- [ ] **Total centralization** - Controlled by a single EOA with no multisig or governance
+
+The total-centralization gate is not marked because the D2 Vault MS also holds trader roles. However, the EOA owner and EOA trader role-holder materially drive the high centralization score.
+
+### Category Scores
+
+#### Category 1: Audits & Historical Track Record (Weight: 20%)
+
+**Subcategory A: Audits & Security Reviews**
+
+| Score | Audit coverage | Bug bounty |
+|-------|-----------------|------------|
+| **1** | 3+ audits by top firms | Active, max payout >$1M |
+| **2** | 2+ audits by reputable firms | Max payout >$200K |
+| **3** | 1 audit by reputable firm | Bounty program present |
+| **4** | 1 audit by lesser-known firm or dated | Minimal or no bounty |
+| **5** | No audit (CRITICAL GATE) | - |
+
+**Subcategory B: Historical Track Record**
+
+| Score | Time in production | Scale (TVL) |
+|-------|-------------------|-------------|
+| **1** | >2 years | Sustained >$100M |
+| **2** | 1-2 years | >$50M |
+| **3** | 6-12 months | >$10M |
+| **4** | 3-6 months | <$10M |
+| **5** | <3 months | No meaningful TVL |
+
+**Audits & Historical Score = (2.0 + 2.5) / 2 = 2.25/5** - Multiple audits exist, and HYPE++ has more than one year of history, but scoped TVL is much lower than $50M and no public bug bounty was verified.
+
+#### Category 2: Centralization & Control Risks (Weight: 30%)
+
+**Subcategory A: Governance**
+
+| Score | Contract Upgradeability | Timelock | Privileged Roles |
+|-------|------------------------|----------|-----------------|
+| **1** | Immutable or fully decentralized DAO | 7+ days timelock on critical operations | Multisig above 3/5 threshold, no EOA roles. Multi-party approval required |
+| **2** | Multisig 7/11+ with timelock | 24+ hours | Limited roles, cannot seize funds |
+| **3** | Multisig 5/9 with timelock | 24+ hours | Some powerful roles, constrained by timelock |
+| **4** | Multisig 3/5 or low threshold | <12 hours | Powerful admin roles with limited constraints |
+| **5** | EOA or <3 signers (CRITICAL GATE) | No timelock | Unlimited admin powers |
+
+**Subcategory B: Programmability**
+
+| Score | System Operations | PPS/Rate Definition |
+|-------|------------------|---------------------|
+| **1** | Fully programmatic | Calculated onchain algorithmically |
+| **2** | Mostly programmatic with minor admin input | onchain with some parameters |
+| **3** | Hybrid onchain/offchain operations | onchain but reliant on admin updates |
+| **4** | Significant manual intervention required | Offchain accounting with periodic reporting |
+| **5** | Fully custodial/centralized operations | Admin-controlled rate, no transparency |
+
+**Subcategory C: External Dependencies**
+
+| Score | Protocol Dependencies | Criticality |
+|-------|----------------------|-------------|
+| **1** | No external dependencies | N/A |
+| **2** | 1-2 blue-chip dependencies | Non-critical |
+| **3** | 2-3 established protocol dependencies | Some critical functions depend on them |
+| **4** | Many or newer protocol dependencies | Critical functionality depends on them |
+| **5** | Single point of failure dependency | Failure breaks entire protocol |
+
+**Centralization Score = (4.5 + 4.0 + 4.0) / 3 = 4.17/5** - EOA owner and EOA trader admin/executor roles, no timelock, broad manual trading, nested D2 strategy exposure, and many allowed external venues.
+
+#### Category 3: Funds Management (Weight: 30%)
+
+**Subcategory A: Collateralization**
+
+| Score | Backing | Collateral Quality | Verifiability |
+|-------|---------|-------------------|---------------|
+| **1** | 100%+ onchain, over-collateralized | Blue-chip assets (ETH, WBTC, stablecoins) | Real-time onchain verification |
+| **2** | 100% onchain collateral | High-quality DeFi assets (LSTs, major LPs) | onchain with some complexity |
+| **3** | 100% collateral, some offchain | Mixed quality or newer protocols | Periodic custodian attestation |
+| **4** | Partially collateralized or custodial | Lower-quality or illiquid assets | Opaque or infrequent reporting |
+| **5** | Uncollateralized or unverifiable (CRITICAL GATE) | Unknown or very high-risk assets | No verification possible |
+
+**Subcategory B: Provability**
+
+| Score | Reserve Transparency | Reporting Mechanism | Third-Party Verification |
+|-------|---------------------|--------------------|-----------------------|
+| **1** | Fully onchain, anyone can verify | Programmatic, real-time | Multiple verification sources |
+| **2** | Mostly onchain, some offchain | onchain with periodic updates | Single reliable source |
+| **3** | Hybrid onchain/offchain | Manual reporting by admins | Known custodian attestation |
+| **4** | Primarily offchain | Infrequent reporting | Self-reported only |
+| **5** | Opaque, cannot verify | No reporting | No verification |
+
+**Funds Management Score = (4.0 + 4.5) / 2 = 4.25/5** - Top-level balances reconcile, but funds are custodied during active trading, `totalAssets()` is not a live full-position valuation while custodied, and nested dgnHYPE backing is only partially visible from ERC-20 balances.
+
+#### Category 4: Liquidity Risk (Weight: 15%)
+
+| Score | Exit Mechanism | Liquidity Depth | Large Holder Impact |
+|-------|---------------|----------------|---------------------|
+| **1** | Direct 1:1 redemption, instant | >$10M, <0.5% slippage | Full exit with <0.5% impact |
+| **2** | Direct redemption with minor delays | >$5M, <1% slippage | Exit with <1% impact over 1-3 days |
+| **3** | Market-based or short queues | >$1M, 1-3% slippage | 3-7 days for full exit |
+| **4** | Withdrawal queues or restrictions | <$1M, >3% slippage | >1 week or >10% impact |
+| **5** | No clear exit mechanism | No liquidity | Cannot exit without massive losses |
+
+**Score: 4.0/5** - Exit path is clear but restricted by epoch/custody state; no meaningful secondary liquidity was verified.
+
+#### Category 5: Operational Risk (Weight: 5%)
+
+| Score | Team Transparency | Documentation | Legal/Compliance |
+|-------|------------------|---------------|-----------------|
+| **1** | Fully doxxed or well-known, established reputation | Excellent, comprehensive | Clear legal structure |
+| **2** | Mostly public or known anons | Good, mostly complete | Established entity |
+| **3** | Mixed unknown and known anons | Adequate, some gaps | Uncertain structure |
+| **4** | Mostly unknown, limited info | Poor or outdated | No clear legal entity |
+| **5** | Fully unknown, no reputation | No documentation | No legal structure |
+
+**Score: 3.0/5** - Documentation and audit disclosures are adequate, but operational role-holder identity, bug bounty status, and vault-owner mismatch remain gaps.
+
+### Final Score Calculation
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 2.25 | 20% | 0.45 |
+| Centralization & Control | 4.17 | 30% | 1.25 |
+| Funds Management | 4.25 | 30% | 1.28 |
+| Liquidity Risk | 4.00 | 15% | 0.60 |
+| Operational Risk | 3.00 | 5% | 0.15 |
+| **Final Score** | | | **3.74/5.0** |
+
+### Risk Tier
+
+| Final Score | Risk Tier | Recommendation |
+|------------|-----------|----------------|
+| **1.0-1.5** | **Minimal Risk** | Approved, high confidence |
+| **1.5-2.5** | **Low Risk** | Approved with standard monitoring |
+| **2.5-3.5** | **Medium Risk** | Approved with enhanced monitoring |
+| **3.5-4.5** | **Elevated Risk** | Limited approval, strict limits |
+| **4.5-5.0** | **High Risk** | Not recommended |
+
+**Final Risk Tier: Elevated Risk**
+
+---
+
+## Reassessment Triggers
+
+- **Governance-based:** Reassess immediately if vault ownership transfers, trader roles change, Safe threshold/signers change, or a timelock is added.
+- **Epoch-based:** Reassess if funds are not returned within 72 hours after the published epoch end or if a new epoch exceeds 30 days.
+- **Funds-based:** Reassess if HYPE++ `totalAssets()` falls by more than 2% outside expected fee/PnL reporting, or if reconciliation between HYPE++ direct assets plus dgnHYPE-derived assets fails by more than 1%.
+- **Dependency-based:** Reassess if dgnHYPE strategy composition changes, if dgnHYPE experiences losses, or if Flowdesk/OTC exposure is introduced.
+- **Incident-based:** Reassess after any D2, Arbitrum, GMX, Aave, 1inch, Camelot, Circle USDC, or nested D2 strategy incident.

--- a/reports/report/d2-hypeplus.md
+++ b/reports/report/d2-hypeplus.md
@@ -38,9 +38,9 @@ The HYPE++ vault is currently in epoch 20. Onchain state verified on June 23, 20
 | Contract | Address | Type |
 |----------|---------|------|
 | HYPE++ Vault | [`0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004`](https://arbiscan.io/address/0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004) | `VaultV1Whitelisted`, ERC-4626-style vault |
-| HYPE++ Trader / OMS | [`0x8CaBD8b787e8c69C5f24091cFDA197fF570345B3`](https://arbiscan.io/address/0x8CaBD8b787e8c69C5f24091cFDA197fF570345B3) | Verified `Strategy` proxy / selector router |
-| Trader Implementation | [`0xc8071ad5560904b3b721e7e5d29742f523a69111`](https://arbiscan.io/address/0xc8071ad5560904b3b721e7e5d29742f523a69111) | Strategy implementation |
-| Vault Owner | [`0x0E8c0470773c65498F438cac380648B314399A46`](https://arbiscan.io/address/0x0E8c0470773c65498F438cac380648B314399A46) | EOA, owns HYPE++ vault |
+| HYPE++ Trader / OMS | [`0x8CaBD8b787e8c69C5f24091cFDA197fF570345B3`](https://arbiscan.io/address/0x8CaBD8b787e8c69C5f24091cFDA197fF570345B3) | Verified selector router (non-upgradeable; delegatecalls modules) |
+| Trader Module (legacy) | [`0xc8071ad5560904b3b721e7e5d29742f523a69111`](https://arbiscan.io/address/0xc8071ad5560904b3b721e7e5d29742f523a69111) | Standalone AccessControl contract; deployed earlier, not proxy-linked to trader |
+| Vault Owner | [`0x0E8c0470773c65498F438cac380648B314399A46`](https://arbiscan.io/address/0x0E8c0470773c65498F438cac380648B314399A46) | EOA, owns BOTH HYPE++ vault and dgnHYPE vault |
 | Trader Admin / Executor / Fee Receiver | [`0x7ab129978091DEE65A319c5FC728818D73221999`](https://arbiscan.io/address/0x7ab129978091DEE65A319c5FC728818D73221999) | EOA with `DEFAULT_ADMIN_ROLE` and `EXECUTOR_ROLE` on trader |
 | D2 Vault Multisig | [`0xB2fEDed045F3fd9FcCCF8E7e95729c4182916CE0`](https://arbiscan.io/address/0xB2fEDed045F3fd9FcCCF8E7e95729c4182916CE0) | Safe, 4-of-7; also trader admin/executor |
 | dgnHYPE Vault | [`0x64167cd42859F64cfF2Aa4B63c3175cceF9659dd`](https://arbiscan.io/address/0x64167cd42859F64cfF2Aa4B63c3175cceF9659dd) | Nested D2 ERC-4626 vault held by HYPE++ trader |
@@ -52,7 +52,9 @@ The HYPE++ vault is currently in epoch 20. Onchain state verified on June 23, 20
 Deployment metadata:
 
 - HYPE++ vault and trader were deployed in transaction [`0xf5642a6a...6265e`](https://arbiscan.io/tx/0xf5642a6afa068616ac286c0c26ef32f46bc43333edf79fe071ff3f60b346265e) at Arbitrum block `276124793` on November 19, 2024.
-- Trader implementation was deployed in transaction [`0xe432dabc...8675`](https://arbiscan.io/tx/0xe432dabfc9572c103e858399f29530b458fdbb882b4ab0e94245eeae553a8675) at block `218684412`.
+- The vault is NOT behind a proxy (both EIP-1967 and OpenZeppelin transparent proxy slots are zero); it is a standalone `VaultV1Whitelisted` contract. Ownership is transferable via the standard Ownable `transferOwnership()`.
+- The trader is NOT a standard proxy (EIP-1967/beacon/transparent proxy slots are zero); it is a standalone selector router that delegatecalls to pre-configured modules.
+- The contract at [`0xc8071ad5560904b3b721e7e5d29742f523a69111`](https://arbiscan.io/address/0xc8071ad5560904b3b721e7e5d29742f523a69111) was deployed earlier (block `218684412`, tx [`0xe432dabc...8675`](https://arbiscan.io/tx/0xe432dabfc9572c103e858399f29530b458fdbb882b4ab0e94245eeae553a8675)) by a different EOA (`0x00Aa367B7692be05E47B9c461fF35410208158b0`) and is not referenced in the trader's bytecode; it does not serve as a proxy implementation for the HYPE++ trader.
 
 ## Audits and Due Diligence Disclosures
 
@@ -69,7 +71,7 @@ Paladin's public page lists the September 2023 strategy audit as completed with 
 
 ### Bug Bounty
 
-No active Immunefi, Sherlock, Cantina, HackerOne, Code4rena, or Safe Harbor program was found in the D2 docs reviewed for this assessment, and targeted searches for D2 Finance on Immunefi and Safe Harbor did not return a listed program. D2 publishes audit links and security process statements, but no public bounty with payout terms was verified.
+No active Immunefi, Sherlock, Cantina, HackerOne, Code4rena, or Safe Harbor program was found in the D2 docs reviewed for this assessment. Targeted manual searches on Immunefi ("D2 Finance") and the [Safe Harbor registry](https://safeharbor.securityalliance.org/) (SEAL) returned no listed program. D2 publishes audit links and security process statements, but no public bounty with payout terms was verified onchain or through the platforms checked.
 
 ## Historical Track Record
 
@@ -98,6 +100,8 @@ Current reserve reconciliation, verified June 23, 2026:
 | dgnHYPE trader custody type | 3-of-5 Safe |
 
 The HYPE++ top-level arithmetic reconciles: direct USDC (~5.52M) plus dgnHYPE reported assets (~6.90M) equals HYPE++ `totalAssets()` (~12.42M). However, dgnHYPE itself is a nested active D2 strategy with custodied funds. Its `trader()` is a 3-of-5 Safe, and dgnHYPE uses the same custodied accounting pattern: while custodied, `totalAssets()` returns the stored `custodiedAmount` rather than live token balances. Only ~1.0M real Arbitrum USDC was found at the dgnHYPE Safe during this pass; the remaining dgnHYPE reported assets are therefore not fully verifiable from simple ERC-20 balances. Recent dgnHYPE Safe token-transfer history also includes a non-USDC token with a visually confusable symbol (`0xd13CEB6071cAe7d0A880059A022c1750E096D3ED`), which was not counted as backing.
+
+**Control concentration:** The dgnHYPE vault's `owner()` is the same EOA ([`0x0E8c0470773c65498F438cac380648B314399A46`](https://arbiscan.io/address/0x0E8c0470773c65498F438cac380648B314399A46)) that owns the HYPE++ vault, concentrating control of both vaults in a single EOA.
 
 ### Accessibility
 
@@ -131,7 +135,7 @@ HYPE++ is not overcollateralized. It is a share token over an actively managed U
 - While custodied, the vault's `totalAssets()` is the stored `custodiedAmount`, not a live mark-to-market of all current trader positions.
 - The verified source comments on `returnFunds()` state that losses may be sustained during trading and investors suffer the loss.
 - HYPE++ currently depends on dgnHYPE for ~55.6% of reported assets by value, creating recursive D2 strategy exposure.
-- The trader's allowed token list contains 32 tokens and the allowed spender list contains 30 addresses, including major Arbitrum DeFi venues and D2 strategy vaults.
+- The trader's allowed token list contains 32 tokens (including volatile assets: WETH [`0x82aF49447D8a07e3bd95BD0d56f35241523fBab1`](https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1), WBTC [`0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f`](https://arbiscan.io/address/0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f), ARB, GMX, GRAIL, PENDLE, LINK, wstETH, and old bridged USDC.e [`0xFF970A61A04b1cA14834A43f5dE4533eDBBD5CC8`](https://arbiscan.io/address/0xFF970A61A04b1cA14834A43f5dE4533eDBBD5CC8)) and the allowed spender list contains 30 addresses, including major Arbitrum DeFi venues and D2 strategy vaults.
 - dgnHYPE's `trader()` is a 3-of-5 Safe; only ~1.0M real USDC was directly observed there versus ~6.90M reported `totalAssets()`.
 
 ### Provability
@@ -156,13 +160,15 @@ No meaningful onchain DEX liquidity for HYPE++ was identified in this pass. The 
 The largest risk is centralization:
 
 - HYPE++ vault owner is an EOA, not the documented D2 Vault MS.
-- The owner EOA can call `startEpoch()`, `setMaxDeposits()`, `setWhitelistAsset()`, `setWhitelistBalance()`, and whitelist status functions.
+- The owner EOA can call `startEpoch()`, `setMaxDeposits()`, `setWhitelistAsset()`, `setWhitelistBalance()`, `transferOwnership()`, and whitelist status functions.
+- The HYPE++ vault is NOT behind a proxy (EIP-1967/beacon/transparent proxy slots verified zero). This means the vault logic cannot be upgraded, but ownership can be transferred at any time via `transferOwnership()`.
 - HYPE++ trader `DEFAULT_ADMIN_ROLE` holders are the D2 Vault MS and an EOA.
 - HYPE++ trader `EXECUTOR_ROLE` holders are the D2 Vault MS and the same EOA.
 - The EOA also receives trader fees via `feeReceiver()`.
 - The D2 Vault MS is a 4-of-7 Safe, matching D2's documented vault multisig address, but there is no onchain timelock on trader role changes or vault owner actions.
+- dgnHYPE vault has the same EOA owner as HYPE++, further concentrating control.
 
-The trader contract is a selector router that delegatecalls modules based on `msg.sig`. The constructor wires many selectors to module targets. Operationally, this gives the executor a broad DeFi action surface, bounded by the strategy's allowed tokens/spenders/modules, but still much more discretionary than a passive vault.
+The trader contract is a standalone selector router (code size ~4.2KB; EIP-1967/beacon/transparent proxy slots all zero) that delegatecalls modules based on `msg.sig`. The constructor wires selectors to module targets. The trader uses OpenZeppelin `AccessControl` (not `AccessControlEnumerable`), so `getRoleMemberCount` and `getRoleMember` are not available — role-holder enumeration requires scanning `RoleGranted`/`RoleRevoked` events. Operationally, this gives the executor a broad DeFi action surface, bounded by the strategy's allowed tokens/spenders/modules, but still much more discretionary than a passive vault.
 
 ### Programmability
 
@@ -207,16 +213,22 @@ Monitor these contracts and values:
   - Events: `EpochStarted`, `FundsCustodied`, `FundsReturned`, `NewMaxDeposits`, `NewWhitelistStatus`, `OwnershipTransferred`
 - HYPE++ trader [`0x8CaB...45B3`](https://arbiscan.io/address/0x8CaBD8b787e8c69C5f24091cFDA197fF570345B3)
   - `hasRole(DEFAULT_ADMIN_ROLE, account)` and `hasRole(EXECUTOR_ROLE, account)` for known holders
-  - Events: `RoleGranted`, `RoleRevoked`
+  - The trader uses plain `AccessControl` (not `AccessControlEnumerable`); `getRoleMemberCount` and `getRoleMember` are unavailable. Monitor `RoleGranted`/`RoleRevoked` events for role-holder enumeration.
+  - Events: `RoleGranted(bytes32,address,address)`, `RoleRevoked(bytes32,address,address)`
   - `getAllowedTokens()`, `getAllowedSpenders()`, `feeReceiver()`, `performanceFeeRate()`, `managementFeeRate()`
+  - Note: `setFeeReceiver()` is gated by `DEFAULT_ADMIN_ROLE` (verified onchain). `setPerformanceFeeRate` and `setManagementFeeRate` selectors were not found on the trader's direct interface — fee changes may route through modules.
 - Vault owner EOA [`0x0E8c...9A46`](https://arbiscan.io/address/0x0E8c0470773c65498F438cac380648B314399A46)
-  - All outbound transactions to the HYPE++ vault.
+  - All outbound transactions to HYPE++ vault, dgnHYPE vault, and any vault factory.
+  - Note: This EOA owns both HYPE++ and dgnHYPE vaults.
 - Trader role EOA [`0x7ab1...1999`](https://arbiscan.io/address/0x7ab129978091DEE65A319c5FC728818D73221999)
   - All role/admin/trading transactions.
 - D2 Vault MS [`0xB2fE...6CE0`](https://arbiscan.io/address/0xB2fEDed045F3fd9FcCCF8E7e95729c4182916CE0)
-  - Safe threshold/owner changes and trader role changes.
+  - Safe: `getThreshold()`, `getOwners()`; monitor `AddedOwner`, `RemovedOwner`, `ChangedThreshold` events.
+  - Trader role changes via this Safe.
 - dgnHYPE vault [`0x6416...59dd`](https://arbiscan.io/address/0x64167cd42859F64cfF2Aa4B63c3175cceF9659dd)
-  - `totalAssets()`, `totalSupply()`, `custodied()`, `trader()`
+  - `totalAssets()`, `totalSupply()`, `custodied()`, `trader()`, `owner()`
+- dgnHYPE Safe [`0x155d...66fb`](https://arbiscan.io/address/0x155d0B27B754ebC664aeD565945C1AaEa91966fb)
+  - `getThreshold()`, `getOwners()`; monitor threshold/owner changes and direct USDC balance against reported `custodiedAmount`.
 
 Suggested alert thresholds:
 
@@ -233,34 +245,43 @@ Suggested alert thresholds:
 User USDC
    |
    v
-[HYPE++ Vault / VaultV1Whitelisted]
+[HYPE++ Vault / VaultV1Whitelisted]  (non-upgradeable, no proxy)
    - ERC-4626 share token
-   - owner: EOA 0x0E8c...
+   - owner: EOA 0x0E8c... (Ownable, transferOwnership available)
    - deposits only during funding window
    - withdrawals only after epoch and when not custodied
+   - trader is immutable (set at construction, no setTrader function)
    |
-   | custodyFunds() during epoch
+   | custodyFunds() during epoch (only trader can call)
    v
-[HYPE++ Trader / Strategy OMS]
+[HYPE++ Trader / Strategy OMS]  (selector router, not a proxy, ~4.2KB)
+   - delegatecalls modules by msg.sig; AccessControl (not Enumerable)
    - DEFAULT_ADMIN_ROLE: Vault MS + EOA 0x7ab1...
    - EXECUTOR_ROLE: Vault MS + EOA 0x7ab1...
-   - fee receiver: EOA 0x7ab1...
+   - fee receiver: EOA 0x7ab1... (performanceFeeRate = 20%)
    - allowed tokens/spenders define trading surface
    |
    +--> Direct USDC balance (~5.52M)
    |
-   +--> [dgnHYPE Vault shares] (~5.27M shares)
+   +--> [dgnHYPE Vault shares] (~5.27M shares = 100% of supply)
           |
           v
-        [dgnHYPE Trader / nested D2 strategy]
-          - reports ~6.90M USDC totalAssets
-          - 3-of-5 custody Safe; ~1.0M real USDC directly observed
+        [dgnHYPE Vault / VaultV1Whitelisted]  (non-upgradeable, no proxy)
+          - owner: EOA 0x0E8c... (same EOA as HYPE++ vault owner)
+          - trader: 3-of-5 Safe 0x155d...
+          |
+          v
+        [dgnHYPE Trader / 3-of-5 Safe]
+          - reports ~6.90M USDC totalAssets (custodiedAmount)
+          - ~1.0M real USDC directly observed; remainder in active positions
 
 Governance / control:
 
-[EOA 0x0E8c...] ----controls----> [HYPE++ Vault]
-[Vault MS 4/7] ----roles-------> [HYPE++ Trader]
-[EOA 0x7ab1...] ----roles------> [HYPE++ Trader]
+[EOA 0x0E8c...] --owns--> [HYPE++ Vault]
+[EOA 0x0E8c...] --owns--> [dgnHYPE Vault]
+[Vault MS 4/7]  --DEFAULT_ADMIN+EXECUTOR--> [HYPE++ Trader]
+[EOA 0x7ab1...] --DEFAULT_ADMIN+EXECUTOR--> [HYPE++ Trader]
+[EOA 0x7ab1...] <--feeReceiver-- [HYPE++ Trader]
 ```
 
 ---
@@ -271,21 +292,23 @@ Governance / control:
 
 - HYPE++ share minting requires USDC deposit; no privileged unbacked share minter was found.
 - Top-level HYPE++ assets reconcile to direct USDC plus dgnHYPE shares.
+- The vault is not upgradeable (no proxy); the trader is a non-proxy selector router — no hidden upgrade path was found.
 - D2 publishes architecture docs, multisig docs, contract lists, and audit links.
 - The D2 Vault MS is a 4-of-7 Safe and holds trader admin/executor roles alongside the EOA.
 
 ### Key Risks
 
-- HYPE++ vault owner is an EOA with direct control over epoch scheduling, deposit caps, and whitelist settings.
+- HYPE++ vault owner is an EOA with direct control over epoch scheduling, deposit caps, and whitelist settings. The same EOA also owns the dgnHYPE vault.
 - Trader admin/executor authority includes an EOA with no timelock.
+- The trader's allowed token list includes volatile assets (WETH, WBTC, ARB, GMX, GRAIL, PENDLE, LINK, wstETH) and old bridged USDC.e, expanding the strategy risk surface.
 - Funds are actively custodied by the trader during epochs; users cannot withdraw while custodied.
-- HYPE++ currently has large nested exposure to dgnHYPE, another D2 active strategy.
+- HYPE++ currently has large nested exposure to dgnHYPE (~55.6% of assets), another D2 active strategy controlled by the same EOA owner.
 - End-to-end backing is not a simple live reserve balance; it depends on D2 trader execution and return of funds.
 
 ### Critical Risks
 
-- A compromised or malicious trader executor can interact with a broad allowed DeFi surface and cause trading losses before funds are returned.
-- A compromised or malicious vault owner can manipulate epoch timing and access controls, delaying exits or changing who can deposit/redeem.
+- A compromised or malicious trader executor can interact with a broad allowed DeFi surface (32 tokens, 30 spenders) and cause trading losses before funds are returned.
+- A compromised or malicious vault owner can manipulate epoch timing, transfer ownership, and change access controls for BOTH vaults, delaying exits or changing who can deposit/redeem.
 
 ---
 

--- a/reports/report/d2-hypeplus.md
+++ b/reports/report/d2-hypeplus.md
@@ -1,6 +1,7 @@
 # Protocol Risk Assessment: D2 Finance HYPE++
 
 - **Assessment Date:** June 24, 2026
+- **Investigation Update:** August 10, 2026
 - **Token:** HYPE++
 - **Chain:** Arbitrum
 - **Token Address:** [`0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004`](https://arbiscan.io/address/0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004)
@@ -19,6 +20,8 @@ The HYPE++ vault is currently in epoch 20. Onchain state verified on June 23, 20
 - `totalAssets() = 12,417,628.982186 USDC`; `totalSupply() = 8,379,842.251215 HYPE++`.
 - HYPE++ trader holds ~5.52M USDC directly and all outstanding dgnHYPE shares; dgnHYPE reports ~6.90M USDC `totalAssets()`. This reconciles to HYPE++ `totalAssets()`, but deeper dgnHYPE positions remain a nested D2 strategy dependency.
 
+**August 10, 2026 tracing update:** The previously unresolved dgnHYPE balance gap was traced further. The dgnHYPE custody Safe sends substantial USDC to two operational EOAs, which then route funds into Hyperliquid through the verified `Bridge2` contract and Circle's HyperCore CCTP extension. This makes the trading destination clearer, but introduces an EOA custody hop between the 3-of-5 Safe and Hyperliquid; see Funds Management.
+
 **Links:**
 
 - [Protocol Documentation](https://gitbook.d2.finance/)
@@ -32,6 +35,8 @@ The HYPE++ vault is currently in epoch 20. Onchain state verified on June 23, 20
 - [Cyfrin D2 v2.1 Audit PDF](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-02-24-cyfrin-d2-v2.1.pdf)
 - [Cyfrin D2 HYPE CoreWriter v2.0 Audit PDF](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-10-16-cyfrin-d2-hype-corewriter-v2.0.pdf)
 - [Arbitrum L2BEAT Risk Page](https://l2beat.com/scaling/projects/arbitrum)
+- [Hyperliquid Bridge2 on Arbitrum](https://arbiscan.io/address/0x2Df1c51E09aECF9cacB7bc98cB1742757f163dF7)
+- [Circle HyperCore CCTP Contract Addresses](https://developers.circle.com/cctp/references/hypercore-contract-addresses)
 
 ## Contract Addresses
 
@@ -45,6 +50,10 @@ The HYPE++ vault is currently in epoch 20. Onchain state verified on June 23, 20
 | D2 Vault Multisig | [`0xB2fEDed045F3fd9FcCCF8E7e95729c4182916CE0`](https://arbiscan.io/address/0xB2fEDed045F3fd9FcCCF8E7e95729c4182916CE0) | Safe, 4-of-7; also trader admin/executor |
 | dgnHYPE Vault | [`0x64167cd42859F64cfF2Aa4B63c3175cceF9659dd`](https://arbiscan.io/address/0x64167cd42859F64cfF2Aa4B63c3175cceF9659dd) | Nested D2 ERC-4626 vault held by HYPE++ trader |
 | dgnHYPE Trader / Custody Safe | [`0x155d0B27B754ebC664aeD565945C1AaEa91966fb`](https://arbiscan.io/address/0x155d0B27B754ebC664aeD565945C1AaEa91966fb) | Nested D2 custody Safe, 3-of-5 |
+| Hyperliquid Operational EOA 1 | [`0x0C684f333A7e120bce61383DA670bbB0157e82d0`](https://arbiscan.io/address/0x0C684f333A7e120bce61383DA670bbB0157e82d0) | EOA receiving USDC from the dgnHYPE Safe before depositing into Hyperliquid Bridge2 |
+| Hyperliquid Operational EOA 2 | [`0x11A691612BD108e57cC04ea42B006C9CB1ff006A`](https://arbiscan.io/address/0x11A691612BD108e57cC04ea42B006C9CB1ff006A) | EOA receiving USDC from the dgnHYPE Safe; routes through Bridge2 and Circle HyperCore CCTP |
+| Hyperliquid Bridge2 | [`0x2Df1c51E09aECF9cacB7bc98cB1742757f163dF7`](https://arbiscan.io/address/0x2Df1c51E09aECF9cacB7bc98cB1742757f163dF7) | Verified Hyperliquid Arbitrum bridge contract; not an EOA |
+| Circle HyperCore CCTP Extension | [`0xA95d9c1F655341597C94393fDdc30cf3c08E4fcE`](https://arbiscan.io/address/0xA95d9c1F655341597C94393fDdc30cf3c08E4fcE) | Circle-documented Arbitrum contract for USDC transfers to HyperCore |
 | USDC | [`0xaf88d065e77c8cC2239327C5EDb3A432268e5831`](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831) | Underlying asset |
 | Vault Factory | [`0xb5B272EF918835651375f84D463b1Ba7B61eF028`](https://arbiscan.io/address/0xb5B272EF918835651375f84D463b1Ba7B61eF028) | Deployed HYPE++ vault |
 | Strategy Factory | [`0x2AA01FdE174aB160b4e4F49F152C20d6Ec029d67`](https://arbiscan.io/address/0x2AA01FdE174aB160b4e4F49F152C20d6Ec029d67) | Deployed HYPE++ trader |
@@ -101,6 +110,16 @@ Current reserve reconciliation, verified June 23, 2026:
 
 The HYPE++ top-level arithmetic reconciles: direct USDC (~5.52M) plus dgnHYPE reported assets (~6.90M) equals HYPE++ `totalAssets()` (~12.42M). However, dgnHYPE itself is a nested active D2 strategy with custodied funds. Its `trader()` is a 3-of-5 Safe, and dgnHYPE uses the same custodied accounting pattern: while custodied, `totalAssets()` returns the stored `custodiedAmount` rather than live token balances. Only ~1.0M real Arbitrum USDC was found at the dgnHYPE Safe during this pass; the remaining dgnHYPE reported assets are therefore not fully verifiable from simple ERC-20 balances. Recent dgnHYPE Safe token-transfer history also includes a non-USDC token with a visually confusable symbol (`0xd13CEB6071cAe7d0A880059A022c1750E096D3ED`), which was not counted as backing.
 
+### Post-assessment Hyperliquid trace (August 10, 2026)
+
+The later epoch provides a clearer end-to-end route for the dgnHYPE capital:
+
+- On July 27, 2026, the dgnHYPE vault transferred **7,500,500.905511 USDC** to its 3-of-5 custody Safe ([transaction](https://arbiscan.io/tx/0x97cb497f929e953743bed88489168d1d185e7f4070ca8d88781b06b514f21a0b)).
+- The Safe subsequently transferred exactly **5.0M USDC** in several transactions to EOA [`0x0C684f...82d0`](https://arbiscan.io/address/0x0C684f333A7e120bce61383DA670bbB0157e82d0), including this representative [900,000 USDC Safe transaction](https://arbiscan.io/tx/0x6d3e7171405c82605f894baa6587af9ce5a542313438f0fc3b5dab886ac4107c). The EOA then deposited the same 5.0M USDC into the verified Hyperliquid `Bridge2` contract in corresponding tranches, including this [900,000 USDC bridge deposit](https://arbiscan.io/tx/0x1c8ac299aba7018fcea3a5ba7dd090d12df0c6b50647af19d4ec4db271437e6d).
+- On August 1, 2026, the Safe transferred exactly **400,000 USDC** in five transactions to a second EOA, [`0x11A691...006A`](https://arbiscan.io/address/0x11A691612BD108e57cC04ea42B006C9CB1ff006A), including this [150,000 USDC Safe transaction](https://arbiscan.io/tx/0x939b4ce096204c516c9e25e6b626bf06edfc7ff0a0a534622cc2e3c8487de7ed). That EOA used both Hyperliquid `Bridge2` ([example deposit](https://arbiscan.io/tx/0xbf2a7e1a935c7888411137e3a485d61112460628d7c8257d7f0d641b22b1e217)) and Circle's documented HyperCore CCTP extension ([30,000 USDC transaction](https://arbiscan.io/tx/0xa16131d106d5b550a2db239b77dd1b5743dab406b6498ddcad4258c9efa8316d)).
+- Both intermediate addresses are EOAs (`is_contract = false`). The actual Hyperliquid `Bridge2` destination is a verified contract, not an EOA. The material trust issue is therefore the **Safe -> EOA -> bridge** path: once the Safe releases funds, its 3-of-5 approval protection no longer governs the assets held or operated by either EOA. Loss or compromise of an operational key could affect funds before bridging and the Hyperliquid account controlled by that key.
+- This trace identifies a major deployment destination and corroborates active Hyperliquid trading. It does not provide complete live NAV or a full strategy exposure map because positions may span multiple Hyperliquid accounts, spot and derivatives, other venues, and offchain counterparties.
+
 **Control concentration:** The dgnHYPE vault's `owner()` is the same EOA ([`0x0E8c0470773c65498F438cac380648B314399A46`](https://arbiscan.io/address/0x0E8c0470773c65498F438cac380648B314399A46)) that owns the HYPE++ vault, concentrating control of both vaults in a single EOA. dgnHYPE is a different contract — its verified source is `VaultV0` (distinct bytecode/codehash from the HYPE++ `VaultV1Whitelisted` vault), and its `whitelistBalance()`/`whitelistAsset()` do not exist (they revert). Its `withdraw`/`redeem` are still gated by `onlyWhitelisted`, but VaultV0's modifier is a pure `require(whitelisted[msg.sender])` with no holder-balance branch. So the **blacklist path applies to dgnHYPE** (the owner can remove its sole holder, the HYPE++ trader), but the `setWhitelistBalance(uint256.max)` balance-gate path does **not** exist there. The HYPE++ trader holds 100% of dgnHYPE supply, so blocking dgnHYPE redemptions would trap ~55.6% of HYPE++ assets (~$6.90M) inside the nested strategy.
 
 ### Accessibility
@@ -138,6 +157,7 @@ HYPE++ is not overcollateralized. It is a share token over an actively managed U
 - HYPE++ currently depends on dgnHYPE for ~55.6% of reported assets by value, creating recursive D2 strategy exposure.
 - The trader's allowed token list contains 32 tokens (including volatile assets: WETH [`0x82aF49447D8a07e3bd95BD0d56f35241523fBab1`](https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1), WBTC [`0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f`](https://arbiscan.io/address/0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f), ARB, GMX, GRAIL, PENDLE, LINK, wstETH, and old bridged USDC.e [`0xFF970A61A04b1cA14834A43f5dE4533eDBBD5CC8`](https://arbiscan.io/address/0xFF970A61A04b1cA14834A43f5dE4533eDBBD5CC8)) and the allowed spender list contains 30 addresses, including major Arbitrum DeFi venues and D2 strategy vaults.
 - dgnHYPE's `trader()` is a 3-of-5 Safe; only ~1.0M real USDC was directly observed there versus ~6.90M reported `totalAssets()`. **The Safe is a standard Gnosis Safe with no on-chain guardrails** — 3-of-5 signers can call `execTransaction` to send assets to any address. Unlike the HYPE++ trader OMS (constrained to 32 pre-approved tokens and 30 venues), the dgnHYPE Safe has unrestricted custody over 55.6% of HYPE++ assets.
+- The August follow-up trace shows that this unrestricted Safe custody is followed by an additional EOA layer: 5.0M USDC and 400,000 USDC were routed to two operational EOAs before Hyperliquid/HyperCore entry. The tracing reduces uncertainty about where a large portion of the balance went, but it does not restore multisig protection after the Safe-to-EOA transfers.
 
 ### Provability
 
@@ -146,6 +166,7 @@ Top-level HYPE++ accounting is partially provable:
 - `totalAssets()`, `custodiedAmount()`, direct USDC balances, dgnHYPE balances, and dgnHYPE `totalAssets()` are onchain.
 - HYPE++ does not need an offchain price oracle for the top-level USDC + dgnHYPE share accounting observed in this pass.
 - End-to-end position risk is not fully transparent from a single call because nested dgnHYPE is itself custodied by a Safe and reports stored custodied accounting while active.
+- Arbitrum transfers now expose the path from dgnHYPE to its Safe, onward through operational EOAs, and into Hyperliquid Bridge2/Circle CCTP. Live position valuation and complete cross-venue reconciliation remain outside the ERC-4626 accounting path.
 - D2 docs state positions are generally onchain-verifiable but disclose exceptions for Flowdesk OTC trades and partial verifiability of Flowdesk collateral. No Flowdesk exposure was proven for HYPE++ in this pass, but the disclosure is relevant to D2's strategy model.
 
 ## Liquidity Risk
@@ -193,6 +214,8 @@ Dependencies include:
 - Arbitrum One as the execution chain. L2BEAT lists Arbitrum One as a Stage 1 optimistic rollup and notes upgrade/security-council and sequencer-related trust assumptions.
 - Circle/Arbitrum USDC as the base asset.
 - D2's nested dgnHYPE strategy.
+- Hyperliquid/HyperCore for spot and derivatives execution, reached from the dgnHYPE Safe through two operational EOAs and then Hyperliquid Bridge2 or Circle CCTP.
+- Circle CCTP as an additional USDC route from Arbitrum to HyperCore.
 - Broad Arbitrum DeFi venues approved in the trader's allowed spender list, including Aave, 1inch, GMX/Camelot-style modules, and D2 strategy contracts.
 - Offchain operator process for strategy decisions.
 
@@ -206,6 +229,7 @@ Operational gaps remain:
 - The EOA with trader admin/executor/fee-receiver roles is not identified in the docs reviewed.
 - No public bug bounty with payout terms was found.
 - Nested dgnHYPE backing is only partially transparent from ERC-20 balances: the dgnHYPE Safe directly held ~1.0M real USDC against ~6.90M reported `totalAssets()`.
+- Subsequent tracing identifies Hyperliquid as a major destination, but operational EOAs sit between the dgnHYPE Safe and the bridge. No public documentation reviewed identifies those EOAs, their key-management policy, recovery process, or whether institutional custody controls protect them.
 
 ## Monitoring
 
@@ -234,6 +258,10 @@ Monitor these contracts and values:
   - `totalAssets()`, `totalSupply()`, `custodied()`, `trader()`, `owner()`
 - dgnHYPE Safe [`0x155d...66fb`](https://arbiscan.io/address/0x155d0B27B754ebC664aeD565945C1AaEa91966fb)
   - `getThreshold()`, `getOwners()`; monitor threshold/owner changes and direct USDC balance against reported `custodiedAmount`.
+- Hyperliquid operational EOAs [`0x0C68...82d0`](https://arbiscan.io/address/0x0C684f333A7e120bce61383DA670bbB0157e82d0) and [`0x11A6...006A`](https://arbiscan.io/address/0x11A691612BD108e57cC04ea42B006C9CB1ff006A)
+  - Monitor every inbound transfer from the dgnHYPE Safe, subsequent Bridge2/CCTP deposits, unexpected destinations, and whether funds return before epoch settlement.
+- Hyperliquid [`Bridge2`](https://arbiscan.io/address/0x2Df1c51E09aECF9cacB7bc98cB1742757f163dF7) and Circle [`HyperCore CCTP extension`](https://arbiscan.io/address/0xA95d9c1F655341597C94393fDdc30cf3c08E4fcE)
+  - Monitor deposits attributable to the operational EOAs and bridge/validator/CCTP incidents.
 
 Suggested alert thresholds:
 
@@ -244,6 +272,7 @@ Suggested alert thresholds:
 - Any new epoch with an end timestamp materially longer than 30 days.
 - Any mismatch where direct HYPE++ trader assets plus dgnHYPE-derived assets fail to reconcile to HYPE++ `totalAssets()` by more than 1%.
 - Any dgnHYPE `totalAssets()` drop greater than 2% between checks.
+- Any dgnHYPE Safe transfer to a new EOA or any operational-EOA transfer to a destination other than the identified Hyperliquid/CCTP routes.
 
 ## Appendix: Contract Architecture
 
@@ -279,7 +308,14 @@ User USDC
           v
         [dgnHYPE Trader / 3-of-5 Safe]
           - reports ~6.90M USDC totalAssets (custodiedAmount)
-          - ~1.0M real USDC directly observed; remainder in active positions
+          - unrestricted Safe execution
+          |
+          +--> [Operational EOA 0x0C68...] --USDC--> [Hyperliquid Bridge2]
+          |
+          +--> [Operational EOA 0x11A6...] --USDC--> [Hyperliquid Bridge2 / Circle CCTP]
+                                                     |
+                                                     v
+                                               [HyperCore trading accounts]
 
 Governance / control:
 
@@ -309,6 +345,7 @@ Governance / control:
 - The trader's allowed token list includes volatile assets (WETH, WBTC, ARB, GMX, GRAIL, PENDLE, LINK, wstETH) and old bridged USDC.e, expanding the strategy risk surface.
 - Funds are actively custodied by the trader during epochs; users cannot withdraw while custodied.
 - HYPE++ currently has large nested exposure to dgnHYPE (~55.6% of assets), another D2 active strategy controlled by the same EOA owner. The dgnHYPE custody Safe has no on-chain guardrails (standard Gnosis Safe, not a constrained OMS) — a separate trust surface for the majority of HYPE++ capital.
+- dgnHYPE capital is routed from its 3-of-5 Safe through operational EOAs before entering Hyperliquid/HyperCore. This creates single-key custody and execution exposure after the multisig-approved transfer, even though the final Hyperliquid Bridge2 destination is a verified contract.
 - End-to-end backing is not a simple live reserve balance; it depends on D2 trader execution and return of funds.
 
 ### Critical Risks
@@ -318,7 +355,7 @@ Governance / control:
   2. **Balance gate:** `setWhitelistBalance(type(uint256).max)` — no user can satisfy `whitelistAsset.balanceOf(user) > uint256.max`, so the holder branch can never pass and every non-whitelisted `withdraw()` and `redeem()` reverts. One transaction, no enumeration needed, blocks every shareholder indiscriminately. This is the reliable single-transaction block on HYPE++.
   Both paths work because the `onlyWhitelisted()` modifier gates `withdraw()` and `redeem()` — not just `deposit()` and `mint()` — verified against the verified `VaultV1Whitelisted` source on June 24, 2026. There is no onchain bypass. The blacklist path also applies to dgnHYPE, a separate `VaultV0` contract (distinct bytecode; `whitelistBalance`/`whitelistAsset` do not exist there), where the HYPE++ trader is the sole dgnHYPE holder — blacklisting it traps $6.90M (55.6% of HYPE++ assets). The vault holds zero USDC while custodied, so the trader must return funds before blocked users could even attempt an exit, but even after `returnFunds()` the gated `withdraw`/`redeem` would revert. Combined with `transferOwnership()`, a hacked EOA can transfer this power to a new attacker address, making the block permanent.
 - A compromised or malicious trader executor can interact with a broad allowed DeFi surface (32 tokens, 30 spenders) and cause trading losses before funds are returned.
-- **The dgnHYPE Safe (3-of-5) can steal $6.90M with no guardrails.** Unlike the HYPE++ trader OMS, which is constrained to pre-approved tokens and venues, the dgnHYPE custody Safe is a standard Gnosis Safe. 3-of-5 signers can call `execTransaction` to execute `USDC.transfer(attacker, amount)` — or any other arbitrary call — with no on-chain restriction. The Safe currently holds $1.00M in direct USDC and controls deployed positions worth ~$5.90M. Neither the dgnHYPE vault, the HYPE++ vault, nor the HYPE++ trader has any mechanism to constrain or override the Safe signers. This is a fundamentally different custody model from the HYPE++ OMS: restricted smart-contract execution vs unrestricted multisig custody. The Safe signers (5 addresses distinct from the HYPE++ trader roles) represent a separate trust surface for 55.6% of HYPE++ assets.
+- **The dgnHYPE Safe (3-of-5) and its downstream operational EOAs form an unrestricted custody path for $6.90M.** Unlike the HYPE++ trader OMS, which is constrained to pre-approved tokens and venues, the dgnHYPE custody Safe is a standard Gnosis Safe. 3-of-5 signers can call `execTransaction` to execute `USDC.transfer(attacker, amount)` — or any other arbitrary call — with no on-chain restriction. The later trace confirms this authority is used to send millions of USDC to EOAs before Hyperliquid bridging. Once transferred, the Safe's threshold no longer protects those funds; control follows the relevant EOA/Hyperliquid account key. Neither the dgnHYPE vault, the HYPE++ vault, nor the HYPE++ trader has a mechanism to constrain or override the Safe signers or the downstream EOA keys. This is a fundamentally different custody model from the HYPE++ OMS: restricted smart-contract execution versus unrestricted multisig custody followed by single-address operation.
 - A compromised or malicious vault owner can manipulate epoch timing, transfer ownership, and change access controls for BOTH vaults, delaying exits or changing who can deposit/redeem.
 
 ---
@@ -420,7 +457,7 @@ The total-centralization gate is not marked because the D2 Vault MS also holds t
 | **4** | Primarily offchain | Infrequent reporting | Self-reported only |
 | **5** | Opaque, cannot verify | No reporting | No verification |
 
-**Funds Management Score = (4.5 + 4.5) / 2 = 4.50/5** - Collateralization raised to 4.5: dgnHYPE Safe (55.6% of assets) is a standard Gnosis Safe with unrestricted custody — signers can transfer funds to any address with no on-chain guardrails. Top-level balances reconcile, but `totalAssets()` is not a live full-position valuation while custodied, and nested dgnHYPE backing is only partially visible from ERC-20 balances.
+**Funds Management Score = (4.5 + 4.5) / 2 = 4.50/5** - Collateralization remains 4.5: dgnHYPE Safe (55.6% of assets) is a standard Gnosis Safe with unrestricted custody, and observed operations route millions through EOAs before Hyperliquid/HyperCore entry. Top-level balances reconcile, but `totalAssets()` is not a live full-position valuation while custodied; tracing identifies a major venue without making complete cross-venue NAV independently provable.
 
 #### Category 4: Liquidity Risk (Weight: 15%)
 
@@ -476,5 +513,5 @@ The total-centralization gate is not marked because the D2 Vault MS also holds t
 - **Governance-based:** Reassess immediately if vault ownership transfers, trader roles change, Safe threshold/signers change, or a timelock is added.
 - **Epoch-based:** Reassess if funds are not returned within 72 hours after the published epoch end or if a new epoch exceeds 30 days.
 - **Funds-based:** Reassess if HYPE++ `totalAssets()` falls by more than 2% outside expected fee/PnL reporting, or if reconciliation between HYPE++ direct assets plus dgnHYPE-derived assets fails by more than 1%.
-- **Dependency-based:** Reassess if dgnHYPE strategy composition changes, if dgnHYPE experiences losses, or if Flowdesk/OTC exposure is introduced.
+- **Dependency-based:** Reassess if dgnHYPE strategy composition changes, if dgnHYPE experiences losses, if either Hyperliquid operational EOA changes, if funds route to a new bridge/custodian, or if Flowdesk/OTC exposure is introduced.
 - **Incident-based:** Reassess after any D2, Arbitrum, GMX, Aave, 1inch, Camelot, Circle USDC, or nested D2 strategy incident.

--- a/src/data/stats.json
+++ b/src/data/stats.json
@@ -1,3 +1,3 @@
 {
-  "reportCount": 37
+  "reportCount": 39
 }


### PR DESCRIPTION
## Summary
- Adds the D2 Finance HYPE++ risk assessment for Arbitrum strategy vault 0x75288264FDFEA8ce68e6D852696aB1cE2f3E5004.
- Adds the matching dependency graph at reports/graph/d2-hypeplus.yaml.
- Updates generated report count via npm run build.

## Source notes
- Loaded report workflow instructions from reports/skill.md and .pi/prompts/report.md.
- Verified D2 docs, audit pages, Arbiscan source/ABI, role logs, Safe threshold, and current vault/trader balances.
- Key finding: HYPE++ top-level accounting reconciles through direct USDC plus nested dgnHYPE, but vault owner and trader role-holder EOAs create elevated centralization risk.

close #267 