### PR TITLE
Reassess Royco srRoyUSDC

### DIFF
--- a/reports/graph/royco-srroyusdc.yaml
+++ b/reports/graph/royco-srroyusdc.yaml
@@ -15,136 +15,178 @@ categories:
     label: External Dependency
 
 nodes:
-  # === Vault / token layer ===
   - id: srroyusdc
-    label: srRoyUSDC (Senior Vault)
+    label: srRoyUSDC Senior Vault
     address: "0xcD9f5907F92818bC06c9Ad70217f089E190d2a32"
     category: vault
-    note: ERC-4626 / ERC-7540 async vault; ERC-1967 proxy
+    note: ERC-4626 / ERC-7540 async vault; ERC-1967 proxy; ~12.93M USDC totalAssets
   - id: vault-impl
-    label: ConcreteAsyncVaultImpl
+    label: ConcreteAsyncVault implementation
     address: "0x1b5cd91e61505d431d2a61192a1006146bd9bb28"
     category: vault
-
-  # === Governance ===
-  - id: owner-safe
-    label: Owner Safe (3-of-5)
-    address: "0x85de42e5697d16b853ea24259c42290dace35190"
-    category: governance
-    note: Vault owner; ADMIN_UPGRADER on RoycoFactory; owns MultisigStrategy ProxyAdmin
   - id: vault-mgr
     label: VAULT_MANAGER Safe (3-of-4)
     address: "0x7c405bbD131e42af506d14e752f2e59B19D49997"
     category: governance
-    note: Fee / queue management
-  - id: treasury-safe
-    label: Treasury Safe (3-of-5, same signers as Owner)
-    address: "0x170ff06326eBb64BF609a848Fc143143994AF6c8"
-    category: governance
-    note: Holds Senior Tranche tokens; calls adjustTotalAssets
+    note: Current vault owner; RoycoFactory AccessManager role holder
   - id: concrete-factory-owner
-    label: ConcreteFactory Owner (Concrete team 3-of-5)
+    label: ConcreteFactory Owner Safe (3-of-5)
     address: "0xdc29BD10CB9000dffBb5aAcD30606c66f07c866C"
     category: governance
-    note: Approves vault implementation upgrades
-
-  # === Protocol infra ===
-  - id: multisig-strategy
-    label: MultisigStrategy (full-custody handoff)
-    address: "0xd3F8Edff57570c4F9B11CC95eA65117e2D7A6C2D"
-    category: infra
-    note: Forwards USDC to Treasury Safe; adjustTotalAssets admin-reported
-  - id: makina-strategy
-    label: RoycoVaultMakinaStrategy (secondary, ~1K USDC)
-    address: "0xc5FeF644d59415cec65049e0653CA10eD9Cba778"
-    category: infra
+  - id: legacy-owner-safe
+    label: Legacy Owner Safe (3-of-4)
+    address: "0x85de42e5697d16b853ea24259c42290dace35190"
+    category: governance
+    note: No longer vault owner; still relevant through legacy MultisigStrategy ProxyAdmin path
+  - id: treasury-safe
+    label: Treasury Safe (3-of-5, legacy)
+    address: "0x170ff06326eBb64BF609a848Fc143143994AF6c8"
+    category: governance
+    note: Old Dawn Senior Tranche custody path; checked Ethereum balances are currently zero
+  - id: makina-security-council
+    label: Makina Security Council Safe (2-of-4)
+    address: "0x89faa3b02EF5aB185b8ACE489Af62748ACB50Afc"
+    category: governance
+    note: Accounting authorized / accounting agent on Makina machine
+  - id: makina-operator
+    label: Makina Operator / Mechanic EOA
+    address: "0x425BbC2cfF0c7E7960baA9BaC2f0Cb67B41d3beF"
+    category: governance
+    note: Operator, mechanic, accounting agent, and accounting authorized
   - id: concrete-factory
-    label: ConcreteFactory (Vault Proxy Admin)
+    label: ConcreteFactory proxy admin
     address: "0x0265d73a8e61f698d8eb0dfeb91ddce55516844c"
     category: infra
-  - id: royco-factory
-    label: RoycoFactory (AccessManager, 5d setback)
+  - id: royco-access-manager
+    label: RoycoFactory AccessManager
     address: "0xD567cCbb336Eb71eC2537057E2bCF6DB840bB71d"
     category: infra
+    note: AccessManager for Royco roles; upgrader/kernel/accountant admin roles delayed 2 days
   - id: royco-factory-proxy
-    label: RoycoFactory Proxy (Dawn Market Factory)
+    label: RoycoFactory Proxy / Strategy Authority
     address: "0x7cC6fB28eC7b5e7afC3cB3986141797ffc27253C"
     category: infra
-  - id: adaptive-ydm
-    label: AdaptiveCurveYDM (immutable)
-    address: "0x071B0FA065774b403B8dae0aE93A09Df5DE3DFAc"
+    note: RoycoFactory proxy; authority() on the Makina strategy
+  - id: makina-authority
+    label: Makina Machine Authority
+    address: "0x0fCEfa3f1047F35521A49cD8B06faBd588665d7F"
     category: infra
-    note: Yield distribution model; no admin
-
-  # === Strategy: Dawn markets (Senior Tranche tokens held by Treasury) ===
-  - id: st-snusd
-    label: ROY-ST-sNUSD (Senior)
-    address: "0x2070Af1C865f5d764F673Baf5654822947e71243"
-    category: strategy
-    note: Neutrl sNUSD market; PERPETUAL (fixedTermDuration=0)
-  - id: st-snusd-legacy
-    label: ROY-ST-sNUSD legacy (Senior)
-    address: "0x3b2df77f0eaa0ca98aaabffa96b03eaf08ec6c8e"
-    category: strategy
-  - id: st-autousd
-    label: ROY-ST-autoUSD (Senior)
-    address: "0x73C641fe41EB0270C7f473f3c3E4A40eb97fd8dE"
-    category: strategy
-    note: 2-day Fixed-Term protection
-  - id: st-savusd
-    label: ROY-ST-savUSD (Senior, Avalanche)
-    category: strategy
-    note: Avalanche chain; address 0xDA7bf1788aecb94fE6D5D3f739358De94f43E5C9
-  - id: kernel-snusd
-    label: Neutrl sNUSD Kernel
-    address: "0x0aE0978B868804929fd4C06B3B22D9197B8cd3c6"
+  - id: makina-strategy
+    label: RoycoVaultMakinaStrategy
+    address: "0xc5FeF644d59415cec65049e0653CA10eD9Cba778"
     category: infra
-  - id: kernel-autousd
-    label: Tokemak autoUSD Kernel
-    address: "0x8748D1c21CC550B435487F473d9Aaf6C84dA46A6"
+    note: Active allocation path; totalAllocatedValue ~12.93M USDC; maxWithdraw ~435.5 USDC
+  - id: makina-machine
+    label: Makina Machine BeaconProxy
+    address: "0xFa097420f0e2C72456B361a1eD85172B9ccd8c38"
     category: infra
-  - id: aave-position
-    label: Aave aUSDC position
-    address: "0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c"
-    category: strategy
-    note: ~$2.1M liquidity reserve
-
-  # === External dependencies (underlying yield protocols) ===
-  - id: dep-neutrl
-    label: Neutrl sNUSD
+    note: lastTotalAum ~12.93M USDC; restrictedAccountingMode true
+  - id: makina-machine-beacon
+    label: Makina Machine Beacon
+    address: "0x5c680ec39bafe8524f3c2fa9d5f6d65f09bd7333"
+    category: infra
+    note: Current implementation 0xb655ad796634562136B593397b8b4849F332213f
+  - id: makina-share-token
+    label: Makina Machine Share Token
+    address: "0x1004D230aCA4b781d0049AFD6D0b1ee8ed3A6787"
+    category: vault
+  - id: makina-hub-caliber
+    label: Makina Hub Caliber
+    address: "0x5476F4E23dAA093Ce6700e1026013c55F7AF9083"
+    category: infra
+    note: 10 hub positions; getDetailedAum ~12.34M USDC
+  - id: makina-hub-beacon
+    label: Makina Hub Caliber Beacon
+    address: "0x3f5a881db86d6f495823028a1e892e7b2cd7e162"
+    category: infra
+    note: Current implementation 0x44B80fB32ae735d9491bE7011A9850072D61FaD9
+  - id: arbitrum-mailbox
+    label: Makina Arbitrum Spoke Mailbox
+    address: "0x81Efb959957B0735A1B25dCF929d4b89579495c6"
+    chain: arbitrum
+    category: infra
+    note: BeaconProxy; beacon 0x2f7101C2EFfa4a2d48A95958F594e3306717a0A0; implementation 0x2fA89c9b9711ddaC4BB429DCAAC918aC65e98b7a
+  - id: arbitrum-caliber
+    label: Makina Arbitrum Spoke Caliber
+    address: "0x5476F4E23dAA093Ce6700e1026013c55F7AF9083"
+    chain: arbitrum
+    category: infra
+    note: getDetailedAum ~584.7K USDC; one position ID 0x280b434adb08af0aec159fc023fa6d96
+  - id: multisig-strategy
+    label: MultisigStrategy (legacy, 0 allocation)
+    address: "0xd3F8Edff57570c4F9B11CC95eA65117e2D7A6C2D"
+    category: infra
+    note: TransparentUpgradeableProxy; current totalAllocatedValue is 0
+  - id: multisig-strategy-impl
+    label: MultisigStrategy implementation
+    address: "0xb417a7c43a7a8aa27bba2b2bb4639878532f9d0c"
+    category: infra
+  - id: usdc
+    label: USDC
+    address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     category: dependency
-    note: ~29% of vault
-  - id: dep-tokemak
-    label: Tokemak autoUSD
+  - id: nusd
+    label: NUSD
+    address: "0xE556ABa6fe6036275Ec1f87eda296BE72C811BCE"
     category: dependency
-    note: ~11% of vault
-  - id: dep-avant
-    label: Avant savUSD (Avalanche)
+  - id: usdg
+    label: USDG
+    address: "0xe343167631d89B6Ffc58B88d6b7fB0228795491D"
     category: dependency
-    note: ~40% of vault (concentration cap)
-  - id: dep-aave
-    label: Aave v3 Core USDC
+  - id: rlusd
+    label: RLUSD
+    address: "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD"
     category: dependency
-    note: ~20% liquidity reserve
+  - id: pyusd
+    label: PYUSD
+    address: "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"
+    category: dependency
+  - id: usdtb
+    label: USDtb
+    address: "0xC139190F447e929f090Edeb554D95AbB8b18aC1C"
+    category: dependency
+  - id: cusd
+    label: cUSD
+    address: "0xcCcc62962d17b8914c62D74FfB843d73B2a3cccC"
+    category: dependency
+  - id: arb-usdc
+    label: USDC (Arbitrum)
+    address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+    chain: arbitrum
+    category: dependency
+  - id: arb-pyusd
+    label: PYUSD (Arbitrum)
+    address: "0x46850aD61c2B7d64d08c9c754F45254596696984"
+    chain: arbitrum
+    category: dependency
+  - id: arb-usdai
+    label: USDai (Arbitrum)
+    address: "0x0a1a1A107E45b7Ced86833863F482BC5f4ed82EF"
+    chain: arbitrum
+    category: dependency
+  - id: curve-pool
+    label: Curve srRoyUSDC/USDC pool
+    address: "0x8fc753f96752b35f64d1bae514e6cf8db0b9322e"
+    category: dependency
+    note: Secondary liquidity only; ~8.7K srRoyUSDC at reassessment
+  - id: morpho-usdc-market
+    label: Morpho srRoyUSDC/USDC market
+    category: dependency
+    note: Market id 0xacc49c4d849c1c7f45b656aa33dc26f80094aee8f8caa1a5d3dc516fc0b52c67; ~$200.8K liquid USDC
 
 edges:
-  # === Governance flow ===
-  - from: owner-safe
+  - from: vault-mgr
     to: srroyusdc
     kind: holds-role
     label: vault owner
   - from: vault-mgr
-    to: srroyusdc
+    to: royco-access-manager
     kind: holds-role
-    label: fee / queue management
-  - from: owner-safe
-    to: multisig-strategy
+    label: AccessManager roles
+  - from: royco-access-manager
+    to: royco-factory-proxy
     kind: manages
-    label: ProxyAdmin (no timelock)
-  - from: owner-safe
-    to: royco-factory
-    kind: holds-role
-    label: ADMIN_UPGRADER (1d delay)
+    label: roles / permissions
   - from: concrete-factory-owner
     to: concrete-factory
     kind: controls
@@ -152,96 +194,120 @@ edges:
   - from: concrete-factory
     to: srroyusdc
     kind: manages
-    label: proxy admin (impl upgrade)
-  - from: treasury-safe
-    to: multisig-strategy
-    kind: controls
-    label: adjustTotalAssets (admin-reported NAV)
-  - from: royco-factory
-    to: royco-factory-proxy
-    kind: manages
-  - from: royco-factory-proxy
-    to: kernel-snusd
-    kind: deploys
-  - from: royco-factory-proxy
-    to: kernel-autousd
-    kind: deploys
-
-  # === Vault internal wiring ===
+    label: proxy admin
   - from: vault-impl
     to: srroyusdc
     kind: manages
-    label: ERC-1967 implementation
-
-  # === Capital flow: vault → MultisigStrategy → Treasury → Senior Tranches ===
-  - from: srroyusdc
-    to: multisig-strategy
-    kind: allocates-to
-    label: ~100% (full-custody handoff)
+    label: implementation
+  - from: royco-factory-proxy
+    to: makina-strategy
+    kind: manages
+    label: authority
+  - from: makina-authority
+    to: makina-machine
+    kind: manages
+    label: AccessManaged authority
   - from: srroyusdc
     to: makina-strategy
     kind: allocates-to
-    label: ~$1K (secondary)
-  - from: multisig-strategy
-    to: treasury-safe
+    label: active strategy (~99.7%)
+  - from: makina-strategy
+    to: makina-machine
+    kind: deposits-into
+    label: USDC -> machine shares
+  - from: makina-machine
+    to: makina-share-token
     kind: routes-through
-    label: safeTransfer to multisig
-
-  # === Treasury → Senior Tranche allocations ===
-  - from: treasury-safe
-    to: st-snusd
-    kind: allocates-to
-    label: "~11% (Neutrl)"
-  - from: treasury-safe
-    to: st-snusd-legacy
-    kind: allocates-to
-    label: "~18% (Neutrl legacy)"
-  - from: treasury-safe
-    to: st-autousd
-    kind: allocates-to
-    label: "~11% (Tokemak)"
-  - from: treasury-safe
-    to: st-savusd
-    kind: allocates-to
-    label: "~40% (Avant, Avalanche)"
-  - from: treasury-safe
-    to: aave-position
-    kind: allocates-to
-    label: "~20% (Aave reserve)"
-
-  # === Senior Tranche → Kernel → Underlying ===
-  - from: st-snusd
-    to: kernel-snusd
-    kind: deposits-into
-  - from: st-snusd-legacy
-    to: kernel-snusd
-    kind: deposits-into
-  - from: st-autousd
-    to: kernel-autousd
-    kind: deposits-into
-  - from: kernel-snusd
-    to: dep-neutrl
-    kind: deposits-into
-    label: sNUSD wrap
-  - from: kernel-autousd
-    to: dep-tokemak
-    kind: deposits-into
-    label: autoUSD wrap
-  - from: st-savusd
-    to: dep-avant
-    kind: deposits-into
-    label: savUSD wrap
-  - from: aave-position
-    to: dep-aave
-    kind: deposits-into
-    label: aUSDC supply
-
-  # === Yield distribution model wiring ===
-  - from: adaptive-ydm
-    to: kernel-snusd
+    label: share accounting
+  - from: makina-machine-beacon
+    to: makina-machine
     kind: manages
-    label: ST/JT yield split
-  - from: adaptive-ydm
-    to: kernel-autousd
+    label: beacon implementation
+  - from: makina-hub-beacon
+    to: makina-hub-caliber
     kind: manages
-    label: ST/JT yield split
+    label: beacon implementation
+  - from: makina-machine
+    to: makina-hub-caliber
+    kind: routes-through
+    label: hub positions
+  - from: makina-machine
+    to: arbitrum-mailbox
+    kind: routes-through
+    label: chain 42161 mailbox
+  - from: arbitrum-mailbox
+    to: arbitrum-caliber
+    kind: routes-through
+    label: spoke caliber
+  - from: makina-operator
+    to: makina-machine
+    kind: holds-role
+    label: operator / accounting
+  - from: makina-security-council
+    to: makina-machine
+    kind: holds-role
+    label: security council / accounting
+  - from: vault-mgr
+    to: makina-machine
+    kind: holds-role
+    label: risk manager
+  - from: makina-hub-caliber
+    to: usdc
+    kind: deposits-into
+    label: base token
+  - from: makina-hub-caliber
+    to: nusd
+    kind: deposits-into
+    label: base token
+  - from: makina-hub-caliber
+    to: usdg
+    kind: deposits-into
+    label: base token
+  - from: makina-hub-caliber
+    to: rlusd
+    kind: deposits-into
+    label: base token
+  - from: makina-hub-caliber
+    to: pyusd
+    kind: deposits-into
+    label: base token
+  - from: makina-hub-caliber
+    to: usdtb
+    kind: deposits-into
+    label: base token
+  - from: makina-hub-caliber
+    to: cusd
+    kind: deposits-into
+    label: base token
+  - from: arbitrum-caliber
+    to: arb-usdc
+    kind: deposits-into
+    label: base token
+  - from: arbitrum-caliber
+    to: arb-pyusd
+    kind: deposits-into
+    label: base token
+  - from: arbitrum-caliber
+    to: arb-usdai
+    kind: deposits-into
+    label: base token
+  - from: srroyusdc
+    to: curve-pool
+    kind: routes-through
+    label: secondary liquidity
+  - from: srroyusdc
+    to: morpho-usdc-market
+    kind: routes-through
+    label: collateral / borrow liquidity
+  - from: legacy-owner-safe
+    to: multisig-strategy
+    kind: manages
+    label: ProxyAdmin owner
+  - from: treasury-safe
+    to: multisig-strategy
+    kind: controls
+    label: legacy accounting/custody
+  - from: multisig-strategy-impl
+    to: multisig-strategy
+    kind: manages
+    label: implementation

--- a/reports/report/royco-srroyusdc.md
+++ b/reports/report/royco-srroyusdc.md
@@ -1,27 +1,25 @@
 # Protocol Risk Assessment: Royco Dawn (srRoyUSDC)
 
-- **Assessment Date:** March 26, 2026
+- **Assessment Date:** June 26, 2026
 - **Token:** srRoyUSDC (Senior Royco USDC)
 - **Chain:** Ethereum Mainnet
 - **Token Address:** [`0xcD9f5907F92818bC06c9Ad70217f089E190d2a32`](https://etherscan.io/address/0xcD9f5907F92818bC06c9Ad70217f089E190d2a32)
-- **Final Score: 3.80/5.0**
+- **Final Score: 4.10/5.0**
 
 ## Overview + Links
 
-srRoyUSDC is the Senior Vault token of Royco Dawn, an onchain yield-splitting protocol that divides yield into two tranches: Senior (conservative, protected) and Junior (enhanced returns, first-loss). Users deposit USDC into the Dawn Senior Vault (DSV) and receive srRoyUSDC tokens (ERC-4626) representing diversified Senior tranche exposure across multiple whitelisted yield markets.
+srRoyUSDC is the Senior Vault token of Royco Dawn. It was initially assessed as a Concrete async vault that allocated through Royco Dawn Senior Tranche markets, but the current capital path has materially changed: as of June 26, 2026, almost all reported vault assets are allocated through `RoycoVaultMakinaStrategy` into a Makina machine rather than through the prior `MultisigStrategy` treasury handoff.
 
-The Senior Vault is curator-managed by the Royco Foundation, which allocates deposited USDC across whitelisted markets including autoUSD (Auto), savUSD (Avant), sNUSD (Neutrl), Aave v3 Core USDC, and stcUSD (Cap Finance, currently paused). Junior capital in each market absorbs losses first, providing a coverage buffer for Senior depositors.
+The new Makina path removes the old Treasury Safe's direct custody of the Ethereum Senior Tranche positions, but it introduces a broader, more opaque managed-position system. The Makina machine reports AUM across hub positions on Ethereum and one Arbitrum spoke caliber. Current position IDs and base tokens are visible onchain, but the exact external venues behind each position require Makina/caliber-specific decoding and monitoring.
 
-Royco's tranche mechanics are enforced onchain, but the vault's capital path is trust-based: `MultisigStrategy` hands full custody of allocated funds to the treasury multisig.
-
-- **Current PPS:** ~1.005571 USDC per srRoyUSDC (verified onchain March 25, 2026)
-- **Total Supply:** ~10,673,575 srRoyUSDC
-- **Total Assets:** ~$10,733,046 USDC (100% deployed via MultisigStrategy, $0 held directly in vault)
-- **Total Holders:** ~8 (3 with meaningful holdings; 1 EOA holds ~69% of supply)
-- **DeFiLlama TVL (Royco V2, all chains):** ~$5.16M (Ethereum: $5.15M, Avalanche: $3.5K)
+- **Current PPS:** ~1.017419 USDC per srRoyUSDC (verified onchain June 26, 2026)
+- **Total Supply:** ~12,712,411 srRoyUSDC
+- **Total Assets:** ~$12,933,854 USDC (about $12,927,643 reported by Makina strategy, ~$44,211 USDC idle in vault)
+- **Total Holders:** ~54 reconstructed from transfer history. The largest EOA holds ~9.56M srRoyUSDC (~75.2% of supply); Morpho Blue holds ~2.42M (~19.0%).
+- **DeFiLlama TVL (Royco V2, all chains):** ~$17.81M on June 26, 2026, down from a June 17, 2026 local peak of ~$19.94M.
 - **Management Fee:** 0%
-- **Performance Fee:** 0% at vault level (`performanceFee()` returns 0, recipient is `address(0)`). Fees are charged at the Dawn market layer instead: 10% on ST yield, 0% on JT yield, 45% on yield share — verified via accountant `getState()`. Documentation claims "10% Senior / 20% Junior" are partially outdated (JT fee is 0%, yield share fee is undocumented).
-- **Contract Created:** January 6, 2026 (~78 days ago)
+- **Performance Fee:** 10% (`performanceFee()` returns recipient [`0xD6F9B6Cdf8dEb1B16E22b830166AD793fd9a0F9C`](https://etherscan.io/address/0xD6F9B6Cdf8dEb1B16E22b830166AD793fd9a0F9C), fee `1000`; recipient currently holds ~203.52 srRoyUSDC). This changed from the March assessment's 0% fee state and triggers reassessment.
+- **Contract Created:** January 6, 2026 (~171 days ago)
 
 **Links:**
 
@@ -41,12 +39,26 @@ Royco's tranche mechanics are enforced onchain, but the vault's capital path is 
 |----------|---------|
 | srRoyUSDC (VaultProxy, ERC-4626) | [`0xcD9f5907F92818bC06c9Ad70217f089E190d2a32`](https://etherscan.io/address/0xcD9f5907F92818bC06c9Ad70217f089E190d2a32) |
 | Implementation (ConcreteAsyncVaultImpl) | [`0x1b5cd91e61505d431d2a61192a1006146bd9bb28`](https://etherscan.io/address/0x1b5cd91e61505d431d2a61192a1006146bd9bb28) |
-| Owner (Gnosis Safe 3/5) | [`0x85de42e5697d16b853ea24259c42290dace35190`](https://etherscan.io/address/0x85de42e5697d16b853ea24259c42290dace35190) |
-| VAULT_MANAGER (Gnosis Safe 3/4) | [`0x7c405bbD131e42af506d14e752f2e59B19D49997`](https://etherscan.io/address/0x7c405bbD131e42af506d14e752f2e59B19D49997) |
-| Multisig Safe (Treasury, 3/5) | [`0x170ff06326eBb64BF609a848Fc143143994AF6c8`](https://etherscan.io/address/0x170ff06326eBb64BF609a848Fc143143994AF6c8) |
-| Multisig Strategy (TransparentUpgradeableProxy) | [`0xd3F8Edff57570c4F9B11CC95eA65117e2D7A6C2D`](https://etherscan.io/address/0xd3F8Edff57570c4F9B11CC95eA65117e2D7A6C2D) |
+| Vault owner / VAULT_MANAGER (Gnosis Safe 3/4) | [`0x7c405bbD131e42af506d14e752f2e59B19D49997`](https://etherscan.io/address/0x7c405bbD131e42af506d14e752f2e59B19D49997) |
+| Legacy Owner Safe (Gnosis Safe 3/4) | [`0x85de42e5697d16b853ea24259c42290dace35190`](https://etherscan.io/address/0x85de42e5697d16b853ea24259c42290dace35190) |
+| Treasury Safe (Gnosis Safe 3/5, legacy MultisigStrategy accounting/custody) | [`0x170ff06326eBb64BF609a848Fc143143994AF6c8`](https://etherscan.io/address/0x170ff06326eBb64BF609a848Fc143143994AF6c8) |
+| Multisig Strategy (TransparentUpgradeableProxy, current allocation 0) | [`0xd3F8Edff57570c4F9B11CC95eA65117e2D7A6C2D`](https://etherscan.io/address/0xd3F8Edff57570c4F9B11CC95eA65117e2D7A6C2D) |
 | MultisigStrategy Implementation | [`0xb417a7c43a7a8aa27bba2b2bb4639878532f9d0c`](https://etherscan.io/address/0xb417a7c43a7a8aa27bba2b2bb4639878532f9d0c) |
-| RoycoVaultMakinaStrategy | [`0xc5FeF644d59415cec65049e0653CA10eD9Cba778`](https://etherscan.io/address/0xc5FeF644d59415cec65049e0653CA10eD9Cba778) |
+| RoycoVaultMakinaStrategy (current primary strategy) | [`0xc5FeF644d59415cec65049e0653CA10eD9Cba778`](https://etherscan.io/address/0xc5FeF644d59415cec65049e0653CA10eD9Cba778) |
+| Makina Machine (BeaconProxy) | [`0xFa097420f0e2C72456B361a1eD85172B9ccd8c38`](https://etherscan.io/address/0xFa097420f0e2C72456B361a1eD85172B9ccd8c38) |
+| Makina Machine Beacon | [`0x5c680ec39bafe8524f3c2fa9d5f6d65f09bd7333`](https://etherscan.io/address/0x5c680ec39bafe8524f3c2fa9d5f6d65f09bd7333) |
+| Makina Machine Implementation | [`0xb655ad796634562136B593397b8b4849F332213f`](https://etherscan.io/address/0xb655ad796634562136B593397b8b4849F332213f) |
+| Makina Share Token | [`0x1004D230aCA4b781d0049AFD6D0b1ee8ed3A6787`](https://etherscan.io/address/0x1004D230aCA4b781d0049AFD6D0b1ee8ed3A6787) |
+| Makina Hub Caliber | [`0x5476F4E23dAA093Ce6700e1026013c55F7AF9083`](https://etherscan.io/address/0x5476F4E23dAA093Ce6700e1026013c55F7AF9083) |
+| Makina Hub Caliber Beacon | [`0x3f5a881db86d6f495823028a1e892e7b2cd7e162`](https://etherscan.io/address/0x3f5a881db86d6f495823028a1e892e7b2cd7e162) |
+| Makina Hub Caliber Implementation | [`0x44B80fB32ae735d9491bE7011A9850072D61FaD9`](https://etherscan.io/address/0x44B80fB32ae735d9491bE7011A9850072D61FaD9) |
+| Makina Arbitrum Spoke Mailbox | [`0x81Efb959957B0735A1B25dCF929d4b89579495c6`](https://arbiscan.io/address/0x81Efb959957B0735A1B25dCF929d4b89579495c6) |
+| Makina Arbitrum Spoke Mailbox Beacon | [`0x2f7101C2EFfa4a2d48A95958F594e3306717a0A0`](https://arbiscan.io/address/0x2f7101C2EFfa4a2d48A95958F594e3306717a0A0) |
+| Makina Arbitrum Spoke Mailbox Implementation | [`0x2fA89c9b9711ddaC4BB429DCAAC918aC65e98b7a`](https://arbiscan.io/address/0x2fA89c9b9711ddaC4BB429DCAAC918aC65e98b7a) |
+| Makina Arbitrum Spoke Caliber | [`0x5476F4E23dAA093Ce6700e1026013c55F7AF9083`](https://arbiscan.io/address/0x5476F4E23dAA093Ce6700e1026013c55F7AF9083) |
+| Makina Machine Authority | [`0x0fCEfa3f1047F35521A49cD8B06faBd588665d7F`](https://etherscan.io/address/0x0fCEfa3f1047F35521A49cD8B06faBd588665d7F) |
+| Makina Operator / Mechanic EOA | [`0x425BbC2cfF0c7E7960baA9BaC2f0Cb67B41d3beF`](https://etherscan.io/address/0x425BbC2cfF0c7E7960baA9BaC2f0Cb67B41d3beF) |
+| Makina Security Council (Gnosis Safe 2/4) | [`0x89faa3b02EF5aB185b8ACE489Af62748ACB50Afc`](https://etherscan.io/address/0x89faa3b02EF5aB185b8ACE489Af62748ACB50Afc) |
 | ConcreteFactory (Vault Proxy Admin) | [`0x0265d73a8e61f698d8eb0dfeb91ddce55516844c`](https://etherscan.io/address/0x0265d73a8e61f698d8eb0dfeb91ddce55516844c) |
 | ConcreteFactory Owner (Gnosis Safe 3/5) | [`0xdc29BD10CB9000dffBb5aAcD30606c66f07c866C`](https://etherscan.io/address/0xdc29BD10CB9000dffBb5aAcD30606c66f07c866C) |
 | RoycoFactory (AccessManager) | [`0xD567cCbb336Eb71eC2537057E2bCF6DB840bB71d`](https://etherscan.io/address/0xD567cCbb336Eb71eC2537057E2bCF6DB840bB71d) |
@@ -54,72 +66,69 @@ Royco's tranche mechanics are enforced onchain, but the vault's capital path is 
 | RoycoFactory Proxy (Dawn Market Factory) | [`0x7cC6fB28eC7b5e7afC3cB3986141797ffc27253C`](https://etherscan.io/address/0x7cC6fB28eC7b5e7afC3cB3986141797ffc27253C) |
 | Contract Creator | [`0xe86055afa2714dcd416594bc2db9b8fa69d70a47`](https://etherscan.io/address/0xe86055afa2714dcd416594bc2db9b8fa69d70a47) |
 
-### Royco Dawn Market Contracts (On-Chain Tranching)
+### Current Makina Allocation Path
 
-The Treasury multisig ([`0x170ff06326eBb64BF609a848Fc143143994AF6c8`](https://etherscan.io/address/0x170ff06326eBb64BF609a848Fc143143994AF6c8)) holds Senior Tranche tokens in each market, linking the srRoyUSDC vault to the Royco Dawn tranching system. All contracts are verified on Etherscan.
+`RoycoVaultMakinaStrategy.getMakinaMachine()` returns [`0xFa097420f0e2C72456B361a1eD85172B9ccd8c38`](https://etherscan.io/address/0xFa097420f0e2C72456B361a1eD85172B9ccd8c38). The strategy is the machine's configured depositor and redeemer. On June 26, 2026:
 
-Blueprint's own architecture docs describe MultisigStrategy as a design that "simply forwards deposits to a multi-sig wallet and retrieves" them later: [`Architecture.md#3.1.3 Multisig Strategies`](https://github.com/Blueprint-Finance/concrete-earn-v2-bug-bounty/blob/a9ace6154cb2728bc9d3d4c5019e040fb2d4b562/doc/Architecture.md#313-multisig-strategies).
+- `RoycoVaultMakinaStrategy.totalAllocatedValue()` = **12,927,642.546087 USDC**
+- Makina machine `recoveryMode()` = **false**
+- Makina machine `maxWithdraw()` = **435.535075 USDC** (only idle USDC at the machine is immediately withdrawable)
+- Machine `lastTotalAum()` = **12,927,642.546088 USDC**, last global accounting update at **2026-06-26 20:02:35 UTC**
+- Hub caliber `getDetailedAum()` = **12,342,555.087744 USDC** across 10 current position IDs
+- One Arbitrum spoke is registered for chain ID 42161. The mailbox [`0x81Efb959957B0735A1B25dCF929d4b89579495c6`](https://arbiscan.io/address/0x81Efb959957B0735A1B25dCF929d4b89579495c6) is a BeaconProxy using beacon [`0x2f7101C2EFfa4a2d48A95958F594e3306717a0A0`](https://arbiscan.io/address/0x2f7101C2EFfa4a2d48A95958F594e3306717a0A0) and implementation [`0x2fA89c9b9711ddaC4BB429DCAAC918aC65e98b7a`](https://arbiscan.io/address/0x2fA89c9b9711ddaC4BB429DCAAC918aC65e98b7a). Its linked Arbitrum caliber is [`0x5476F4E23dAA093Ce6700e1026013c55F7AF9083`](https://arbiscan.io/address/0x5476F4E23dAA093Ce6700e1026013c55F7AF9083); `getDetailedAum()` reports **584,651.923269 USDC** across one position ID (`0x280b434adb08af0aec159fc023fa6d96`).
 
-The configured `multiSig` address was also verified live onchain to be a standard Safe v1.4.1, not a custom treasury contract: `MultisigStrategy.getMultiSig()` returns [`0x170ff06326eBb64BF609a848Fc143143994AF6c8`](https://etherscan.io/address/0x170ff06326eBb64BF609a848Fc143143994AF6c8), and that address responds to `VERSION()` = `1.4.1`, `getThreshold()` = `3`, and `getOwners()` = 5 owners.
-| Market | Contract | Address |
-|--------|----------|---------|
-| Neutrl sNUSD | Kernel | [`0x0aE0978B868804929fd4C06B3B22D9197B8cd3c6`](https://etherscan.io/address/0x0aE0978B868804929fd4C06B3B22D9197B8cd3c6) |
-| Neutrl sNUSD | Senior Tranche (ROY-ST-sNUSD) | [`0x2070Af1C865f5d764F673Baf5654822947e71243`](https://etherscan.io/address/0x2070Af1C865f5d764F673Baf5654822947e71243) |
-| Neutrl sNUSD | Junior Tranche (ROY-JT-sNUSD) | [`0x3821eBea3BBbE23F3dea74f24082BD0f0b67f6c5`](https://etherscan.io/address/0x3821eBea3BBbE23F3dea74f24082BD0f0b67f6c5) |
-| Neutrl sNUSD | Accountant | [`0xCaa3F221fCf3c2EC7b6a49B73BB810cca35e1085`](https://etherscan.io/address/0xCaa3F221fCf3c2EC7b6a49B73BB810cca35e1085) |
-| Neutrl sNUSD (legacy active market) | Kernel | [`0xbdf2d357464727ee136a5f81479554f86759993a`](https://etherscan.io/address/0xbdf2d357464727ee136a5f81479554f86759993a) |
-| Neutrl sNUSD (legacy active market) | Senior Tranche (ROY-ST-sNUSD) | [`0x3b2df77f0eaa0ca98aaabffa96b03eaf08ec6c8e`](https://etherscan.io/address/0x3b2df77f0eaa0ca98aaabffa96b03eaf08ec6c8e) |
-| Neutrl sNUSD (legacy active market) | Junior Tranche (ROY-JT-sNUSD) | [`0x58c578d7e4f291ee1a11399d03e4418443e7a134`](https://etherscan.io/address/0x58c578d7e4f291ee1a11399d03e4418443e7a134) |
-| Neutrl sNUSD (legacy active market) | Accountant | [`0x3371871e8901899fec4539ae2d1737d84acb6d89`](https://etherscan.io/address/0x3371871e8901899fec4539ae2d1737d84acb6d89) |
-| Tokemak autoUSD | Kernel | [`0x8748D1c21CC550B435487F473d9Aaf6C84dA46A6`](https://etherscan.io/address/0x8748D1c21CC550B435487F473d9Aaf6C84dA46A6) |
-| Tokemak autoUSD | Senior Tranche (ROY-ST-autoUSD) | [`0x73C641fe41EB0270C7f473f3c3E4A40eb97fd8dE`](https://etherscan.io/address/0x73C641fe41EB0270C7f473f3c3E4A40eb97fd8dE) |
-| Tokemak autoUSD | Junior Tranche (ROY-JT-autoUSD) | [`0x6f0D6567099621deE3850C673d73c532071A888d`](https://etherscan.io/address/0x6f0D6567099621deE3850C673d73c532071A888d) |
-| Tokemak autoUSD | Accountant | [`0xB0166629D78E3876F570f18B154A60b99024b6f4`](https://etherscan.io/address/0xB0166629D78E3876F570f18B154A60b99024b6f4) |
-| Avant savUSD (Avalanche) | Kernel | [`0x7240FF91b471217FF93349184ABE9f102Ca1955C`](https://snowtrace.io/address/0x7240FF91b471217FF93349184ABE9f102Ca1955C) |
-| Avant savUSD (Avalanche) | Senior Tranche (ROY-ST-savUSD) | [`0xDA7bf1788aecb94fE6D5D3f739358De94f43E5C9`](https://snowtrace.io/address/0xDA7bf1788aecb94fE6D5D3f739358De94f43E5C9) |
-| Avant savUSD (Avalanche) | Junior Tranche (ROY-JT-savUSD) | [`0x2dfde7811567562aaB39D0A292e43aa7195f6Cf6`](https://snowtrace.io/address/0x2dfde7811567562aaB39D0A292e43aa7195f6Cf6) |
-| Avant savUSD (Avalanche) | Accountant | [`0x1067405d143a3973Dc48fD0Ea14ed6c1AF20dbb1`](https://snowtrace.io/address/0x1067405d143a3973Dc48fD0Ea14ed6c1AF20dbb1) |
+Makina hub base tokens currently registered on Ethereum:
 
-#### On-Chain Coverage Data (Verified March 26, 2026)
+| Token | Address |
+|-------|---------|
+| USDC | [`0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`](https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48) |
+| NUSD (Neutrl USD) | [`0xE556ABa6fe6036275Ec1f87eda296BE72C811BCE`](https://etherscan.io/address/0xE556ABa6fe6036275Ec1f87eda296BE72C811BCE) |
+| USDG (Global Dollar) | [`0xe343167631d89B6Ffc58B88d6b7fB0228795491D`](https://etherscan.io/address/0xe343167631d89B6Ffc58B88d6b7fB0228795491D) |
+| RLUSD | [`0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD`](https://etherscan.io/address/0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD) |
+| PYUSD | [`0x6c3ea9036406852006290770BEdFcAbA0e23A0e8`](https://etherscan.io/address/0x6c3ea9036406852006290770BEdFcAbA0e23A0e8) |
+| USDtb | [`0xC139190F447e929f090Edeb554D95AbB8b18aC1C`](https://etherscan.io/address/0xC139190F447e929f090Edeb554D95AbB8b18aC1C) |
+| cUSD (Cap) | [`0xcCcc62962d17b8914c62D74FfB843d73B2a3cccC`](https://etherscan.io/address/0xcCcc62962d17b8914c62D74FfB843d73B2a3cccC) |
 
-Each market's Accountant contract exposes `getState()` which returns all NAV and coverage parameters. Junior capital absorbs losses first, enforced by the kernel/accountant contracts ([source code](https://github.com/roycoprotocol/royco-dawn/blob/main/src/accountant/RoycoAccountant.sol)).
+Makina Arbitrum spoke base tokens currently registered:
 
-| Market | ST Effective NAV | JT Effective NAV | Coverage (JT/ST) | Required Coverage | Market State |
-|--------|-----------------|-----------------|-------------------|-------------------|--------------|
-| Neutrl sNUSD | ~1,172,599 sNUSD | ~145,187 sNUSD | 12.4% | 10% | PERPETUAL |
-| Tokemak autoUSD | ~1,168,619 autoUSD | ~145,849 autoUSD | 12.5% | 10% | PERPETUAL |
+| Token | Address |
+|-------|---------|
+| USDC | [`0xaf88d065e77c8cC2239327C5EDb3A432268e5831`](https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831) |
+| PYUSD | [`0x46850aD61c2B7d64d08c9c754F45254596696984`](https://arbiscan.io/address/0x46850aD61c2B7d64d08c9c754F45254596696984) |
+| USDai | [`0x0a1a1A107E45b7Ced86833863F482BC5f4ed82EF`](https://arbiscan.io/address/0x0a1a1A107E45b7Ced86833863F482BC5f4ed82EF) |
 
-Smokehouse USDC and Maple syrupUSDC markets have dust-level Senior NAV (<$10) and are not currently allocated by the Treasury. They contain only Junior capital (~$20K and ~$19.6K respectively).
+Current hub position values are visible only by position ID, not by human-readable venue:
 
-- **Treasury multisig holds**: ~1,172,390 ROY-ST-sNUSD shares at [`0x2070Af1C865f5d764F673Baf5654822947e71243`](https://etherscan.io/address/0x2070Af1C865f5d764F673Baf5654822947e71243), ~1,981,280 ROY-ST-sNUSD shares at [`0x3b2df77f0eaa0ca98aaabffa96b03eaf08ec6c8e`](https://etherscan.io/address/0x3b2df77f0eaa0ca98aaabffa96b03eaf08ec6c8e), ~1,168,613 ROY-ST-autoUSD shares at [`0x73C641fe41EB0270C7f473f3c3E4A40eb97fd8dE`](https://etherscan.io/address/0x73C641fe41EB0270C7f473f3c3E4A40eb97fd8dE), and on Avalanche ~4,278,073 ROY-ST-savUSD shares at [`0xDA7bf1788aecb94fE6D5D3f739358De94f43E5C9`](https://snowtrace.io/address/0xDA7bf1788aecb94fE6D5D3f739358De94f43E5C9)
-- **Junior depositors**: 2-3 independent addresses per market (e.g., [`0x2d745a6596d47a0fe28a7db7bd9dc7bdbca4e476`](https://etherscan.io/address/0x2d745a6596d47a0fe28a7db7bd9dc7bdbca4e476), [`0xfef0bb8df6210e441f03de23edafb0150129e176`](https://etherscan.io/address/0xfef0bb8df6210e441f03de23edafb0150129e176))
-- **No impermanent loss** recorded in any market (both `stImpermanentLoss` and `jtImpermanentLoss` are 0)
-- **Beta = 1.0** (1e18) in all markets — Junior uses the same underlying asset as Senior, meaning JT losses correlate with ST losses
-- **Per-market Fixed-Term (Protection Mode) configuration differs significantly:**
-  - **Neutrl sNUSD: `fixedTermDuration = 0`** — this market is **permanently PERPETUAL** and can never enter Protection Mode. When JT covers ST losses, `jtImpermanentLoss` is immediately erased — JT permanently absorbs the loss with zero recovery period. ST withdrawals are never paused. Liquidation threshold: ~100.09%.
-  - **Tokemak autoUSD: `fixedTermDuration = 172,800s (2 days)`** — enters Protection Mode when JT covers losses. ST withdrawals blocked for up to 2 days. If no recovery, JT absorbs permanently. Liquidation threshold: 122.5%.
-- **Dawn-level protocol fees (per-market, separate from vault fees):**
-  - ST protocol fee: 10% of Senior yield
-  - JT protocol fee: 0%
-  - Yield share protocol fee: 45% of the risk premium (yield share) paid from ST to JT
-  - Fee recipient: [`0x05ea95aE815809D77153Ed3500Ad6d936712b639`](https://etherscan.io/address/0x05ea95aE815809D77153Ed3500Ad6d936712b639)
-  - No fees taken during Fixed-Term state
-- **JT withdrawal is coverage-constrained:** The kernel enforces `postOpSyncTrancheAccountingAndEnforceCoverage` on every JT redemption — if the withdrawal would push utilization above 1.0 (coverage below required %), the tx reverts. JT can only withdraw the surplus above the coverage requirement. Current withdrawable surplus: ~28K sNUSD (Neutrl), ~28K autoUSD (Tokemak). However, coverage can still breach the threshold via underlying asset depreciation (no withdrawal needed) — this is when the loss escalation flow kicks in.
+| Position ID | Value (USDC) |
+|-------------|--------------|
+| `0xee8d64c04ee7633412b9ddfad3b42979` | ~1,781,172 |
+| `0xbf7e4ddf0195edf3a0240c54c91869fe` | ~2,445,835 |
+| `0xcdf058132e4b72dac4b2be45f350b54d` | ~1,546,209 |
+| `0x4879fe0d3dff270d0e4de1269bee3631` | ~2,598,939 |
+| `0x88099e63d7c94e1d222b1c075ba7290c` | ~1,756,865 |
+| `0x92944864fa8c7a6664302cfd7ab2bb40` | ~1,606,558 |
+| `0x903ba29812874db073661de18fb5401` | ~605,000 |
+| Other dust / small IDs | ~$1,978 |
+
+### Legacy Dawn Market Contracts
+
+The March 2026 assessment traced Treasury-held Senior Tranche positions across Neutrl sNUSD, Tokemak autoUSD, Aave aUSDC, and Avalanche savUSD. On June 26, 2026, Ethereum `balanceOf()` checks for the Treasury Safe returned **0** for aUSDC, ROY-ST-sNUSD, ROY-ST-sNUSD legacy, ROY-ST-autoUSD, and USDC. The prior Dawn tranching table is therefore historical context, not the current srRoyUSDC allocation path.
 
 ## Audits and Due Diligence Disclosures
 
-Royco Dawn has been audited by Hexens, with a Cantina competitive audit still in judging phase (262 submissions, judging by Royco team). The protocol is built on the Concrete vault framework (ConcreteAsyncVaultImpl) which was separately audited by Halborn, Code4rena, and Zellic according to the Concrete project. However, those audits cover the Concrete framework, not Royco Dawn-specific logic.
+Royco Dawn has multiple public audit artifacts in the `roycoprotocol/royco-dawn` repository. Since the March assessment, the public audit folder has added Certora and additional Hexens reports. The protocol is built on the Concrete vault framework and now routes srRoyUSDC through Makina contracts; audits of Royco Dawn do not remove the current operational/accounting dependency on Makina-controlled positions.
 
 | Auditor | Scope | Date | Status | Report |
 |---------|-------|------|--------|--------|
-| Hexens | Royco Dawn (full audit) | ~Jan 2026 | Completed | [Report (PDF)](https://github.com/roycoprotocol/royco-dawn/blob/main/audit/Hexens-Royco-Dawn-1.pdf) |
+| Hexens | Royco Dawn | 2026 | Completed | [Report 1](https://github.com/roycoprotocol/royco-dawn/blob/main/audit/Hexens-Royco-Dawn-1.pdf), [Report 2](https://github.com/roycoprotocol/royco-dawn/blob/main/audit/Hexens-Royco-Dawn-2.pdf), [Report 3](https://github.com/roycoprotocol/royco-dawn/blob/main/audit/Hexens-Royco-Dawn-3.pdf) |
 | Hexens | Royco Dawn (whitelist) | ~Jan 2026 | Completed | [Report (PDF)](https://github.com/roycoprotocol/royco-dawn/blob/main/audit/Hexens-Royco-Dawn-Whitelist.pdf) |
-| Cantina | Royco Dawn (competition) | Jan 20-27, 2026 | Judging (262 submissions, judged by Royco team) | [Competition Page](https://cantina.xyz/competitions/9c6e38e2-535e-47b2-83ef-29df91fbb774) |
+| Certora | Royco Dawn | 2026 | Completed | [Report (PDF)](https://github.com/roycoprotocol/royco-dawn/blob/main/audit/Certora-Royco-Dawn-1.pdf) |
+| Cantina | Royco Dawn (competition) | Jan 20-27, 2026 | Public competition page still available; final standalone report not found in repo audit folder | [Competition Page](https://cantina.xyz/competitions/9c6e38e2-535e-47b2-83ef-29df91fbb774) |
 | Cantina | Royco Dawn (whitelist) | Jan 2026 | Completed | [Report (PDF)](https://github.com/roycoprotocol/royco-dawn/blob/main/audit/Cantina-Royco-Dawn-Whitelist.pdf) |
 | Spearbit | Royco V1 (not Dawn) | Oct 2024 | Completed | [Report (PDF)](https://3836750677-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FFUgP4mdwyU2SaFFJTcT6%2Fuploads%2FyMcPEXtbAbVKk8rFSLAZ%2Freport-spearbit.pdf) |
 | Nethermind | Royco Boosts (not Dawn) | May 2025 | Completed | [Blog Post](https://www.nethermind.io/blog/how-nethermind-secured-royco-boosts-development) |
 
-**Smart Contract Complexity:** Moderate — Upgradeable proxy (ERC-1967), ERC-4626 vault based on Concrete framework, MultisigStrategy for fund deployment, RoycoVaultMakinaStrategy (inactive), yield distribution model (AdaptiveCurveYDM), multi-market allocation, tranching mechanics with Protection Mode, OZ AccessManager for factory roles.
+**Smart Contract Complexity:** High — ERC-1967 Concrete vault, legacy TransparentUpgradeableProxy `MultisigStrategy`, active `RoycoVaultMakinaStrategy`, Makina BeaconProxy machine and hub caliber, Arbitrum spoke accounting, AccessManager permissions, async vault queue, fee-share minting, and opaque managed positions.
 
 **Note:** The Cantina competition explicitly excluded from scope: oracle/NAV/share price manipulation, whitelisted parties behaving maliciously, external protocol bugs, centralization risks, MEV, and frontrunning. These exclusions mean some significant risk vectors remain unaudited.
 
@@ -138,199 +147,123 @@ Royco is **not** listed on the [SEAL Safe Harbor Registry](https://safeharbor.se
 ## Historical Track Record
 
 - **Royco V1 Launch:** 2024 (incentive marketplace for DeFi liquidity)
-- **Royco Dawn (V2) Launch:** January 6, 2026 (~78 days in production)
+- **Royco Dawn (V2) Launch:** January 6, 2026 (~171 days in production)
 - **Smart Contract Exploits:** None known. Protocol is still very new.
 - **Security Incidents:** None found in rekt.news, de.fi REKT Database, or other exploit trackers.
-- **TVL:** ~$5.16M across Royco V2 on DeFiLlama (Ethereum: $5.15M, Avalanche: $3.5K). srRoyUSDC vault `totalAssets()`: ~$10.73M (discrepancy likely due to DeFiLlama methodology vs onchain reported value via MultisigStrategy).
-- **Holder Distribution:** ~8 holders with non-zero balances (3 with meaningful holdings). One EOA holds ~7.36M srRoyUSDC (~69% of supply). Morpho Blue holds ~2.83M (~26%, collateral from Morpho lending). Curve pool holds ~489K (~4.6%). Extreme concentration risk. The vault holds $0 USDC directly — 100% of ~$10.73M is deployed via MultisigStrategy.
-- **Peg Stability:** srRoyUSDC is a yield-bearing vault token priced at ~1.005571 USDC (reflecting accrued yield since January 6). The Curve CurveStableSwapNG pool ([`0x8fc753f96752b35f64d1bae514e6cf8db0b9322e`](https://etherscan.io/address/0x8fc753f96752b35f64d1bae514e6cf8db0b9322e)) holds ~489K srRoyUSDC, a significant improvement from initial launch (~$600).
+- **TVL:** ~$17.81M across Royco V2 on DeFiLlama on June 26, 2026. srRoyUSDC vault `totalAssets()`: ~$12.93M, primarily reported by Makina machine accounting.
+- **Holder Distribution:** 54 current holders reconstructed from transfer history. The largest EOA ([`0x72f9c5433113289985977e72f87d76969194f9ef`](https://etherscan.io/address/0x72f9c5433113289985977e72f87d76969194f9ef)) holds ~9.56M srRoyUSDC (~75.2%). Morpho Blue ([`0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb`](https://etherscan.io/address/0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb)) holds ~2.42M (~19.0%). Extreme concentration risk remains.
+- **Peg Stability / Secondary Liquidity:** srRoyUSDC is priced at ~1.017419 USDC. Curve CurveStableSwapNG pool ([`0x8fc753f96752b35f64d1bae514e6cf8db0b9322e`](https://etherscan.io/address/0x8fc753f96752b35f64d1bae514e6cf8db0b9322e)) now holds only ~8,686 srRoyUSDC, a sharp decline from March.
 - **GitHub Activity:** 548 commits on main branch, 2 contributors (Shivaansh Kapoor and Ankur Dubey). v1.0.0 released February 5, 2026. Repository has 4 stars.
 
 ## Funds Management
 
-The Senior Vault allocates deposited USDC across whitelisted markets where Junior tranche capital provides first-loss protection. The Royco Foundation curates allocations.
+The vault now allocates primarily through RoycoVaultMakinaStrategy into a Makina machine. This is a material change from the March architecture where the Treasury Safe held Senior Tranche tokens and aUSDC.
 
-### Target Allocations
+### Current Allocation
 
-| Market | Protocol | Chain | Target | Actual (March 27, 2026) | Status |
-|--------|----------|-------|--------|------------------------|--------|
-| savUSD | Avant | Avalanche | 35% | **~40%** (~$4.278M) | Active — at concentration cap |
-| sNUSD | Neutrl | Ethereum | 35% | **~29.4%** (~$3.153M, across 2 markets) | Active — under target |
-| Aave v3 Core USDC | Aave | Ethereum | 20% | **~19.7%** (~$2.108M) | Active (liquidity reserve) |
-| autoUSD | Auto | Ethereum | 10% | **~10.9%** (~$1.169M) | Active |
-| stcUSD | Cap Finance | Ethereum | Paused | 0% | Paused (compressed yields) |
-| sUSDai | USD.ai | Arbitrum | Pending | 0% | Pending integration |
+| Component | Current value / status (June 26, 2026) |
+|-----------|----------------------------------------|
+| Vault `totalAssets()` | ~$12.934M |
+| Vault idle USDC | ~$44.2K |
+| MultisigStrategy allocation | 0 |
+| RoycoVaultMakinaStrategy allocation | ~$12.927M |
+| Makina hub caliber AUM | ~$12.343M across 10 opaque position IDs |
+| Makina Arbitrum spoke AUM | ~$584.7K verified on Arbitrum across one position ID |
+| Makina idle USDC / immediate strategy `maxWithdraw()` | ~$435.5 |
 
-Actual allocations computed from Treasury multisig token balances (see [Reserve Location Reconciliation](#reserve-location-reconciliation-verified-march-27-2026)). Target allocations are set offchain by the Royco Foundation curator — not stored in any contract.
-
-**Concentration Controls:**
-- Per-protocol: 40% max — Avant is currently at the cap (~40%)
-- Per-asset: 40% max
-- Per-chain: 40% max (Ethereum exempt) — Avalanche at ~40% (Avant savUSD only)
-- Aave v3 USDC exempt from per-market caps
+The current allocation is no longer expressible as the old Avant / Neutrl / Aave / Auto target table. Makina base tokens now include USDC, NUSD, USDG, RLUSD, PYUSD, USDtb, and cUSD. That widens the dependency set to multiple stablecoin issuers and Makina position management.
 
 ### Accessibility
 
-- **Deposits:** KYC-gated. Participants undergo KYC verification and deposits restricted to whitelisted addresses. Not fully permissionless.
-- **Withdrawals:** Request triggers up to 14-day unlock period. Vault sources liquidity from underlying Senior tranches. After unlock period, funds become claimable.
-- **Fees:** 0% management fee, 0% performance fee at the vault level (`managementFee()` and `performanceFee()` both return 0 with `address(0)` recipients, verified onchain). Fees are charged at the Dawn market layer: 10% on ST yield (`stProtocolFeeWAD`), 0% on JT yield (`jtProtocolFeeWAD`), 45% on yield share / risk premium (`yieldShareProtocolFeeWAD`) — verified via accountant `getState()`. Documentation claims "10% Senior / 20% Junior" are partially outdated. Vault-level fee updates require VAULT_MANAGER role (3/4 multisig).
-- **Secondary Market:** Improved since launch. Curve CurveStableSwapNG pool holds ~489K srRoyUSDC. Morpho Blue markets: srRoyUSDC/USDC (~$272K supply, 84% utilized), srRoyUSDC/pmUSD (~$1.99M supply, 91% utilized — loan asset is pmUSD, not direct USDC exit).
+- **Deposits:** KYC-gated. Participants undergo KYC verification and deposits are restricted to whitelisted addresses.
+- **Withdrawals:** Async withdrawal queue remains active. Vault exits depend on Makina strategy redemptions and machine liquidity.
+- **Fees:** Management fee remains 0%. Performance fee is now 1000 bps with recipient [`0xD6F9B6Cdf8dEb1B16E22b830166AD793fd9a0F9C`](https://etherscan.io/address/0xD6F9B6Cdf8dEb1B16E22b830166AD793fd9a0F9C). Fee changes require the VAULT_MANAGER Safe.
+- **Secondary Market:** Curve liquidity has fallen to ~8,686 srRoyUSDC. Morpho USDC liquidity is larger than March but still limited relative to the dominant holder and vault size.
 
 ### Collateralization
 
-- USDC deposits are deployed to underlying yield markets (not held as idle collateral)
-- Junior tranche capital in each market absorbs losses first — this is enforced onchain by each market's RoycoAccountant contract (verified in [source code](https://github.com/roycoprotocol/royco-dawn/blob/main/src/accountant/RoycoAccountant.sol) and on deployed contracts). The loss waterfall: JT effective NAV is reduced first; if JT is depleted, residual losses hit ST as `stImpermanentLoss`.
-- **Onchain coverage verified (March 26, 2026):** Neutrl sNUSD: 12.4% (required 10%), Tokemak autoUSD: 12.5% (required 10%). See [On-Chain Coverage Data](#onchain-coverage-data-verified-march-26-2026) for full breakdown.
-- If losses exceed Junior coverage, Senior absorbs remaining losses
-- **Loss Escalation Flow (enforced onchain by kernel/accountant):**
-
-  The flow differs per market depending on the `fixedTermDuration` parameter. Note: srRoyUSDC vault holders always face the 14-day async withdrawal queue at the Concrete vault layer regardless of market state below.
-
-  **Path A — Permanently PERPETUAL markets (`fixedTermDuration = 0`): Neutrl sNUSD (~29% of vault)**
-  1. **Normal:** ST and JT deposit/redeem instantly at market level (subject to coverage).
-  2. **Loss occurs:** JT covers ST losses. `jtImpermanentLoss` is **immediately erased** — JT permanently absorbs the loss with zero recovery period. Market stays PERPETUAL. ST can always withdraw. No Protection Mode, no withdrawal pause, no recovery window for JT.
-  3. **Severe loss → Liquidation threshold (~100.09%):** If utilization breaches the liquidation threshold, ST can exit with a self-liquidation bonus sourced from JT's remaining NAV. If JT is fully depleted, remaining losses hit ST as `stImpermanentLoss`.
-
-  **Path B — Fixed-Term markets (`fixedTermDuration > 0`): Tokemak autoUSD (~11% of vault, 2-day term)**
-  1. **Normal (PERPETUAL):** ST and JT deposit/redeem instantly at market level (subject to coverage).
-  2. **Small loss → Fixed-Term (Protection Mode):** When JT covers ST drawdowns and `jtImpermanentLoss` exceeds dust tolerance, market transitions to Fixed-Term. **ST withdrawals blocked** (protects JT from ST withdrawing covered capital). JT deposits blocked (protects existing JT from dilution). ST deposits and JT redemptions remain enabled (JT can still exit surplus above coverage). YDM curve frozen. No protocol fees taken.
-  3. **Recovery within fixed term:** Underlying asset recovers before the term expires, `jtImpermanentLoss` is repaid from ST appreciation, and the market returns to PERPETUAL.
-  4. **No recovery, term expires:** `jtImpermanentLoss` is **permanently zeroed** — JT absorbs the loss forever with no recourse. Market returns to PERPETUAL. ST is made whole at JT's expense.
-  5. **Severe loss → Liquidation threshold (122.5%):** The market is forced back to PERPETUAL regardless of Fixed-Term status. ST can withdraw with a self-liquidation bonus from JT's remaining NAV. If JT is fully depleted, remaining losses hit ST as `stImpermanentLoss`.
-
-  **Impact on srRoyUSDC:** During Fixed-Term (Tokemak only, up to 2 days), the Treasury multisig cannot redeem Senior Tranche tokens from the affected market, blocking vault liquidity sourcing for that sleeve. Neutrl never blocks withdrawals. The srRoyUSDC vault itself is not aware of market states.
-- Coverage adjustments require 3-day notice to whitelisted depositors with incremental 1% daily changes
-- **Loss propagation from Dawn markets to Senior vault is indirect:** While the Royco Dawn kernel/accountant contracts enforce Junior-first loss coverage onchain, the srRoyUSDC Concrete vault itself cannot read these contracts. The Treasury multisig holds the Senior Tranche tokens and calls `adjustTotalAssets()` on the MultisigStrategy to report the net value. The loss waterfall (underlying drawdown → JT absorption → residual ST loss) is enforced at the market level, but the reporting of the net result to the vault is mediated by the multisig.
-
-**Collateral Concerns:**
-- Underlying protocols (Avant, Neutrl, Auto, Cap Finance) are newer, less battle-tested DeFi protocols
-- savUSD (Avant) on Avalanche introduces cross-chain risk
-- sNUSD (Neutrl) and autoUSD (Auto) are relatively unknown protocols — limited public track record
-- **Junior coverage is verifiable at the market level but indirect from the vault:** Each market's Accountant exposes `getState()` returning JT effective NAV, coverage parameters, and impermanent loss. However, the srRoyUSDC Concrete vault has no onchain link to these contracts — it relies on the Treasury multisig holding Senior Tranche tokens and reporting values via `adjustTotalAssets()`. The tranching enforcement is onchain, but the vault's view of it is trust-based.
-- **Junior capital is concentrated:** Only 2-3 depositor addresses per market. Junior depositors could withdraw (subject to coverage enforcement — kernel blocks JT redemption if it would breach coverage).
-- **Coverage buffer is thin:** Active markets have 12.4-12.5% actual coverage vs 10% required — only ~2.5% buffer above minimum.
-- **Beta = 1.0:** In all markets, Junior uses the same underlying asset as Senior, meaning JT and ST losses are correlated. JT does not provide diversification — only a capital buffer.
-- Vault holds $0 USDC directly — 100% of ~$10.73M is deployed externally via MultisigStrategy. Importantly, this strategy is a **full-custody handoff** design: the vault calls `allocateFunds()`, the strategy's `_allocateToPosition()` forwards USDC directly to the Treasury multisig via `safeTransfer(multiSig, amount)`, and assets return only if the multisig cooperates with `_retrieveAssetsFromMultisig()` / `safeTransferFrom(multiSig, ...)`. There is no onchain guarantee that forwarded funds will be deployed to approved markets or returned to the vault. Once funds reach the Treasury multisig, that multisig can break the expected flow and use the funds freely.
-- Vault holds $0 USDC directly — 100% of ~$10.73M is deployed externally via MultisigStrategy. Importantly, this strategy is a **full-custody handoff** design: the vault calls `allocateFunds()`, the strategy's `_allocateToPosition()` forwards USDC directly to the Treasury multisig via `safeTransfer(multiSig, amount)`, and assets return only if the multisig cooperates with `_retrieveAssetsFromMultisig()` / `safeTransferFrom(multiSig, ...)`. There is no onchain guarantee that forwarded funds will be deployed to approved markets or returned to the vault. Once funds reach the Treasury multisig, that multisig can break the expected flow and use the funds freely.
-
-#### Reserve Location Reconciliation (Verified March 27, 2026)
-
-I traced the current reserve path further by combining live `balanceOf()` reads on Ethereum and Avalanche, Royco deployment configs, and treasury USDC transfer history.
-
-| Chain | Position | Contract | Treasury Balance | Approx. Raw Value |
-|------|----------|----------|------------------|-------------------|
-| Ethereum | Aave aUSDC | [`0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c`](https://etherscan.io/address/0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c) | ~2,108,035.93 aUSDC | ~$2.108M |
-| Ethereum | ROY-ST-sNUSD | [`0x2070Af1C865f5d764F673Baf5654822947e71243`](https://etherscan.io/address/0x2070Af1C865f5d764F673Baf5654822947e71243) | ~1,172,390.32 shares | ~$1.172M raw shares |
-| Ethereum | ROY-ST-sNUSD (legacy active market) | [`0x3b2df77f0eaa0ca98aaabffa96b03eaf08ec6c8e`](https://etherscan.io/address/0x3b2df77f0eaa0ca98aaabffa96b03eaf08ec6c8e) | ~1,981,279.85 shares | ~$1.981M raw shares |
-| Ethereum | ROY-ST-autoUSD | [`0x73C641fe41EB0270C7f473f3c3E4A40eb97fd8dE`](https://etherscan.io/address/0x73C641fe41EB0270C7f473f3c3E4A40eb97fd8dE) | ~1,168,613.95 shares | ~$1.169M raw shares |
-| Avalanche | ROY-ST-savUSD | [`0xDA7bf1788aecb94fE6D5D3f739358De94f43E5C9`](https://snowtrace.io/address/0xDA7bf1788aecb94fE6D5D3f739358De94f43E5C9) | ~4,278,072.87 shares | ~$4.278M raw shares |
-
-- These raw treasury balances sum to **~$10.708M**, versus vault `totalAssets()` of **~$10.7378M**. Residual unexplained gap: **~$29.4K**.
-- The vault's second strategy is **not** at zero anymore: `getStrategyData(0xc5FeF644d59415cec65049e0653CA10eD9Cba778)` returns allocation **1,000 USDC** on March 27, 2026.
-- The Treasury multisig sent **~3.155M USDC** cumulatively to the Neutrl NUSD Router [`0xa052883ebee7354fc2aa0f9c727e657fdeca744a`](https://etherscan.io/address/0xa052883ebee7354fc2aa0f9c727e657fdeca744a), which aligns closely with the two live sNUSD senior tranche positions.
-- The Treasury multisig sent **~4.2628M USDC** cumulatively to Circle `TokenMinterV2` [`0xfd78ee919681417d192449715b2594ab58f5d002`](https://etherscan.io/address/0xfd78ee919681417d192449715b2594ab58f5d002), and the same Treasury safe address on Avalanche currently holds **~4.2781M ROY-ST-savUSD** shares in Royco's Avalanche kernel [`0x7240FF91b471217FF93349184ABE9f102Ca1955C`](https://snowtrace.io/address/0x7240FF91b471217FF93349184ABE9f102Ca1955C).
-- This is strong evidence for reserve *location* across Aave, Neutrl sNUSD, Tokemak autoUSD, and Avant savUSD.
-- **Important caveat:** if the tranche tokens are valued via current `convertToAssets()`/`previewRedeem()` outputs rather than raw share balances, the traced redeemable value is only **~$9.944M**, about **~$794K below** the vault's reported `totalAssets()`. So the reserve location is now mostly evidenced, but the vault's exact NAV methodology remains trust-based and cannot be treated as fully independently provable.
+- srRoyUSDC remains USDC-denominated, but current backing is mediated by Makina machine accounting rather than directly visible Senior Tranche balances.
+- The Makina hub exposes position IDs and USDC-denominated values; it does not provide human-readable venue labels from simple read calls.
+- The old Dawn Junior-first coverage analysis is no longer the primary collateralization path for srRoyUSDC because Treasury Safe balances in the prior Senior Tranche tokens are now zero on Ethereum.
+- Current backing includes exposure to registered Ethereum base tokens USDC, NUSD, USDG, RLUSD, PYUSD, USDtb, and cUSD, plus Arbitrum spoke base tokens USDC, PYUSD, and USDai. Each introduces issuer, liquidity, oracle/accounting, and bridge/spoke risks.
+- Makina `recoveryMode()` is currently false, but `maxWithdraw()` is only ~$435.5 because machine withdrawals are limited to idle accounting-token balance. This makes the async vault dependent on position unwinds, not a large immediately liquid reserve.
 
 ### Provability
 
-- srRoyUSDC exchange rate is computed onchain via ERC-4626 (`totalAssets()` / `totalSupply()`)
-- `totalAssets()` = `totalAllocatedValue()` from MultisigStrategy (~$10.73M). Vault holds $0 USDC directly — 100% of assets are reported by the strategy.
-- **Accounting is admin-reported:** The MultisigStrategy's `totalAllocatedValue()` is updated via `adjustTotalAssets(int256 diff, uint256 nonce)`, called by the 3/5 treasury multisig ([`0x170ff06326eBb64BF609a848Fc143143994AF6c8`](https://etherscan.io/address/0x170ff06326eBb64BF609a848Fc143143994AF6c8)). This is **not** computed from onchain positions — it is manually reported by the multisig.
-- **How `adjustTotalAssets` works:** The `diff` parameter is a **signed raw USDC amount** (not a percentage), added to or subtracted from `vaultDepositedAmount`. Positive diffs increase reported assets (yield accrual), negative diffs decrease them (loss reporting). The funds themselves are onchain in underlying protocols (Aave, Avant, etc.), but the vault cannot read those balances directly — instead the multisig manually reports the net change.
-- **Accounting constraints (verified onchain March 25, 2026):**
-  - Max change per update: 50 bps (~0.5% of current `vaultDepositedAmount`), applies to both positive and negative diffs (`abs(diff)` is checked). At ~$10.73M, max ~$53.6K per call in either direction. If exceeded, contract **auto-pauses without applying the diff** — calls `_pause()` and returns immediately, discarding the change. This is a circuit breaker: the suspicious accounting update is rejected and the contract locks until `STRATEGY_ADMIN` calls `unpauseAndAdjustTotalAssets()`.
-  - Cooldown between updates: 43,200 seconds (12 hours). If violated, same circuit-breaker behavior — **diff is discarded**, contract pauses.
-  - Validity period: 2,592,000 seconds (30 days) — if no update within 30 days, `_previewPosition()` reverts with `AccountingValidityPeriodExpired`, freezing deposits/withdrawals.
-  - Sequential nonce required (current: 37, ~1 update every 2 days). Prevents replay/out-of-order submissions.
-  - Underflow protection: negative diffs cannot reduce `vaultDepositedAmount` below zero (reverts with `InsufficientUnderlyingBalance`). This is a floor guard only — the 0.5% cap is the actual per-call limit on losses.
-  - Last updated: March 25, 2026
-- **Emergency bypass — `unpauseAndAdjustTotalAssets(int256 diff)`:** Callable only by `STRATEGY_ADMIN`. Skips diff validation (no nonce check, no percentage cap, no cooldown). The diff is `int256` — can be positive or negative, unconstrained in magnitude. However, **the contract must be paused first** — OpenZeppelin's `_unpause()` reverts if not paused. This means the bypass can only be used after the circuit breaker has already triggered (a `Paused` event is emitted onchain when `adjustTotalAssets` fails validation). The intended flow: (1) `adjustTotalAssets` exceeds 0.5% cap or cooldown → contract auto-pauses, diff discarded, `Paused` event emitted; (2) STRATEGY_ADMIN investigates the anomaly; (3) STRATEGY_ADMIN calls `unpauseAndAdjustTotalAssets(diff)` → emits `Unpaused` + `AdjustTotalAssets` in one tx. This design ensures the emergency bypass is always preceded by an observable onchain pause event, providing a detection window before the unconstrained adjustment is applied.
-- **Observed usage pattern:** 36 adjustments since Jan 30, 2026. Overwhelmingly small positive diffs (+$800–4,000 USDC for yield accrual). One negative diff observed (nonce 7: -$1,225 USDC). Calls every 12–72 hours.
-- **Yield distribution — AdaptiveCurveYDM** ([`0x071B0FA065774b403B8dae0aE93A09Df5DE3DFAc`](https://etherscan.io/address/0x071B0FA065774b403B8dae0aE93A09Df5DE3DFAc)): Determines what percentage of Senior yield is redirected to Junior as a risk premium. Inspired by [Morpho's AdaptiveCurveIrm](https://github.com/morpho-org/morpho-blue-irm). Uses a piecewise linear curve with a kink at 90% utilization (Junior capital backing Senior exposure). When utilization > 90% (Junior scarce), Junior's yield share increases exponentially over time to attract more Junior capital; when < 90% (Junior abundant), it decreases. **Immutable contract** — no admin functions, no owner, no upgradeability. Parameters are set once at market initialization and the curve adapts autonomously. Floor: 0.01% JT yield share, ceiling: 100%.
-- **Per-market Junior/Senior coverage is verifiable onchain:** Each market's Accountant contract exposes `getState()` returning `lastSTEffectiveNAV`, `lastJTEffectiveNAV`, `lastSTImpermanentLoss`, `lastJTImpermanentLoss`, `coverageWAD`, `betaWAD`, and `marketState`. The kernel exposes `getState()` returning `stOwnedYieldBearingAssets` and `jtOwnedYieldBearingAssets`. These can be queried without protocol-specific tooling (standard `eth_call` to verified contracts).
-- Underlying market positions must be verified by checking each external protocol individually
-- No third-party verification mechanism (no Chainlink PoR, no custodian attestations)
-- **Overall provability is limited but better than initially documented**: Treasury holdings on Ethereum and Avalanche now evidence ~99.7% of reported assets by raw share balances, but the vault exchange rate still depends on the MultisigStrategy correctly reporting strategy NAV. The current tranche `convertToAssets()` outputs do not fully reconcile to the reported `totalAssets()`, so the exact accounting methodology remains trust-based.
+- srRoyUSDC exchange rate is computed onchain via ERC-4626 (`totalAssets()` / `totalSupply()`).
+- `totalAssets()` is currently dominated by `RoycoVaultMakinaStrategy.totalAllocatedValue()`, which values the strategy share-token balance in the Makina machine via `convertToAssets()`.
+- Makina machine `lastTotalAum()` is onchain and was updated on June 26, 2026. Hub caliber position values are visible onchain by position ID.
+- The exact external venue behind each Makina position ID is not decoded in this report. That limits independent reserve verification and makes the Makina operator/accounting process a central risk surface.
+- The Makina operator/mechanic EOA [`0x425BbC2cfF0c7E7960baA9BaC2f0Cb67B41d3beF`](https://etherscan.io/address/0x425BbC2cfF0c7E7960baA9BaC2f0Cb67B41d3beF) is currently an accounting agent. The Makina Security Council Safe is also accounting-authorized.
+- Arbitrum spoke accounting was decoded through the monitoring RPC. The spoke caliber reports one position ID (`0x280b434adb08af0aec159fc023fa6d96`) worth ~584,651.923269 USDC, with registered Arbitrum base tokens USDC, PYUSD, and USDai. This confirms the spoke AUM reported by the machine, but the human-readable external venue behind the position ID remains opaque.
 
 ## Liquidity Risk
 
-- **Primary Exit:** Async withdrawal from vault (ERC-7540 pattern — `maxWithdraw()` returns 0, confirming no instant redemption). Request triggers up to 14-day unlock period. Vault sources liquidity from underlying Senior tranches during this window. The 20% Aave v3 USDC allocation is described as a "liquidity reserve" but this refers to the vault's internal rebalancing speed (Aave is instant to unwind on the vault side), **not** instant withdrawals for depositors — all exits go through the request-and-wait mechanism.
-- **Secondary Exit (DEX):** Curve CurveStableSwapNG pool ([`0x8fc753f96752b35f64d1bae514e6cf8db0b9322e`](https://etherscan.io/address/0x8fc753f96752b35f64d1bae514e6cf8db0b9322e)) holds ~489K srRoyUSDC — significant improvement from ~$600 at initial assessment. Meaningful DEX liquidity now exists.
-- **Morpho Blue Markets** (verified via [Morpho API](https://api.morpho.org/graphql), March 25, 2026):
-  - srRoyUSDC/USDC (91.5% LLTV, [market](https://app.morpho.org/ethereum/market/0xacc49fbf58feb1ac971acce68f8adc177c43682d6a7087bbd4991a05cb7a2c67/srroyusdc-usdc)): ~$272K supply, ~$228K borrowed, 84% utilized — meaningful USDC exit path, significant growth from ~$22K at initial assessment
-  - srRoyUSDC/pmUSD (86% LLTV, [market](https://app.morpho.org/ethereum/market/0x72cc79433e9f91c2a185422725510f4bdd19c9006010f464f851468b2371b756/srroyusdc-pmusd)): ~$1.99M supply, ~$1.81M borrowed, 91% utilized — largest market by supply, but loan asset is pmUSD (Precious Metals USD from RAAC protocol), not direct USDC exit. Morpho Blue holds ~2.83M srRoyUSDC (~26% of total supply) as collateral.
-  - Two additional markets (srRoyUSDC/pmUSD at 91.5% LLTV and srRoyUSDC/USDC at 86% LLTV) are empty or negligible
-- **Slippage Analysis:** Curve pool now provides meaningful exit liquidity (~$490K). Large exits still face slippage given the vault's ~$10.7M total assets.
-- **Withdrawal Queues:** Up to 14-day max during normal conditions. Protection Mode impact on vault liquidity is **per-market and proportional to exposure**, not a vault-wide pause: Neutrl sNUSD (`fixedTermDuration=0`) never enters Protection Mode — ST can always withdraw. Tokemak autoUSD has a 2-day Protection Mode that blocks ST redemptions during losses. Only the affected market's allocation becomes illiquid; the vault can still source from other markets.
-- **Stress Scenario:** If Tokemak enters Protection Mode, ~$1.17M of vault exposure (~11%) becomes temporarily illiquid (up to 2 days). Neutrl never pauses. In a worst case where all non-Aave, non-Neutrl markets are impaired simultaneously, the vault could still source from Aave (~$2.1M, instant unwind) and Neutrl (~$3.15M, always redeemable). The Curve pool provides an additional escape valve for smaller positions.
-- **Large Holder Impact:** One EOA holds ~69% of supply (~7.36M srRoyUSDC). A withdrawal of this magnitude would require unwinding the vast majority of underlying positions.
+- **Primary Exit:** Async withdrawal from vault. There is no instant vault redemption path.
+- **Makina liquidity:** RoycoVaultMakinaStrategy `maxWithdraw()` is only ~435.5 USDC despite ~$12.93M allocated value, so exits depend on Makina position unwinds and accounting freshness.
+- **Secondary Exit (DEX):** Curve CurveStableSwapNG pool ([`0x8fc753f96752b35f64d1bae514e6cf8db0b9322e`](https://etherscan.io/address/0x8fc753f96752b35f64d1bae514e6cf8db0b9322e)) holds only ~8,686 srRoyUSDC, so DEX exit capacity is negligible versus TVL.
+- **Morpho Blue Markets** (verified via [Morpho API](https://api.morpho.org/graphql), June 26, 2026):
+  - srRoyUSDC/USDC (91.5% LLTV, [market](https://app.morpho.org/ethereum/market/0xacc49fbf58feb1ac971acce68f8adc177c43682d6a7087bbd4991a05cb7a2c67/srroyusdc-usdc)): ~$1.665M supply, ~$1.465M borrowed, 87.94% utilized, ~$200.8K liquid USDC, and ~$2.46M srRoyUSDC collateral.
+  - srRoyUSDC/pmUSD (86% LLTV, [market](https://app.morpho.org/ethereum/market/0x72cc79433e9f91c2a185422725510f4bdd19c9006010f464f851468b2371b756/srroyusdc-pmusd)): ~$35.9K supply, ~$2 borrowed, near-zero utilization, and only ~$7.6 srRoyUSDC collateral.
+- **Large Holder Impact:** The largest EOA holds ~75.2% of supply. A withdrawal or sale of this size would require a managed unwind of most vault exposure and cannot be absorbed by current secondary liquidity.
 
 ## Centralization & Control Risks
 
 ### Governance
 
-The vault governance involves multiple multisigs and two factory contracts with different access controls.
+The current governance path involves the Concrete vault proxy admin, the Royco AccessManager, the VAULT_MANAGER Safe, Makina governance roles, and a legacy MultisigStrategy proxy admin.
 
-**Owner Multisig (Vault Owner):** [`0x85de42e5697d16b853ea24259c42290dace35190`](https://etherscan.io/address/0x85de42e5697d16b853ea24259c42290dace35190)
+**VAULT_MANAGER / Vault Owner:** [`0x7c405bbD131e42af506d14e752f2e59B19D49997`](https://etherscan.io/address/0x7c405bbD131e42af506d14e752f2e59B19D49997)
+- **Type:** Gnosis Safe v1.4.1
+- **Threshold:** 3 of 4 signers
+- **Powers:** Current `owner()` of the srRoyUSDC vault, fee/queue management, Makina risk manager and risk-manager timelock, and current holder of several RoycoFactory AccessManager admin roles.
+
+**Legacy Owner Safe:** [`0x85de42e5697d16b853ea24259c42290dace35190`](https://etherscan.io/address/0x85de42e5697d16b853ea24259c42290dace35190)
 - **Type:** Gnosis Safe v1.3.0
-- **Threshold:** 3 of 5 signers (anonymous EOAs, no ENS)
-- **Powers:** Vault owner (strategy management, parameters). Also holds `ADMIN_UPGRADER_ROLE` on RoycoFactory with 1-day execution delay. Controls MultisigStrategy proxy upgrades (no timelock).
+- **Threshold:** 3 of 4 signers
+- **Powers:** No longer the vault `owner()`. Still relevant because the MultisigStrategy ProxyAdmin owner remains tied to this legacy control path.
 
-**VAULT_MANAGER Multisig:** [`0x7c405bbD131e42af506d14e752f2e59B19D49997`](https://etherscan.io/address/0x7c405bbD131e42af506d14e752f2e59B19D49997)
-- **Type:** Gnosis Safe
-- **Threshold:** 3 of 4 signers (3 signers overlap with Owner multisig, 1 new signer)
-- **Powers:** Can update fees (management/performance), toggle queue, manage withdrawal requests
+**Treasury Safe:** [`0x170ff06326eBb64BF609a848Fc143143994AF6c8`](https://etherscan.io/address/0x170ff06326eBb64BF609a848Fc143143994AF6c8)
+- **Type:** Gnosis Safe v1.4.1
+- **Threshold:** 3 of 5 signers
+- **Powers:** Legacy MultisigStrategy accounting/custody path. Current Ethereum balances for the old senior tranche and aUSDC positions are zero.
 
-**Multisig Safe (Treasury):** [`0x170ff06326eBb64BF609a848Fc143143994AF6c8`](https://etherscan.io/address/0x170ff06326eBb64BF609a848Fc143143994AF6c8)
-- **Type:** Gnosis Safe v1.3.0
-- **Threshold:** 3 of 5 signers (same 5 signers as Owner multisig — no separation of powers)
-- **Powers:** Controls `adjustTotalAssets()` on MultisigStrategy (admin-reported accounting)
+**Makina Security Council:** [`0x89faa3b02EF5aB185b8ACE489Af62748ACB50Afc`](https://etherscan.io/address/0x89faa3b02EF5aB185b8ACE489Af62748ACB50Afc)
+- **Type:** Gnosis Safe v1.4.1
+- **Threshold:** 2 of 4 signers
+- **Powers:** Accounting-authorized on the active Makina machine.
+
+**Makina Operator / Mechanic:** [`0x425BbC2cfF0c7E7960baA9BaC2f0Cb67B41d3beF`](https://etherscan.io/address/0x425BbC2cfF0c7E7960baA9BaC2f0Cb67B41d3beF)
+- **Type:** EOA
+- **Powers:** Machine `operator`, `mechanic`, accounting agent, and accounting-authorized address. This is a major operational centralization point.
 
 **ConcreteFactory Owner:** [`0xdc29BD10CB9000dffBb5aAcD30606c66f07c866C`](https://etherscan.io/address/0xdc29BD10CB9000dffBb5aAcD30606c66f07c866C)
-- **Type:** Gnosis Safe v1.3.0
-- **Threshold:** 3 of 5 signers (completely different signers from Royco — these are Concrete protocol team)
-- **Powers:** Approves and deploys vault implementation upgrades via ConcreteFactory
+- **Type:** Gnosis Safe v1.4.1
+- **Threshold:** 3 of 5 signers
+- **Powers:** Approves vault implementation upgrades through ConcreteFactory.
 
-**Signer Overlap:** The Owner and Treasury multisigs share identical 5 signers. The VAULT_MANAGER shares 3 of those 5 plus 1 additional signer. Effectively, the same group of anonymous EOAs controls vault administration, treasury, and fee management. The ConcreteFactory owner is a separate party (Concrete team).
-
-**Timelock Architecture:**
-- **RoycoFactory (AccessManager):** Uses OZ AccessManager with `minSetback` of 432,000 seconds (5 days) and `expiration` of 604,800 seconds (7 days). The Owner multisig has `ADMIN_UPGRADER_ROLE` with a 1-day (86,400s) execution delay for factory-mediated operations.
-- **Vault implementation upgrades:** Controlled by the ConcreteFactory (owned by Concrete team 3/5 multisig). The vault's `upgrade()` function requires `msg.sender == factory` (the ConcreteFactory). This means vault implementation upgrades require cooperation between the Concrete team and Royco team — a dual-control mechanism.
-- **MultisigStrategy upgrades:** Controlled by a ProxyAdmin owned by the Royco Owner multisig (3/5). **No timelock** — can be upgraded immediately. This is the most direct risk vector.
-- **Accounting adjustments:** No timelock, but constrained by max 0.5% change per update and 12-hour cooldown.
-- **Dawn market `setConversionRate`:** Each kernel's NAV conversion rate can be admin-set via `setConversionRate()` (AccessManager role, **no timelock**). For ERC4626 kernels, NAV = `ERC4626.convertToAssets(shares) × conversionRate`. Manipulating this rate directly affects raw NAVs, which drives the entire tranching/loss waterfall. Currently: Neutrl uses oracle (stored rate = 0), Tokemak uses hardcoded 1:1 (stored rate = 1e18).
+**Timelock / delay observations:** RoycoFactory AccessManager roles now appear assigned to VAULT_MANAGER. Sidecar checks found `ADMIN_UPGRADER_ROLE`, `ADMIN_KERNEL_ROLE`, and `ADMIN_ACCOUNTANT_ROLE` with 172,800 second delays; `ADMIN_ROLE`, `ADMIN_PAUSER_ROLE`, and `SYNC_ROLE` had zero delay. The active Makina machine uses its own AccessManaged authority [`0x0fCEfa3f1047F35521A49cD8B06faBd588665d7F`](https://etherscan.io/address/0x0fCEfa3f1047F35521A49cD8B06faBd588665d7F).
 
 **Upgradeable Contracts:**
-- srRoyUSDC vault: ERC-1967 proxy → ConcreteAsyncVaultImpl (upgradeable via ConcreteFactory, requires Concrete team approval)
-- MultisigStrategy: TransparentUpgradeableProxy → MultisigStrategy implementation (upgradeable by Owner multisig, **no timelock**)
-- RoycoVaultMakinaStrategy: New strategy added, currently has a small live allocation (~1,000 USDC on March 27, 2026)
+- srRoyUSDC vault: ERC-1967 proxy -> ConcreteAsyncVaultImpl [`0x1b5c...bb28`](https://etherscan.io/address/0x1b5cd91e61505d431d2a61192a1006146bd9bb28); admin ConcreteFactory [`0x0265...844c`](https://etherscan.io/address/0x0265d73a8e61f698d8eb0dfeb91ddce55516844c).
+- MultisigStrategy: TransparentUpgradeableProxy -> [`0xb417...9d0c`](https://etherscan.io/address/0xb417a7c43a7a8aa27bba2b2bb4639878532f9d0c); current allocation 0, but proxy remains upgradeable.
+- Makina strategy: verified non-proxy strategy contract with immutable vault and machine addresses.
+- Makina machine: BeaconProxy; beacon [`0x5c68...333`](https://etherscan.io/address/0x5c680ec39bafe8524f3c2fa9d5f6d65f09bd7333), implementation [`0xb655...213f`](https://etherscan.io/address/0xb655ad796634562136B593397b8b4849F332213f).
+- Makina hub caliber: BeaconProxy; beacon [`0x3f5a...e162`](https://etherscan.io/address/0x3f5a881db86d6f495823028a1e892e7b2cd7e162), implementation [`0x44B8...FaD9`](https://etherscan.io/address/0x44B80fB32ae735d9491bE7011A9850072D61FaD9).
 
 ### Programmability
 
-- srRoyUSDC PPS is calculated onchain via ERC-4626 standard (`totalAssets()` / `totalSupply()`)
-- Yield distribution uses the onchain AdaptiveCurveYDM model
-- Fund deployment and rebalancing are executed by the MultisigStrategy, which is controlled by the 3/5 treasury multisig — **significant manual intervention**
-- A second strategy (RoycoVaultMakinaStrategy) has been added and currently has a small live allocation (~1,000 USDC on March 27, 2026). It uses an OZ AccessManager authority rather than direct multisig control, potentially for automated fund deployment via Makina.
-- Market selection, allocation targets, and coverage parameters are set by the Royco Foundation (offchain decisions)
-- Fee management (management/performance fees) requires VAULT_MANAGER role (3/4 multisig). Both fees are currently 0%.
-- `accrueYield()` is callable by anyone (no access control) — triggers yield computation and fee share minting (currently mints 0 since fees are 0%)
-- Protection Mode activation and parameters are configurable
-- KYC gating for deposits adds an offchain dependency
+- PPS is calculated onchain via ERC-4626, but the asset value now depends on Makina machine accounting.
+- Makina accounting is more programmatic than the old full Treasury handoff, but still depends on authorized operators/accounting agents and position accounting freshness.
+- Performance fee is now enabled at 10%, so `accrueYield()` can mint fee shares to a nonzero recipient.
+- KYC gating remains an offchain dependency for deposits.
 
 ### External Dependencies
 
-1. **Underlying Yield Protocols (Critical):**
-   - **Avant (savUSD, Avalanche)** — 35% target allocation. Newer protocol. Cross-chain dependency adds bridge risk.
-   - **Neutrl (sNUSD, Ethereum)** — 35% target allocation. Newer protocol with limited public track record.
-   - **Aave v3 (Ethereum)** — 20% target. Blue-chip protocol, lowest risk dependency.
-   - **Auto (autoUSD, Ethereum)** — 10% target. Newer protocol.
-   - **Cap Finance (stcUSD, Ethereum)** — Currently paused.
-   - **USD.ai (sUSDai, Arbitrum)** — Pending integration. Cross-chain dependency.
-
-2. **Concrete Framework (Medium-High):** The vault implementation uses the Concrete vault framework (ConcreteAsyncVaultImpl). Bugs in Concrete would affect srRoyUSDC. Additionally, the ConcreteFactory (owned by the Concrete team's 3/5 multisig) serves as the vault's proxy admin and controls implementation upgrades. This adds a **third-party trust dependency** — the Concrete team can approve new vault implementations.
-
-3. **Accounting/NAV (High):** `totalAllocatedValue()` on the MultisigStrategy is **manually adjusted** by the 3/5 treasury multisig via `adjustTotalAssets()`. There is no oracle — deployed asset values are admin-reported. The vault holds $0 USDC directly — 100% of `totalAssets()` (~$10.73M) is reported via this mechanism. The Cantina competition excluded NAV/share price manipulation from scope, confirming this is a known trust assumption. Constraints exist (max 0.5% change per update, 12-hour cooldown, 30-day validity) but the system ultimately relies on the multisig reporting accurate values.
+1. **Makina machine / caliber system (Critical):** Active allocation path, opaque position IDs, BeaconProxy upgrade surface, accounting agents, and one Arbitrum spoke.
+2. **Stablecoin/base-token dependencies (Critical):** USDC, NUSD, USDG, RLUSD, PYUSD, USDtb, and cUSD are registered base tokens in the Makina hub.
+3. **Concrete Framework (Medium-High):** Concrete remains the vault implementation and proxy-admin framework.
+4. **Morpho / Curve secondary liquidity (Medium):** Secondary liquidity is limited and cannot absorb large exits.
 
 ## Operational Risk
 
@@ -347,161 +280,53 @@ The vault governance involves multiple multisigs and two factory contracts with 
 
 | Contract | Address | Purpose | Key Events/Functions |
 |----------|---------|---------|---------------------|
-| srRoyUSDC Vault | [`0xcD9f5907F92818bC06c9Ad70217f089E190d2a32`](https://etherscan.io/address/0xcD9f5907F92818bC06c9Ad70217f089E190d2a32) | Vault state | `Deposit`, `Withdraw`, `Transfer`, `totalAssets()`, `totalSupply()`, `convertToAssets()`, `accrueYield()` |
-| Owner Multisig | [`0x85de42e5697d16b853ea24259c42290dace35190`](https://etherscan.io/address/0x85de42e5697d16b853ea24259c42290dace35190) | Governance | Submitted/confirmed/executed transactions, owner changes |
-| VAULT_MANAGER | [`0x7c405bbD131e42af506d14e752f2e59B19D49997`](https://etherscan.io/address/0x7c405bbD131e42af506d14e752f2e59B19D49997) | Fee/queue mgmt | Fee updates, queue toggles, signer changes |
-| MultisigStrategy | [`0xd3F8Edff57570c4F9B11CC95eA65117e2D7A6C2D`](https://etherscan.io/address/0xd3F8Edff57570c4F9B11CC95eA65117e2D7A6C2D) | Fund deployment | `adjustTotalAssets()`, strategy changes, proxy upgrades |
-| RoycoVaultMakinaStrategy | [`0xc5FeF644d59415cec65049e0653CA10eD9Cba778`](https://etherscan.io/address/0xc5FeF644d59415cec65049e0653CA10eD9Cba778) | Secondary strategy | `allocateFunds()`, `totalAllocatedValue()` (~1,000 USDC allocated on March 27, 2026) |
-| Multisig Safe (Treasury) | [`0x170ff06326eBb64BF609a848Fc143143994AF6c8`](https://etherscan.io/address/0x170ff06326eBb64BF609a848Fc143143994AF6c8) | Treasury/accounting | `adjustTotalAssets()` calls, large transfers, signer changes |
+| srRoyUSDC Vault | [`0xcD9f5907F92818bC06c9Ad70217f089E190d2a32`](https://etherscan.io/address/0xcD9f5907F92818bC06c9Ad70217f089E190d2a32) | Vault state | `totalAssets()`, `totalSupply()`, `convertToAssets()`, queue state, fee config, `accrueYield()` |
+| VAULT_MANAGER | [`0x7c405bbD131e42af506d14e752f2e59B19D49997`](https://etherscan.io/address/0x7c405bbD131e42af506d14e752f2e59B19D49997) | Vault owner / risk manager | Fee updates, queue changes, AccessManager role actions, signer changes |
+| RoycoVaultMakinaStrategy | [`0xc5FeF644d59415cec65049e0653CA10eD9Cba778`](https://etherscan.io/address/0xc5FeF644d59415cec65049e0653CA10eD9Cba778) | Active strategy | `totalAllocatedValue()`, `maxWithdraw()`, `paused()`, machine address |
+| Makina Machine | [`0xFa097420f0e2C72456B361a1eD85172B9ccd8c38`](https://etherscan.io/address/0xFa097420f0e2C72456B361a1eD85172B9ccd8c38) | Active allocator/accounting | `lastTotalAum()`, `lastGlobalAccountingTime()`, `recoveryMode()`, `maxWithdraw()`, base tokens, spoke calibers |
+| Makina Hub Caliber | [`0x5476F4E23dAA093Ce6700e1026013c55F7AF9083`](https://etherscan.io/address/0x5476F4E23dAA093Ce6700e1026013c55F7AF9083) | Position accounting | `getDetailedAum()`, `getPositionsLength()`, `getPosition()`, allowed instruction root |
+| Makina Security Council | [`0x89faa3b02EF5aB185b8ACE489Af62748ACB50Afc`](https://etherscan.io/address/0x89faa3b02EF5aB185b8ACE489Af62748ACB50Afc) | Accounting-authorized Safe | signer/threshold changes, accounting actions |
+| Makina Operator / Mechanic | [`0x425BbC2cfF0c7E7960baA9BaC2f0Cb67B41d3beF`](https://etherscan.io/address/0x425BbC2cfF0c7E7960baA9BaC2f0Cb67B41d3beF) | Accounting/operator EOA | accounting updates, position management, role changes |
 | ConcreteFactory | [`0x0265d73a8e61f698d8eb0dfeb91ddce55516844c`](https://etherscan.io/address/0x0265d73a8e61f698d8eb0dfeb91ddce55516844c) | Vault proxy admin | Implementation approvals, vault upgrades |
-| RoycoFactory | [`0xD567cCbb336Eb71eC2537057E2bCF6DB840bB71d`](https://etherscan.io/address/0xD567cCbb336Eb71eC2537057E2bCF6DB840bB71d) | AccessManager | Role grants, scheduled operations, market creation |
-| AdaptiveCurveYDM | [`0x071B0FA065774b403B8dae0aE93A09Df5DE3DFAc`](https://etherscan.io/address/0x071B0FA065774b403B8dae0aE93A09Df5DE3DFAc) | Yield distribution | Parameter changes |
-| Neutrl sNUSD Kernel | [`0x0aE0978B868804929fd4C06B3B22D9197B8cd3c6`](https://etherscan.io/address/0x0aE0978B868804929fd4C06B3B22D9197B8cd3c6) | Dawn market (sNUSD) | `syncTrancheAccounting()`, `pause()`, `getState()`, coverage changes |
-| Tokemak autoUSD Kernel | [`0x8748D1c21CC550B435487F473d9Aaf6C84dA46A6`](https://etherscan.io/address/0x8748D1c21CC550B435487F473d9Aaf6C84dA46A6) | Dawn market (autoUSD) | `syncTrancheAccounting()`, `pause()`, `getState()`, coverage changes |
-| RoycoFactory Proxy | [`0x7cC6fB28eC7b5e7afC3cB3986141797ffc27253C`](https://etherscan.io/address/0x7cC6fB28eC7b5e7afC3cB3986141797ffc27253C) | Dawn market factory | `deployMarket()`, role grants, scheduled operations |
+| RoycoFactory / AccessManager | [`0xD567cCbb336Eb71eC2537057E2bCF6DB840bB71d`](https://etherscan.io/address/0xD567cCbb336Eb71eC2537057E2bCF6DB840bB71d) | Role manager | role grants, scheduled operations, delay changes |
 
 ### Critical Monitoring Points
 
-- **PPS (Price Per Share):** Track `convertToAssets(1e6)` — should be monotonically increasing. Alert on any decrease (indicates loss event or Protection Mode). Current: ~1.005571.
-- **Total Assets:** Monitor `totalAssets()` — currently 100% dependent on MultisigStrategy's admin-reported `totalAllocatedValue()`. Cross-reference with actual onchain positions in underlying protocols (Aave, Avant, Neutrl, Auto) for sanity checking.
-- **Accounting Updates (`adjustTotalAssets`):**
-  - Track all `adjustTotalAssets(int256 diff, uint256 nonce)` calls on MultisigStrategy ([`0xd3F8Edff57570c4F9B11CC95eA65117e2D7A6C2D`](https://etherscan.io/address/0xd3F8Edff57570c4F9B11CC95eA65117e2D7A6C2D))
-  - `diff` is a signed raw USDC amount (positive = yield accrual, negative = loss). Normal range: +$800–4,000 per update.
-  - Alert on: negative diffs (loss events), unusually large positive diffs (>$10K), nonce gaps or out-of-sequence, updates faster than 12-hour cooldown
-  - Alert on contract pause: if diff exceeds 0.5% cap or cooldown is violated, the contract auto-pauses instead of reverting
-  - **Critical alert on `unpauseAndAdjustTotalAssets()`**: This emergency function skips diff validation (no cap, no cooldown, no nonce). Can only be called when the contract is already paused (circuit breaker triggered). Monitor for the sequence: `Paused` event (circuit breaker) followed by `Unpaused` + `AdjustTotalAssets` in same tx. Any such sequence is a high-severity event requiring immediate investigation.
-  - Monitor `accountingValidityPeriod`: if no update for 30 days, vault freezes (deposits/withdrawals revert)
-  - Verify nonce increments sequentially (current: 37)
-- **Governance:** Monitor Owner multisig for MultisigStrategy proxy upgrade transactions (**no timelock**). Monitor ConcreteFactory for vault implementation upgrade proposals. Monitor RoycoFactory for role grants and scheduled operations.
-- **Fee Changes:** Monitor VAULT_MANAGER multisig for `updateManagementFee()` and `updatePerformanceFee()` calls. Currently both 0% — any change would enable fee share minting via `accrueYield()`.
-- **Strategy:** Monitor MultisigStrategy for fund movements. Monitor RoycoVaultMakinaStrategy for growth beyond its current small allocation (~1,000 USDC on March 27, 2026).
-- **Protection Mode / Fixed-Term State:** Alert on any market transitioning from PERPETUAL (0) to FIXED_TERM (1) state via `marketState` in accountant `getState()`. This means JT is covering ST losses and Senior withdrawals are paused.
-
-### Junior Vault / Tranching Monitoring
-
-The Junior tranche provides the first-loss buffer protecting Senior depositors. Loss of Junior capital directly reduces srRoyUSDC's structural protection. All data below is queryable onchain via the kernel and accountant contracts.
-
-**Contracts to poll (via `getState()`):**
-
-| Market | Accountant | Kernel | Junior Tranche (ERC20) |
-|--------|-----------|--------|------------------------|
-| Neutrl sNUSD | [`0xCaa3F221fCf3c2EC7b6a49B73BB810cca35e1085`](https://etherscan.io/address/0xCaa3F221fCf3c2EC7b6a49B73BB810cca35e1085) | [`0x0aE0978B868804929fd4C06B3B22D9197B8cd3c6`](https://etherscan.io/address/0x0aE0978B868804929fd4C06B3B22D9197B8cd3c6) | [`0x3821eBea3BBbE23F3dea74f24082BD0f0b67f6c5`](https://etherscan.io/address/0x3821eBea3BBbE23F3dea74f24082BD0f0b67f6c5) |
-| Tokemak autoUSD | [`0xB0166629D78E3876F570f18B154A60b99024b6f4`](https://etherscan.io/address/0xB0166629D78E3876F570f18B154A60b99024b6f4) | [`0x8748D1c21CC550B435487F473d9Aaf6C84dA46A6`](https://etherscan.io/address/0x8748D1c21CC550B435487F473d9Aaf6C84dA46A6) | [`0x6f0D6567099621deE3850C673d73c532071A888d`](https://etherscan.io/address/0x6f0D6567099621deE3850C673d73c532071A888d) |
-
-**Key metrics (from Accountant `getState()` tuple):**
-
-| Field | Index | Type | Alert Condition |
-|-------|-------|------|-----------------|
-| `lastMarketState` | 0 | uint8 | Alert if != 0 (0 = PERPETUAL, 1 = FIXED_TERM). Fixed-Term means JT is actively covering ST losses and Senior withdrawals are paused. |
-| `coverageWAD` | 3 | uint64 | Alert on any change. Currently 1e17 (10%) for both active markets. Decrease = less protection. |
-| `betaWAD` | 4 | uint96 | Alert on any change. Currently 1e18 (100%) — JT has same underlying exposure as ST. |
-| `lastSTRawNAV` | 10 | uint256 | Track for trend. Decrease = underlying asset depreciation. |
-| `lastJTRawNAV` | 11 | uint256 | Track for trend. Decrease = JT asset depreciation (since beta=1.0, correlates with ST). |
-| `lastSTEffectiveNAV` | 12 | uint256 | Alert if < `lastSTRawNAV` (means JT has NOT fully covered ST losses). |
-| `lastJTEffectiveNAV` | 13 | uint256 | **Critical metric.** Alert if drops >10% in 24h. Alert if approaches 0 (JT depleted = no protection). |
-| `lastSTImpermanentLoss` | 14 | uint256 | Alert if != 0. Non-zero means ST has suffered losses beyond what JT could cover. |
-| `lastJTImpermanentLoss` | 15 | uint256 | Alert if != 0. Non-zero means JT is actively covering ST losses. |
-| `fixedTermEndTimestamp` | 2 | uint32 | If market is in FIXED_TERM, this is when the protection period ends. After expiry, `jtImpermanentLoss` is zeroed (JT permanently absorbs loss). |
-
-**Key metrics (from Kernel `getState()` tuple):**
-
-| Field | Index | Type | Alert Condition |
-|-------|-------|------|-----------------|
-| `stOwnedYieldBearingAssets` | 3 | uint256 | Track. Cross-reference with accountant NAV for consistency. |
-| `jtOwnedYieldBearingAssets` | 4 | uint256 | Track. Significant decrease = JT capital leaving. |
-
-**Derived metrics to compute and track:**
-
-| Metric | Formula | Baseline (March 26, 2026) | Alert Threshold |
-|--------|---------|--------------------------|-----------------|
-| Coverage ratio (Neutrl) | `lastJTEffectiveNAV / lastSTEffectiveNAV` | 12.4% | < 11% (approaching 10% minimum) |
-| Coverage ratio (Tokemak) | `lastJTEffectiveNAV / lastSTEffectiveNAV` | 12.5% | < 11% (approaching 10% minimum) |
-| Utilization (Neutrl) | `(stRawNAV + jtRawNAV × beta) × coverageWAD / jtEffectiveNAV` | ~90.8% | > 95% (approaching liquidation at 100%) |
-| Utilization (Tokemak) | `(stRawNAV + jtRawNAV × beta) × coverageWAD / jtEffectiveNAV` | ~90.0% | > 95% (approaching liquidation at 122.5%) |
-
-**Junior depositor monitoring:**
-- **ROY-JT-sNUSD holders** (2 addresses holding ~145K shares total):
-  - [`0x2d745a6596d47a0fe28a7db7bd9dc7bdbca4e476`](https://etherscan.io/address/0x2d745a6596d47a0fe28a7db7bd9dc7bdbca4e476): ~76,224 shares
-  - [`0xfef0bb8df6210e441f03de23edafb0150129e176`](https://etherscan.io/address/0xfef0bb8df6210e441f03de23edafb0150129e176): ~68,903 shares
-- **ROY-JT-autoUSD holders** (3 addresses holding ~145K shares total):
-  - [`0x72f9c5433113289985977e72f87d76969194f9ef`](https://etherscan.io/address/0x72f9c5433113289985977e72f87d76969194f9ef): ~100,414 shares
-  - [`0x2d745a6596d47a0fe28a7db7bd9dc7bdbca4e476`](https://etherscan.io/address/0x2d745a6596d47a0fe28a7db7bd9dc7bdbca4e476): ~30,256 shares
-  - [`0xfef0bb8df6210e441f03de23edafb0150129e176`](https://etherscan.io/address/0xfef0bb8df6210e441f03de23edafb0150129e176): ~15,177 shares
-- Alert on any `Transfer` event from these addresses (potential JT exit reducing coverage)
-- Alert on JT `totalSupply()` decrease > 5% in 24h
-- Note: Kernel enforces coverage on JT redemption — JT cannot withdraw below coverage requirement. However, if market enters Fixed-Term, JT deposits are also paused (cannot replenish).
-
-**Senior Tranche token monitoring (Treasury holdings):**
-- Treasury multisig ([`0x170ff06326eBb64BF609a848Fc143143994AF6c8`](https://etherscan.io/address/0x170ff06326eBb64BF609a848Fc143143994AF6c8)) holds:
-  - ~1,172,390 ROY-ST-sNUSD at [`0x2070Af1C865f5d764F673Baf5654822947e71243`](https://etherscan.io/address/0x2070Af1C865f5d764F673Baf5654822947e71243)
-  - ~1,168,613 ROY-ST-autoUSD at [`0x73C641fe41EB0270C7f473f3c3E4A40eb97fd8dE`](https://etherscan.io/address/0x73C641fe41EB0270C7f473f3c3E4A40eb97fd8dE)
-- Alert if Treasury transfers or redeems Senior Tranche tokens (could indicate rebalancing or exit)
-- Alert if Treasury deposits into new markets (new Senior Tranche tokens appearing)
-**Market allocation monitoring:**
-
-Target allocations are set offchain by the Royco Foundation curator — there is no onchain registry of targets. Actual allocations must be reconstructed from the Treasury multisig's token balances across chains.
-
-*How to compute current allocation per market:*
-
-| Step | Chain | Call | Purpose |
-|------|-------|------|---------|
-| 1 | Ethereum | `balanceOf(0x170ff0...)` on aUSDC [`0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c`](https://etherscan.io/address/0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c) | Aave USDC position |
-| 2 | Ethereum | `balanceOf(0x170ff0...)` on ROY-ST-sNUSD [`0x2070Af1C865f5d764F673Baf5654822947e71243`](https://etherscan.io/address/0x2070Af1C865f5d764F673Baf5654822947e71243) | Neutrl sNUSD market 1 |
-| 3 | Ethereum | `balanceOf(0x170ff0...)` on ROY-ST-sNUSD [`0x3b2df77f0eaa0ca98aaabffa96b03eaf08ec6c8e`](https://etherscan.io/address/0x3b2df77f0eaa0ca98aaabffa96b03eaf08ec6c8e) | Neutrl sNUSD market 2 |
-| 4 | Ethereum | `balanceOf(0x170ff0...)` on ROY-ST-autoUSD [`0x73C641fe41EB0270C7f473f3c3E4A40eb97fd8dE`](https://etherscan.io/address/0x73C641fe41EB0270C7f473f3c3E4A40eb97fd8dE) | Tokemak autoUSD market |
-| 5 | Avalanche | `balanceOf(0x170ff0...)` on ROY-ST-savUSD [`0xDA7bf1788aecb94fE6D5D3f739358De94f43E5C9`](https://snowtrace.io/address/0xDA7bf1788aecb94fE6D5D3f739358De94f43E5C9) | Avant savUSD market |
-| 6 | — | Convert each balance to USD via `convertToAssets()` on each tranche (for Senior Tranche shares) or 1:1 for aUSDC | Get USD value per position |
-| 7 | — | Sum all positions and compute % per market | Current allocation |
-
-*Alert conditions:*
-- Any single protocol exceeding 40% concentration cap (Avant currently at ~40%)
-- Any single chain exceeding 40% (Avalanche currently at ~40%, Ethereum exempt)
-- Allocation drift >5% from last known target for any market
-- New positions appearing (Treasury holding new token types)
-- Positions disappearing (Treasury balance dropping to 0 on an existing market)
-
-*Important limitation:* The vault's `totalAssets()` (~$10.74M) is reported by the MultisigStrategy via `adjustTotalAssets()`. The sum of Treasury token balances converted via `convertToAssets()` (~$9.944M) does not exactly match the vault's reported value — there is a ~$794K gap. This means allocation percentages computed from Treasury balances are approximate. The vault's own accounting is the authoritative source, but it doesn't break down by market.
-**New market deployment monitoring:**
-- Monitor RoycoFactory Proxy ([`0x7cC6fB28eC7b5e7afC3cB3986141797ffc27253C`](https://etherscan.io/address/0x7cC6fB28eC7b5e7afC3cB3986141797ffc27253C)) for `deployMarket()` calls (6 markets deployed so far)
-- When new markets appear, verify coverage parameters and underlying assets
-
-**Recommended polling frequency:**
-- Accountant/Kernel `getState()`: Every 1 hour (coverage and market state)
-- Junior Tranche `Transfer` events: Real-time (event subscription) or every 15 minutes
-- Treasury Senior Tranche `balanceOf()`: Every 6 hours
-- **Allocation monitoring:** Daily — compute per-market allocation from Treasury balances, alert on concentration cap breaches or significant drift
-- RoycoFactory `deployMarket()` events: Daily
-- **Holder Concentration:** Monitor the dominant EOA holder (~69% of supply) and Morpho Blue (~26%) for significant movements.
-- **Underlying Protocols:** Monitor health of Avant (savUSD), Neutrl (sNUSD), Auto (autoUSD), and Aave.
-- **Recommended Frequency:** Hourly for PPS, governance, and strategy. Daily for underlying protocol health and allocation. Immediate alerts for proxy upgrades and fee changes.
+- **PPS:** Track `convertToAssets(1e6)`. Current baseline: ~1.017419 USDC.
+- **Fee config:** Management fee 0%; performance fee 1000 bps to [`0xD6F9...0F9C`](https://etherscan.io/address/0xD6F9B6Cdf8dEb1B16E22b830166AD793fd9a0F9C). Alert on any fee or recipient change.
+- **Makina AUM:** Track `lastTotalAum()`, `lastGlobalAccountingTime()`, hub `getDetailedAum()`, and the chain-42161 spoke. Alert if accounting becomes stale or if AUM changes without expected position events.
+- **Makina liquidity:** Track strategy `maxWithdraw()` and machine idle USDC. Current baseline is only ~435.5 USDC.
+- **Recovery mode / pauses:** Alert if Makina machine `recoveryMode()` or strategy `paused()` becomes true.
+- **Position IDs:** Alert on new, removed, or sharply changing Makina hub positions; decode adapters/venues before treating a new position as understood.
+- **Base tokens:** Alert on additions/removals of hub base tokens, especially new non-USDC stablecoin dependencies.
+- **Holder concentration:** Monitor the dominant EOA (~75.2%), Morpho Blue (~19.0%), and Curve pool (~8.7K srRoyUSDC).
+- **Secondary liquidity:** Monitor Curve srRoyUSDC balance and Morpho USDC market liquid assets.
 
 ## Risk Summary
 
 ### Key Strengths
 
-1. **Tranching mechanism provides structural protection (verified onchain at market level)** — Junior capital absorbs losses first, enforced by onchain kernel/accountant contracts. Coverage verified: ~12.4% (Neutrl), ~12.5% (Tokemak) vs 10% required. Treasury holdings now evidence live exposure across Aave, two sNUSD senior tranche positions, autoUSD, and Avalanche savUSD. The srRoyUSDC vault itself still doesn't directly reference these contracts (indirect link via Treasury multisig).
-2. **Institutional-grade access controls** — KYC and whitelisting convert potential exploits into recoverable, legally actionable incidents
-3. **Experienced founder** — Jai Bhavnani has prior DeFi experience (Rari Capital, Ambo) and backing from reputable investors (Electric Capital, Coinbase Ventures, Hashed)
-4. **Active bug bounty** — $250K on Immunefi
-5. **Conservative allocation framework** — Concentration limits (40% per protocol/asset/chain), with Aave v3 USDC as a 20% liquidity reserve
-6. **Dual-control vault upgrades** — Vault implementation upgrades require Concrete team (ConcreteFactory owner, separate 3/5 multisig) cooperation, not just Royco team. RoycoFactory uses OZ AccessManager with 5-day minSetback and 1-day execution delay for upgrader role.
-7. **Improved DEX liquidity** — Curve pool grew from ~$600 to ~$490K since launch
+1. **Onchain vault/share accounting remains available** — srRoyUSDC PPS, supply, total assets, strategy value, and Makina machine AUM are queryable onchain.
+2. **More audit artifacts are public** — Royco Dawn now has additional Hexens reports and a Certora report in the public audit folder.
+3. **Dual-control vault implementation upgrades remain** — ConcreteFactory still controls vault implementation upgrades, separating that path from Royco-only controls.
+4. **KYC-gated participation** — deposits remain permissioned, reducing anonymous depositor risk.
+5. **Makina position values are at least observable by ID** — while not human-readable, hub position AUM and timestamps can be monitored directly.
 
 ### Key Risks
 
-1. **Still a new protocol** — ~78 days in production (created January 6, 2026). Limited track record.
-2. **Extreme holder concentration** — One EOA holds ~69% of supply. ~$10.73M total assets with only ~8 holders.
-3. **MultisigStrategy upgradeable without timelock** — The Owner multisig (3/5) can upgrade the MultisigStrategy proxy immediately. This controls how all funds are deployed.
-4. **Reliance on newer underlying protocols** — 70% target allocation to Avant (savUSD) and Neutrl (sNUSD), which are relatively unknown protocols with limited public track records.
-5. **100% of assets admin-reported** — Funds are deployed onchain to underlying protocols, but the vault cannot read those balances. The entire ~$10.73M totalAssets is reported via MultisigStrategy's `adjustTotalAssets()` (signed USDC delta per call). No oracle or onchain verification of actual positions. Emergency function `unpauseAndAdjustTotalAssets()` can bypass diff constraints, but requires the contract to be paused first (observable onchain).
+1. **Material strategy migration** — nearly all assets moved from the old Treasury / Dawn Senior Tranche path to Makina. The previous allocation and coverage analysis is stale for current risk.
+2. **Opaque Makina positions** — the report can verify position IDs and values, but not the human-readable venues behind them without additional Makina adapter decoding.
+3. **Very low immediate liquidity** — Makina `maxWithdraw()` is ~$435.5, Curve holds only ~8,686 srRoyUSDC, and Morpho liquid USDC is only ~$200.8K.
+4. **Extreme holder concentration** — the largest EOA holds ~75.2% of supply.
+5. **Performance fee enabled** — performance fee changed from 0% to 10%, enabling fee-share minting to a nonzero recipient.
+6. **Makina operator/accounting centralization** — an EOA is operator, mechanic, accounting agent, and accounting-authorized; a 2-of-4 Safe is also accounting-authorized.
 
 ### Critical Risks
 
-- **MultisigStrategy upgradeable with no timelock:** The Owner multisig (3/5) controls the MultisigStrategy's ProxyAdmin and can upgrade the strategy implementation immediately. A malicious upgrade could redirect funds or bypass the 0.5% accounting constraint. This is the most direct risk vector.
-- **Treasury multisig can divert 100% of allocated funds:** `onlyVault` restricts who can call strategy entrypoints, but does not constrain what happens after allocation. Once the vault allocates, `_allocateToPosition()` transfers the full amount to the Treasury multisig. The strategy cannot force deployment into Aave / Dawn markets, and `_retrieveAssetsFromMultisig()` requires the multisig to approve funds back. This means the Treasury multisig has full practical control over all forwarded capital and can break the expected flow, divert funds elsewhere, or refuse to return them to the vault.
-- **Underlying protocol risk is opaque:** The quality and health of Avant, Neutrl, Auto, and Cap Finance positions are not easily verifiable. These protocols themselves are newer with limited audit and track record history.
-- **Junior coverage is onchain but indirect from the vault:** The Royco Dawn kernel/accountant contracts enforce Junior-first loss coverage onchain (verified: ~12.4-12.5% actual coverage, 10% required, 0 impermanent loss). However, the srRoyUSDC Concrete vault has no direct onchain link to these contracts — the Treasury multisig bridges this gap by holding Senior Tranche tokens and reporting values via `adjustTotalAssets()`. The loss waterfall enforcement is real at the market level, but the vault cannot independently verify it. Coverage buffer is thin (~2.5% above minimum) and Junior capital comes from only 2-3 depositor addresses per market.
-- **Strategy totalAssets is manually reported, not derived from onchain data:** `totalAllocatedValue()` returns a stored `vaultDepositedAmount` variable updated via `adjustTotalAssets()` by the treasury multisig. It does not read balances from Aave, Avant, Neutrl, or any underlying protocol. The reported value may not represent actual onchain positions — there is no mechanism to verify accuracy.
+- **Reserve provability is still conditional:** The vault value is onchain, but the backing path now depends on Makina position accounting and opaque position IDs. This is not equivalent to independently verifying all underlying venues.
+- **Exit liquidity is weak:** A large withdrawal must rely on managed position unwinds. Current immediate machine liquidity and secondary market depth are tiny versus vault TVL.
+- **Expanded stablecoin dependency set:** Current Makina base tokens include NUSD, USDG, RLUSD, PYUSD, USDtb, and cUSD in addition to USDC.
+- **Governance/accounting concentration:** VAULT_MANAGER controls the vault; Makina operator/accounting permissions are concentrated in an EOA and a 2-of-4 Safe.
 
 ---
 
@@ -509,52 +334,27 @@ Target allocations are set offchain by the Royco Foundation curator — there is
 
 ### Current Implementation — No Direct Minting Without Assets
 
-The vault implementation (ConcreteAsyncVaultImpl) uses standard ERC-4626 minting:
+The vault implementation uses standard ERC-4626 mint/deposit paths that require USDC transfer before share minting. There is no directly observed unrestricted `mint` function for arbitrary srRoyUSDC supply creation.
 
-1. **`mint(uint256 shares, address receiver)`** — Standard ERC-4626. Internally calls `SafeERC20.safeTransferFrom()` to pull USDC from the caller before minting shares. **Cannot mint without depositing USDC.**
+### Fee Share Minting
 
-2. **`deposit(uint256 assets, address receiver)`** — Standard ERC-4626 deposit. Same underlying flow — requires USDC transfer first.
+Fee share minting is now active as a risk path because performance fee is nonzero:
 
-3. **Fee Share Minting (`accrueYield()`)** — The vault can mint shares to fee recipients via `accrueManagementFee()` and `accruePerformanceFee()`. These are the only code paths that mint shares without requiring a corresponding USDC deposit. However:
-   - Both management fee and performance fee are currently **0%** (verified onchain March 25, 2026)
-   - Both fee recipient addresses are `address(0)` (no recipient set)
-   - `accrueYield()` is publicly callable (no access control), but currently mints 0 shares since fees are 0%
-   - Fee changes require the VAULT_MANAGER role (3/4 Gnosis Safe at [`0x7c405bbD131e42af506d14e752f2e59B19D49997`](https://etherscan.io/address/0x7c405bbD131e42af506d14e752f2e59B19D49997))
-   - Fee caps exist: `MAX_MANAGEMENT_FEE` and `MAX_PERFORMANCE_FEE` (set in the implementation)
+- `managementFee()` returns recipient `address(0)`, fee `0`, last update timestamp `1782491051`.
+- `performanceFee()` returns recipient [`0xD6F9B6Cdf8dEb1B16E22b830166AD793fd9a0F9C`](https://etherscan.io/address/0xD6F9B6Cdf8dEb1B16E22b830166AD793fd9a0F9C), fee `1000`.
+- The performance-fee recipient currently holds ~203.52 srRoyUSDC.
+- `accrueYield()` is publicly callable, so once yield is recognized, fee shares can be minted according to current fee config.
 
 ### Indirect Inflation Vectors
 
-While tokens cannot be directly minted without assets, the following mechanisms could effectively inflate or dilute value:
-
-1. **`adjustTotalAssets()` — PPS Inflation (Constrained)**
-   - The treasury multisig (3/5) can call `adjustTotalAssets(int256 diff, uint256 nonce)` on the MultisigStrategy to inflate the reported `totalAllocatedValue()`
-   - `diff` is a signed raw USDC amount added to `vaultDepositedAmount`. Positive values inflate `totalAssets()` and thus PPS.
-   - Constrained: max 50 bps (~0.5%) per update, 12-hour cooldown, sequential nonce, 30-day validity period
-   - At ~$10.73M total assets, each update can inflate by at most ~$53.6K
-   - This doesn't mint new tokens but can gradually misrepresent value
-   - **Emergency bypass:** `unpauseAndAdjustTotalAssets(int256 diff)` (STRATEGY_ADMIN only) skips caps/cooldowns — requires contract to be paused first (circuit breaker must have triggered), then enables unconstrained adjustment in a single call
-
-2. **Fee Manipulation → Fee Share Minting**
-   - The VAULT_MANAGER (3/4 Safe) could set non-zero fees via `updateManagementFee()` / `updatePerformanceFee()`
-   - Then `accrueYield()` (callable by anyone) would mint fee shares to the fee recipient
-   - Combined with `adjustTotalAssets()` inflation: the multisig could inflate totalAssets (creating fake "yield"), then fee shares would be minted based on this fake yield
-   - This is a **realistic attack vector** requiring cooperation of the VAULT_MANAGER (3/4 Safe) and Treasury (3/5 Safe) — which share overlapping signers
-
-3. **MultisigStrategy Proxy Upgrade (No Timelock)**
-   - The Owner multisig (3/5) can upgrade the MultisigStrategy implementation immediately
-   - A malicious implementation could remove the 0.5% cap on `adjustTotalAssets()`, enabling unlimited PPS inflation
-   - Or could add a function that drains deposited USDC directly
-
-4. **Vault Implementation Upgrade (Dual-Control)**
-   - A new vault implementation could include an unrestricted `mint()` function
-   - Requires ConcreteFactory owner (Concrete team 3/5 multisig) to approve the new implementation
-   - This is the highest-impact but hardest-to-execute vector — requires cooperation between two separate teams
+1. **Makina AUM / PPS reporting:** srRoyUSDC PPS now depends on Makina machine `lastTotalAum()` and strategy-owned machine shares. Incorrect or malicious Makina accounting can affect vault PPS.
+2. **Performance fee minting:** A nonzero performance fee can dilute depositors by minting fee shares to the recipient when yield accrues.
+3. **Vault implementation upgrade:** A malicious vault implementation could add unrestricted minting, but this requires the ConcreteFactory upgrade path.
+4. **Makina implementation / authority changes:** Beacon upgrades or authority changes in the Makina machine/hub path could alter accounting, withdrawals, or position-management constraints.
 
 ### Conclusion
 
-**In the current implementation, there is no function that can mint srRoyUSDC tokens without depositing underlying USDC.** The `mint` function is standard ERC-4626 and requires USDC transfer. Fee minting is disabled (0% fees, no recipient set).
-
-The most realistic risk vector is the MultisigStrategy proxy upgrade (no timelock, controlled by Owner 3/5 multisig), which could remove accounting constraints and enable PPS manipulation or fund diversion. The fee manipulation path (VAULT_MANAGER sets fees + treasury inflates totalAssets) is also viable but slower-acting due to the 0.5% cap and 12-hour cooldown on accounting adjustments.
+There is still no direct unrestricted srRoyUSDC mint path in the current vault implementation. The important June 2026 change is that fee minting is no longer disabled: the performance fee is set to 1000 bps with a nonzero recipient. The larger inflation/accounting risk is now Makina AUM correctness rather than the old MultisigStrategy `adjustTotalAssets()` path.
 
 ---
 
@@ -562,9 +362,9 @@ The most realistic risk vector is the MultisigStrategy proxy upgrade (no timeloc
 
 ### Critical Risk Gates
 
-- [ ] **No audit** → **PASS** (Hexens completed full audit + whitelist audit; Cantina competition with 262 submissions still in judging)
-- [ ] **Unverifiable reserves** → **CONDITIONAL PASS** (ERC-4626 exchange rate is onchain. Treasury holdings on Ethereum and Avalanche now evidence ~99.7% of reported assets by raw share balances, including Aave, two sNUSD tranche positions, autoUSD, and Avalanche savUSD. However, the vault's totalAssets still relies on MultisigStrategy reporting, and current tranche `convertToAssets()` outputs do not fully reconcile to reported NAV.)
-- [ ] **Total centralization** → **PASS** (multiple multisigs with dual-control for vault upgrades via ConcreteFactory — though MultisigStrategy upgrade has no timelock)
+- [ ] **No audit** → **PASS** (Royco Dawn has Hexens, Certora, and whitelist audit artifacts; Makina-specific integration risk remains a live review item)
+- [ ] **Unverifiable reserves** → **CONDITIONAL PASS** (ERC-4626 exchange rate and Makina machine AUM are onchain. Arbitrum spoke AUM is now decoded, but the human-readable venue composition behind Makina position IDs is still not fully transparent from the vault layer.)
+- [ ] **Total centralization** → **PASS, with elevated centralization** (vault ownership moved to VAULT_MANAGER Safe and Royco AccessManager roles are multisig-held, but Makina operation/accounting includes concentrated EOA and security-council authority)
 
 ### Category Scores
 
@@ -572,106 +372,86 @@ The most realistic risk vector is the MultisigStrategy proxy upgrade (no timeloc
 
 | Aspect | Assessment |
 |--------|-----------|
-| Audits | Hexens completed full audit + whitelist audit (Dawn). Cantina competition in judging phase (262 submissions, ~2 months since competition ended). Cantina whitelist audit completed. Spearbit/Nethermind audited V1/Boosts only. The Cantina competition excluded oracle manipulation, centralization risks, and whitelisted party misbehavior from scope. |
-| Bug Bounty | $250K on Immunefi (live since Feb 17, 2026 — ~5 weeks active) |
-| Time in Production | ~78 days (since Jan 6, 2026). V1 (different product) launched 2024. |
-| TVL | ~$10.73M in srRoyUSDC vault (admin-reported). ~$5.16M across Royco V2 on DeFiLlama. |
-| Historical Incidents | None in ~78 days. |
+| Audits | Royco Dawn public audit folder now includes Hexens, Certora, and whitelist reports. A standalone final Cantina competition report was not found in the repo audit folder. Makina path integration should be treated as separate operational surface. |
+| Bug Bounty | Immunefi bounty remains a positive signal, but it does not cover all whitelisted-party, governance, or offchain/accounting failures. |
+| Time in Production | ~171 days since January 6, 2026 launch of this product line. |
+| TVL | srRoyUSDC reports ~12.93M USDC total assets. Royco V2 DeFiLlama TVL was ~$17.81M on June 26, 2026. |
+| Historical Incidents | No public incident found during reassessment. |
 
-Hexens audit completed; Cantina competition still in judging after ~2 months (concerning delay — 262 submissions, only high-severity eligible for rewards). Protocol approaching 3 months with growing TVL. Bug bounty established for 5+ weeks. Cantina competition excluded key risk vectors from scope.
+The audit trail has improved since March, and the product has operated longer without a public incident. The score remains constrained by short production history, reliance on newer Royco/Makina components, and the absence of a readily located final public Cantina competition report.
 
 **Score: 3.0/5**
 
-#### Category 2: Centralization & Control Risks (Weight: 30%) — **3.5**
+#### Category 2: Centralization & Control Risks (Weight: 30%) — **4.0**
 
-**Subcategory A: Governance — 3.0**
+**Subcategory A: Governance — 4.0**
 
-- 3/5 Gnosis Safe multisig for vault ownership
-- Vault implementation upgrades require dual-control: ConcreteFactory (Concrete team 3/5 multisig) + Royco team. This is significantly better than single-party control.
-- RoycoFactory uses OZ AccessManager with 5-day minSetback and 1-day execution delay for upgrader role.
-- **MultisigStrategy proxy upgrade has no timelock** — Owner multisig can upgrade immediately. This is the primary remaining governance risk.
-- Owner and Treasury multisig share the same 5 anonymous EOA signers — no separation of powers for those functions
-- VAULT_MANAGER is a separate 3/4 multisig (3 overlapping signers + 1 new)
-- No onchain governance, no DAO, no community vote mechanism
-- Pausing mechanism via Protection Mode (automatic, not admin-triggered — this is reasonable)
+- Vault `owner()` is now VAULT_MANAGER Safe (`0x7c405b...9997`, 3-of-4), replacing the old Owner Safe for the primary vault owner path.
+- RoycoFactory AccessManager roles are now assigned primarily to VAULT_MANAGER, with 2-day delays on upgrader/kernel/accountant admin roles and no delay on several operational roles.
+- Vault implementation upgrades still involve the ConcreteFactory proxy-admin path, owned by Concrete's 3-of-5 Safe.
+- The legacy MultisigStrategy remains upgradeable and ProxyAdmin-owned by the old Owner Safe, but current allocation is 0.
+- No DAO or broad token-holder governance exists.
 
-**Subcategory B: Programmability — 3.5**
+**Subcategory B: Programmability — 4.0**
 
-- PPS calculated onchain via ERC-4626
-- Yield distribution uses onchain AdaptiveCurveYDM model
-- Fund deployment is controlled by MultisigStrategy — requires multisig intervention for allocation changes
-- New RoycoVaultMakinaStrategy added with a small live allocation (~1,000 USDC) — may indicate move toward automated allocation
-- `accrueYield()` is publicly callable (no access control) — currently no effect since fees are 0%
-- Market selection and coverage parameters set offchain by Royco Foundation
-- KYC gating adds offchain dependency for deposits
-- Protection Mode activation is partially programmatic (triggered by drawdowns)
-- Hybrid system: core vault mechanics are onchain, but allocation decisions and strategy execution are manual
+- PPS and vault accounting are onchain, but now depend on Makina machine AUM and machine-share accounting rather than direct Dawn Senior Tranche balances.
+- Makina `restrictedAccountingMode()` is true and accounting stale threshold is 8 hours, but updates depend on authorized Makina actors.
+- Machine operator/mechanic/accounting authority includes EOA [`0x425BbC2cfF0c7E7960baA9BaC2f0Cb67B41d3beF`](https://etherscan.io/address/0x425BbC2cfF0c7E7960baA9BaC2f0Cb67B41d3beF).
+- The security council Safe (`0x89faa3...0Afc`, 2-of-4) also has accounting authority.
+- Performance fee is now nonzero, and `accrueYield()` can mint fee shares according to current fee settings.
 
 **Subcategory C: External Dependencies — 4.0**
 
-- Depends on 4-5 underlying yield protocols, most of which are newer/less established
-- Avant (savUSD, Avalanche) — newer protocol, cross-chain dependency, 35% allocation
-- Neutrl (sNUSD) — newer protocol, 35% allocation
-- Auto (autoUSD) — newer protocol, 10% allocation
-- Aave v3 — blue-chip, 20% allocation (positive)
-- Concrete vault framework — serves as proxy admin and controls vault upgrades. Adds third-party trust dependency.
-- Failure of any major underlying protocol (Avant or Neutrl) would impact 35% of allocated capital
-- **Junior coverage verified at market level, but indirect from vault** — Junior capital exists onchain (~12.4-12.5% coverage, enforced by kernel/accountant), but the srRoyUSDC vault cannot directly query these contracts. The Treasury multisig holding Senior Tranche tokens is the bridge. Coverage buffer is thin (2.5% above minimum) with concentrated Junior depositors (2-3 addresses).
+- Capital path now depends on the Makina strategy, Makina BeaconProxy machine, hub caliber, Arbitrum spoke caliber, and base-token universe.
+- Base-token universe includes USDC, NUSD, USDG, RLUSD, PYUSD, USDtb, and cUSD.
+- Current hub caliber positions are opaque IDs rather than the prior easy-to-map Dawn Senior Tranche table.
+- Concrete remains a third-party dependency for vault proxy administration.
+- Secondary liquidity depends on Curve and Morpho markets, neither of which can absorb a large holder exit without meaningful slippage or queue reliance.
 
-**Score: (3.0 + 3.5 + 4.0) / 3 = 3.5/5**
+**Score: (4.0 + 4.0 + 4.0) / 3 = 4.0/5**
 
 #### Category 3: Funds Management (Weight: 30%) — **5.0**
 
 **Subcategory A: Collateralization — 5.0**
 
-- 100% USDC-backed (deposits are USDC, deployed to yield markets)
-- Junior tranche provides first-loss protection, enforced onchain by each market's kernel/accountant contracts. Verified coverage (March 26, 2026): Neutrl sNUSD 12.4%, Tokemak autoUSD 12.5%, both above 10% required minimum. No impermanent loss recorded. Treasury multisig holds Senior Tranche tokens, connecting srRoyUSDC to these markets.
-- **Coverage is thin and concentrated:** Only ~2.5% buffer above the 10% minimum. Junior capital comes from 2-3 depositor addresses per market. Beta = 1.0 (JT uses same asset as ST — correlated losses, not diversification).
-- Underlying yield comes from newer protocols (Avant, Neutrl, Auto) — collateral quality is mixed
-- Protection Mode (Fixed-Term State) is enforced onchain by the accountant — pauses ST withdrawals and JT deposits when JT is covering losses. However, the srRoyUSDC vault itself is not aware of this state — it would manifest as the Treasury multisig being unable to redeem Senior Tranche tokens.
-- Vault holds $0 USDC directly — 100% of ~$10.73M deployed externally via MultisigStrategy
-- **MultisigStrategy breaks collateral enforcement at the vault layer:** `allocateFunds()` forwards assets into `MultisigStrategy`, and `_allocateToPosition()` transfers the full amount to the Treasury multisig via `safeTransfer(multiSig, amount)`. Once this happens, the Treasury multisig has full practical control over the capital.
-- **No onchain guarantee funds stay in the intended flow:** The strategy cannot force the Treasury multisig to deploy capital to Aave / Dawn markets, keep it there, or return it to the vault. `_retrieveAssetsFromMultisig()` depends on multisig approval and balance.
-- **Treasury multisig can divert 100% of allocated funds:** Because the capital path is a custody handoff rather than an escrowed strategy, the Treasury multisig can break the expected flow and use all forwarded funds freely.
-- If Junior coverage is insufficient, Senior absorbs losses
+- Vault `totalAssets()` reports ~12.93M USDC, with ~12.93M USDC-equivalent allocated through RoycoVaultMakinaStrategy and only ~44.2K idle in the vault.
+- The active strategy owns Makina machine shares rather than the old Senior Tranche positions.
+- Makina machine `lastTotalAum()` is ~12.93M USDC and hub caliber `getDetailedAum()` is ~12.34M USDC.
+- The Makina base-token universe includes several newer stablecoin/receipt-token dependencies: NUSD, USDG, RLUSD, PYUSD, USDtb, and cUSD.
+- Current onchain `maxWithdraw()` from the machine/strategy is only ~435.5 USDC, so collateral quality and liquidity depend on Makina position unwind behavior.
+- Legacy Treasury Safe balances for the old Dawn Senior Tranche and aUSDC positions checked on Ethereum are zero.
 
 **Subcategory B: Provability — 5.0**
 
-- ERC-4626 exchange rate is onchain (PPS verifiable)
-- However, `totalAssets()` depends entirely on MultisigStrategy's `adjustTotalAssets(int256 diff, uint256 nonce)` — the multisig submits a signed USDC delta (not an absolute value), which is added/subtracted from `vaultDepositedAmount`. This is **not** computed from onchain positions in underlying protocols.
-- Funds are onchain in Aave/Avant/Neutrl/Auto only if the Treasury multisig actually deploys them there. The strategy itself does not enforce deployment: `_allocateToPosition()` forwards full custody to the multisig, and `_retrieveAssetsFromMultisig()` depends on multisig approval to pull assets back. The entire PPS therefore depends on both multisig accounting honesty and multisig custody cooperation, because there is no onchain guarantee that allocated funds remain in the intended flow after reaching the Treasury multisig (reporting is constrained by max 0.5% per update, 12-hour cooldown, nonce 37 confirming regular updates).
-- **Emergency bypass exists:** `unpauseAndAdjustTotalAssets()` skips diff validation — but requires contract to be paused first (circuit breaker triggered, `Paused` event emitted onchain). Provides a detection window before the unconstrained adjustment.
-- **Underlying protocols remain partially opaque:** The vault is exposed to newer protocols where the actual safety, redeemability, and withdrawal behavior of deployed capital cannot be independently guaranteed from the vault layer. Even when reserve locations are partially evidenced, that does not prove capital will be recoverable on demand or safe from underlying protocol-specific failure modes.
-- Individual underlying market positions are not easily auditable without protocol-specific tooling
-- **Per-market Junior coverage IS verifiable onchain:** Each market's Accountant `getState()` returns JT/ST effective NAV, impermanent loss, coverage parameters, and market state. Kernel `getState()` returns owned yield-bearing assets per tranche. All contracts are verified on Etherscan.
-- No third-party verification mechanism (no Chainlink PoR, no custodian attestations)
-- Yield computation is onchain via AdaptiveCurveYDM
-- **Self-reported accounting** with constraints is better than no reporting, but fundamentally depends on multisig honesty and does not solve uncertainty around the underlying protocols themselves
+- ERC-4626 exchange rate is onchain, and current PPS is ~1.017419 USDC per srRoyUSDC.
+- Makina AUM and hub position values are queryable onchain, but the position IDs do not provide simple, user-readable attribution to final protocols from the vault report alone.
+- Arbitrum spoke accounting is now verified from Arbitrum RPC: one position ID reports ~584,651.923269 USDC, with USDC, PYUSD, and USDai as registered spoke base tokens.
+- No independent proof-of-reserves, third-party attestation, or fully decoded position inventory was found.
+- The provability risk moved from old `adjustTotalAssets()` self-reporting to Makina accounting and cross-chain position transparency.
 
 **Score: (5.0 + 5.0) / 2 = 5.0/5**
 
-#### Category 4: Liquidity Risk (Weight: 15%) — **3.5**
+#### Category 4: Liquidity Risk (Weight: 15%) — **4.5**
 
 - Queue-based withdrawal with up to 14-day unlock period
-- Protection Mode impact is per-market: Neutrl never pauses (fixedTermDuration=0), Tokemak pauses ST for up to 2 days. Not a vault-wide freeze — proportional to affected market exposure.
-- **Improved DEX liquidity:** Curve CurveStableSwapNG pool holds ~489K srRoyUSDC (~$490K) — significant improvement from ~$600 at launch
-- Morpho Blue markets: srRoyUSDC/USDC (~$272K supply, 84% utilized — meaningful USDC exit), srRoyUSDC/pmUSD (~$1.99M supply, not direct USDC exit). Morpho holds ~2.83M srRoyUSDC (26% of supply) as collateral.
-- Extreme holder concentration — one EOA holds ~69% of supply. A single large withdrawal would require unwinding most underlying positions.
+- Current onchain `maxWithdraw()` from the Makina machine/strategy is ~435.5 USDC, far below vault TVL.
+- Curve CurveStableSwapNG pool now holds only ~8,686 srRoyUSDC, a sharp decline from March.
+- Morpho srRoyUSDC/USDC market has ~$200.8K liquid USDC against ~$2.46M collateral and ~87.9% utilization.
+- Morpho srRoyUSDC/pmUSD market has ~$35.9K liquidity and negligible borrow, but it is not a direct USDC exit.
+- Holder concentration is extreme: the largest holder owns ~75.17% of supply, while Morpho Blue holds ~19.00%.
+- A single large withdrawal or collateral liquidation would require Makina unwinds and/or queue processing.
 - Same-value asset (USDC-denominated) mitigates some waiting risk
-- Throttle mechanism (14-day max + Protection Mode pauses): +0.5
-- Same-value asset: -0.5 (net neutral)
 
-**Score: 3.5/5**
+**Score: 4.5/5**
 
 #### Category 5: Operational Risk (Weight: 5%) — **2.5**
 
 - Founder Jai Bhavnani is publicly known with DeFi track record
 - VC-backed by reputable investors (Electric Capital, Coinbase Ventures, Hashed, Amber Group)
 - Public GitHub repo ([roycoprotocol/royco-dawn](https://github.com/roycoprotocol/royco-dawn)) — verified source code
-- Small dev team (2 GitHub contributors)
-- Documentation has some gaps: oracle mechanism unclear, per-market risk data only on JS-rendered site. However, per-market Junior coverage is verifiable directly onchain via accountant `getState()`, partially compensating for documentation gaps.
-- Hypernative monitoring being configured but not yet active
-- Security council being assembled but not yet formed
+- Documentation and public reporting have gaps around the current Makina position inventory and spoke composition.
+- Monitoring should include vault PPS, Makina AUM, stale accounting threshold, Makina roles, fees, holder concentration, Curve/Morpho liquidity, and spoke changes.
+- Makina security council is now identifiable onchain, but the operator/accounting EOA remains a concentrated operational dependency.
 - No publicly documented incident response plan
 - KYC requirements suggest regulatory compliance awareness
 - Legal structure: Waymont Co., Los Angeles — details limited
@@ -685,11 +465,11 @@ No optional modifiers apply (protocol is <2 years old, TVL <$500M).
 | Category | Score | Weight | Weighted |
 |----------|-------|--------|----------|
 | Audits & Historical | 3.0 | 20% | 0.60 |
-| Centralization & Control | 3.5 | 30% | 1.05 |
+| Centralization & Control | 4.0 | 30% | 1.20 |
 | Funds Management | 5.0 | 30% | 1.50 |
-| Liquidity Risk | 3.5 | 15% | 0.525 |
+| Liquidity Risk | 4.5 | 15% | 0.675 |
 | Operational Risk | 2.5 | 5% | 0.125 |
-| **Final Score** | | | **3.80 / 5.0** |
+| **Final Score** | | | **4.10 / 5.0** |
 
 ### Risk Tier
 
@@ -707,125 +487,69 @@ No optional modifiers apply (protocol is <2 years old, TVL <$500M).
 
 ## Reassessment Triggers
 
-- **Time-based:** Reassess in 2 months (May 2026) or when Cantina audit judging concludes and remediation is publicly confirmed
+- **Time-based:** Reassess by August 2026
 - **TVL-based:** Reassess if TVL exceeds $50M or drops below $2M
-- **Incident-based:** Reassess after any exploit, Protection Mode activation, or governance change
-- **Governance-based:** Reassess if timelock is added to MultisigStrategy, the multisig threshold/signers change, MultisigStrategy is replaced, or a new governance mechanism is introduced
-- **Strategy-based:** Reassess if RoycoVaultMakinaStrategy grows materially beyond its current small allocation (~1,000 USDC)
-- **Fee-based:** Reassess if performance or management fees are changed from 0%
-- **Underlying protocol:** Reassess if any whitelisted market (Avant, Neutrl, Auto) experiences an exploit or significant issue, or if the set of underlying protocols / markets changes materially
+- **Incident-based:** Reassess after any exploit, accounting anomaly, protection-mode event, delayed withdrawal event, or Makina recovery-mode activation
+- **Governance-based:** Reassess if VAULT_MANAGER, ConcreteFactory owner, RoycoFactory roles, Makina operator/mechanic, Makina security council, risk manager, or beacon implementations change
+- **Strategy-based:** Reassess if Makina base tokens, position IDs, spoke chains, or AUM distribution change materially
+- **Fee-based:** Reassess if management fee, performance fee, or fee recipient changes
+- **Liquidity-based:** Reassess if Curve liquidity falls further, Morpho USDC liquidity drops below $100K, the largest holder exceeds 80%, or the largest holder/Morpho position moves materially
+- **Verification-based:** Reassess when Makina position IDs can be mapped to human-readable venues/adapters, or if spoke accounting no longer reconciles with machine-reported spoke AUM
 
 ---
 
 ## Appendix: Contract Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│                     CONCRETE VAULT LAYER                            │
-│                                                                     │
-│  ┌──────────────────────┐       ┌───────────────────────────────┐  │
-│  │  srRoyUSDC Vault     │       │  MultisigStrategy             │  │
-│  │  (ERC-4626 Proxy)    │──────▶│  (TransparentUpgradeableProxy)│  │
-│  │  0xcD9f...           │       │  0xd3F8...                    │  │
-│  │                      │       │                               │  │
-│  │  totalAssets() reads │       │  adjustTotalAssets(diff,nonce) │  │
-│  │  from strategy       │       │  unpauseAndAdjustTotalAssets() │  │
-│  └──────────┬───────────┘       └──────────────┬────────────────┘  │
-│             │                                  │                    │
-│             │ upgrade                          │ calls              │
-│             ▼                                  ▼                    │
-│  ┌──────────────────────┐       ┌───────────────────────────────┐  │
-│  │  ConcreteFactory     │       │  Treasury Multisig (3/5)      │  │
-│  │  (Proxy Admin)       │       │  0x170ff0...                  │  │
-│  │  0x0265...           │       │                               │  │
-│  │  Owner: Concrete 3/5 │       │  - Reports value via diff     │  │
-│  │  0xdc29...           │       │  - Holds Senior Tranche tokens│  │
-│  └──────────────────────┘       └──────────────┬────────────────┘  │
-│                                                │                    │
-└────────────────────────────────────────────────┼────────────────────┘
-                                                 │
-                                    holds ST tokens / redeems
-                                                 │
-┌────────────────────────────────────────────────┼────────────────────┐
-│                   ROYCO DAWN TRANCHING LAYER   │                    │
-│                                                ▼                    │
-│  ┌──────────────────────────────────────────────────────────────┐  │
-│  │  RoycoFactory Proxy (AccessManager)  0x7cC6...              │  │
-│  │  Manages roles for all Dawn contracts (DEPLOYER, LP, SYNC)  │  │
-│  └────────────────────────────┬─────────────────────────────────┘  │
-│                               │ deploys & governs                   │
-│               ┌───────────────┼───────────────┐                     │
-│               ▼               ▼               ▼                     │
-│  ┌─────────────────┐ ┌──────────────┐ ┌──────────────────┐        │
-│  │  PER-MARKET SET  │ │              │ │                  │        │
-│  │  (×2 active)     │ │  Neutrl      │ │  Tokemak         │        │
-│  │                  │ │  sNUSD       │ │  autoUSD         │        │
-│  │ ┌──────────────┐│ │  Market      │ │  Market          │        │
-│  │ │   Kernel     ││ │              │ │                  │        │
-│  │ │ stDeposit()  ││ │ fixedTerm=0  │ │ fixedTerm=2days  │        │
-│  │ │ stRedeem()   ││ │ liqUtil=100% │ │ liqUtil=122.5%   │        │
-│  │ │ jtDeposit()  ││ └──────────────┘ └──────────────────┘        │
-│  │ │ jtRedeem()   ││                                               │
-│  │ │ setConversion││                                               │
-│  │ │  Rate()      ││                                               │
-│  │ └──────┬───────┘│                                               │
-│  │        │        │                                               │
-│  │ ┌──────▼───────┐│  ┌──────────────┐  ┌──────────────────┐      │
-│  │ │  Accountant  ││  │Senior Tranche│  │ Junior Tranche   │      │
-│  │ │  getState()  ││  │ (ERC-4626)   │  │ (ERC-4626)       │      │
-│  │ │  coverage    ││  │ ROY-ST-*     │  │ ROY-JT-*         │      │
-│  │ │  NAV sync    │◀─▶│              │  │                  │      │
-│  │ │  loss waterf.││  │ Held by      │  │ Held by 2-3      │      │
-│  │ │  market state││  │ Treasury     │  │ independent      │      │
-│  │ └──────────────┘│  │ multisig     │  │ depositors       │      │
-│  │                  │  └──────────────┘  └──────────────────┘      │
-│  └─────────────────┘                                               │
-│                                                                     │
-│  ┌──────────────────────────────────────────────────────────────┐  │
-│  │  AdaptiveCurveYDM (Immutable)  0x071B...                    │  │
-│  │  Determines JT yield share (risk premium). No admin.        │  │
-│  └──────────────────────────────────────────────────────────────┘  │
-│                                                                     │
-└─────────────────────────────────────────────────────────────────────┘
-                                │
-                    deposits yield-bearing assets
-                                │
-┌───────────────────────────────┼─────────────────────────────────────┐
-│              UNDERLYING YIELD PROTOCOLS                              │
-│                               ▼                                     │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐              │
-│  │  Neutrl      │  │  Tokemak     │  │  Aave v3     │              │
-│  │  (sNUSD)     │  │  (autoUSD)   │  │  (USDC)      │              │
-│  │  35% target  │  │  10% target  │  │  20% target  │              │
-│  └──────────────┘  └──────────────┘  └──────────────┘              │
-│  ┌──────────────┐  ┌──────────────┐                                 │
-│  │  Avant       │  │  Cap Finance │                                 │
-│  │  (savUSD)    │  │  (stcUSD)    │                                 │
-│  │  35% target  │  │  Paused      │                                 │
-│  └──────────────┘  └──────────────┘                                 │
-│                                                                     │
-└─────────────────────────────────────────────────────────────────────┘
+User USDC
+  |
+  v
+srRoyUSDC vault (ERC-4626 / ERC-7540, ERC-1967 proxy)
+0xcD9f5907F92818bC06c9Ad70217f089E190d2a32
+  | owner: VAULT_MANAGER Safe 0x7c405b...9997
+  | proxy admin: ConcreteFactory 0x0265...5844
+  |
+  v
+RoycoVaultMakinaStrategy
+0xc5FeF644d59415cec65049e0653CA10eD9Cba778
+  | current allocated value: ~12.93M USDC
+  | maxWithdraw: ~435.5 USDC
+  |
+  v
+Makina Machine (BeaconProxy)
+0xFa097420f0e2C72456B361a1eD85172B9ccd8c38
+  | beacon: 0x5c680e...7333
+  | implementation: 0xb655...213f
+  | share token: 0x1004D230aCA4b781d0049AFD6D0b1ee8ed3A6787
+  | restrictedAccountingMode: true
+  | operator/mechanic/accounting EOA: 0x425BbC...3beF
+  | security council: 0x89faa3...0Afc
+  |
+  +--> Hub Caliber (Ethereum)
+  |    0x5476F4E23dAA093Ce6700e1026013c55F7AF9083
+  |    beacon implementation: 0x44B80f...FaD9
+  |    detailed AUM: ~12.34M USDC
+  |    base tokens: USDC, NUSD, USDG, RLUSD, PYUSD, USDtb, cUSD
+  |
+  +--> Arbitrum Spoke Caliber
+       0x81Efb959957B0735A1B25dCF929d4b89579495c6
+       mailbox beacon: 0x2f7101...7a0A0
+       implementation: 0x2fA89c...8b7a
+       caliber: 0x5476F4...9083
+       verified spoke AUM: ~$584.7K
+       one position ID: 0x280b434adb08af0aec159fc023fa6d96
+       base tokens: USDC, PYUSD, USDai
 
-┌─────────────────────────────────────────────────────────────────────┐
-│                        GOVERNANCE                                   │
-│                                                                     │
-│  Owner Multisig (3/5)          VAULT_MANAGER (3/4)                 │
-│  0x85de42...                   0x7c405b...                         │
-│  - Vault owner                 - Fee management                    │
-│  - MultisigStrategy upgrade    - Queue toggles                     │
-│    (NO TIMELOCK)                                                    │
-│                                                                     │
-│  Treasury Multisig (3/5)       ConcreteFactory Owner (3/5)         │
-│  0x170ff0...                   0xdc29BD... (Concrete team)         │
-│  - adjustTotalAssets()         - Vault implementation upgrades     │
-│  - Holds Senior Tranche tokens                                     │
-│                                                                     │
-│  ⚠ Owner & Treasury share same 5 signers (no separation of powers)│
-│  ⚠ VAULT_MANAGER shares 3 of 5 + 1 additional                    │
-│                                                                     │
-└─────────────────────────────────────────────────────────────────────┘
+Legacy path retained for monitoring:
+srRoyUSDC -> MultisigStrategy -> Treasury Safe -> Dawn Senior Tranches
+Current MultisigStrategy allocation is 0, and Treasury Safe balances for the
+old Ethereum Dawn Senior Tranche/aUSDC positions checked during reassessment
+were 0.
 
-Data flow: User deposits USDC → srRoyUSDC vault → MultisigStrategy
-→ Treasury multisig deploys to Dawn Senior Tranches → Kernel routes
-to underlying protocols. Value reported back via adjustTotalAssets().
+Governance/control:
+- VAULT_MANAGER Safe controls the vault owner role and RoycoFactory AccessManager roles.
+- ConcreteFactory owner controls vault implementation upgrade approval path.
+- Makina authority/risk-manager/security-council/operator roles control accounting,
+  recovery, and machine operations.
+- Performance fee recipient is nonzero and currently holds fee shares.
 ```


### PR DESCRIPTION
Closes #224

Summary:
- Reassesses Royco Dawn srRoyUSDC as of June 26, 2026 and updates score to 4.10 / 5.0.
- Replaces the stale Treasury / MultisigStrategy allocation analysis with the active RoycoVaultMakinaStrategy and Makina machine path.
- Updates governance, fee, holder concentration, Morpho/Curve liquidity, monitoring triggers, appendix architecture, and dependency graph YAML.
- Decodes the Arbitrum spoke through the monitoring RPC: mailbox BeaconProxy, implementation, linked caliber, one position ID, ~$584.65K AUM, and USDC/PYUSD/USDai base tokens.

Validation:
- npm run build
- git diff --check

Notes:
- Makina position IDs are now visible on Ethereum and Arbitrum, but the human-readable venues/adapters behind those IDs remain opaque.
