### PR TITLE
feat: report links on monitoring cards + table layout for alert history

### DIFF
--- a/src/data/monitoring.ts
+++ b/src/data/monitoring.ts
@@ -13,6 +13,8 @@ export interface Protocol {
   // this is the join key for live alert history. Left unset for protocols with no enabled
   // backend job yet (euler, pendle, silo) — the UI omits live data for those.
   apiProtocol?: string;
+  // Risk assessment report slug (optional). Links to /report/<slug>/ on the monitoring card.
+  reportSlug?: string;
 }
 
 // --- API response types ---
@@ -83,6 +85,22 @@ const SLUG_TO_ALERT_PROTOCOL: Record<string, string> = {
   "lrt-pegs": "",
 };
 
+// monitoring.yaml slugs -> risk report slugs.
+// Reports live at /report/<slug>/; omit entries for protocols without a
+// dedicated report.
+const SLUG_TO_REPORT: Record<string, string> = {
+  "3jane": "3jane-usd3",
+  aave: "aave-sgho",
+  cap: "cap-stcusd",
+  fluid: "fluid",
+  infinifi: "infinifi",
+  maker: "sky-usds",
+  maple: "maple-syrupusdc",
+  rtoken: "reserve-ethplus",
+  strata: "strata-srusde",
+  ustb: "superstate-ustb",
+};
+
 /** Transform the API response into the shape the monitoring page expects. */
 export function transformApiProtocols(apiProtocols: ApiProtocol[]): Protocol[] {
   return apiProtocols
@@ -92,6 +110,7 @@ export function transformApiProtocols(apiProtocols: ApiProtocol[]): Protocol[] {
       name: p.display_name,
       defillamaSlug: SLUG_TO_DEFILLAMA[p.slug] ?? "",
       apiProtocol: SLUG_TO_ALERT_PROTOCOL[p.slug] ?? p.slug,
+      reportSlug: SLUG_TO_REPORT[p.slug],
       items: p.monitors.map((m) => ({
         label: m.name,
         description: m.description,
@@ -108,6 +127,7 @@ export const FALLBACK_PROTOCOLS: Protocol[] = [
     name: "3Jane",
     defillamaSlug: "3jane",
     apiProtocol: "3jane",
+    reportSlug: "3jane-usd3",
     items: [
       {
         label: "Price Per Share",
@@ -140,6 +160,7 @@ export const FALLBACK_PROTOCOLS: Protocol[] = [
     name: "Aave V3",
     defillamaSlug: "aave-v3",
     apiProtocol: "aave",
+    reportSlug: "aave-sgho",
     items: [
       {
         label: "Bad Debt Ratio",
@@ -169,6 +190,7 @@ export const FALLBACK_PROTOCOLS: Protocol[] = [
     name: "CAP",
     defillamaSlug: "cap-protocol",
     apiProtocol: "cap",
+    reportSlug: "cap-stcusd",
     items: [
       {
         label: "Withdrawable Liquidity",
@@ -240,6 +262,7 @@ export const FALLBACK_PROTOCOLS: Protocol[] = [
     name: "Fluid",
     defillamaSlug: "fluid",
     apiProtocol: "fluid",
+    reportSlug: "fluid",
     items: [
       {
         label: "Governance Proposals",
@@ -256,6 +279,7 @@ export const FALLBACK_PROTOCOLS: Protocol[] = [
     name: "Infinifi",
     defillamaSlug: "infinifi",
     apiProtocol: "infinifi",
+    reportSlug: "infinifi",
     items: [
       {
         label: "Reserves & Backing",
@@ -362,6 +386,7 @@ export const FALLBACK_PROTOCOLS: Protocol[] = [
     name: "Maker DAO",
     defillamaSlug: "sky",
     apiProtocol: "maker",
+    reportSlug: "sky-usds",
     items: [
       {
         label: "Executive Proposals",
@@ -390,6 +415,7 @@ export const FALLBACK_PROTOCOLS: Protocol[] = [
     name: "Maple Finance",
     defillamaSlug: "maple",
     apiProtocol: "maple",
+    reportSlug: "maple-syrupusdc",
     items: [
       {
         label: "Price Per Share",
@@ -459,6 +485,7 @@ export const FALLBACK_PROTOCOLS: Protocol[] = [
     name: "RToken (ETH+)",
     defillamaSlug: "reserve-protocol",
     apiProtocol: "ethplus",
+    reportSlug: "reserve-ethplus",
     items: [
       {
         label: "Collateral Coverage",
@@ -487,6 +514,7 @@ export const FALLBACK_PROTOCOLS: Protocol[] = [
     name: "Strata",
     defillamaSlug: "strata-finance",
     apiProtocol: "strata",
+    reportSlug: "strata-srusde",
     items: [
       {
         label: "srUSDe Exchange Rate",
@@ -525,6 +553,7 @@ export const FALLBACK_PROTOCOLS: Protocol[] = [
     name: "Superstate USTB",
     defillamaSlug: "superstate",
     apiProtocol: "ustb",
+    reportSlug: "superstate-ustb",
     items: [
       {
         label: "NAV/Share Monotonicity",

--- a/src/pages/monitoring.astro
+++ b/src/pages/monitoring.astro
@@ -102,10 +102,18 @@ if (API_URL) {
                 </li>
               ))}
             </ul>
-            <a class="history-link" href={`/monitoring/${p.id}/`}>
-              View alert history
-              <span aria-hidden="true">&rarr;</span>
-            </a>
+            <div class="monitor-links">
+              <a class="history-link" href={`/monitoring/${p.id}/`}>
+                View alert history
+                <span aria-hidden="true">&rarr;</span>
+              </a>
+              {p.reportSlug && (
+                <a class="report-link" href={`/report/${p.reportSlug}/`}>
+                  View risk report
+                  <span aria-hidden="true">&rarr;</span>
+                </a>
+              )}
+            </div>
           </div>
         </div>
       );
@@ -560,23 +568,37 @@ if (API_URL) {
     flex-shrink: 0;
   }
 
-  /* Link from a card to its per-protocol detail page */
-  .history-link {
+  /* Links from a card to detail page / risk report */
+  .monitor-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.85rem;
+  }
+  .history-link,
+  .report-link {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
-    margin-top: 0.85rem;
     font-size: 0.82rem;
     font-weight: 600;
+  }
+  .history-link {
     color: var(--brand-blue);
   }
-  .history-link:hover {
+  .report-link {
+    color: var(--text-secondary);
+  }
+  .history-link:hover,
+  .report-link:hover {
     text-decoration: underline;
   }
-  .history-link span {
+  .history-link span,
+  .report-link span {
     transition: transform 0.2s;
   }
-  .history-link:hover span {
+  .history-link:hover span,
+  .report-link:hover span {
     transform: translateX(2px);
   }
 

--- a/src/pages/monitoring/[id].astro
+++ b/src/pages/monitoring/[id].astro
@@ -41,7 +41,6 @@ const apiProtocol = protocol.apiProtocol ?? "";
       <h1>{protocol.name}</h1>
       <div class="detail-meta">
         <span class="meta-pill">{protocol.items.length} monitors</span>
-        <span class="meta-pill meta-pill--blue">{protocol.frequency}</span>
       </div>
     </div>
   </div>
@@ -85,8 +84,18 @@ const apiProtocol = protocol.apiProtocol ?? "";
         </label>
       </div>
     )}
-    <div class="alert-history" id="alert-history" data-api-protocol={apiProtocol}>
-      <div class="history-empty">Loading recent alerts…</div>
+    <table class="alert-table" id="alert-table" data-api-protocol={apiProtocol} hidden>
+      <thead>
+        <tr>
+          <th>Message</th>
+          <th>Severity</th>
+          <th>Time</th>
+        </tr>
+      </thead>
+      <tbody id="alert-tbody"></tbody>
+    </table>
+    <div class="history-empty" id="history-empty" data-api-protocol={apiProtocol}>
+      Loading recent alerts…
     </div>
     <div class="history-more" id="history-more" hidden>
       <button type="button" class="load-more-btn" id="load-more">Load more</button>
@@ -99,10 +108,10 @@ const apiProtocol = protocol.apiProtocol ?? "";
   </section>
 
   <script>
+    import { marked } from "marked";
     import {
       fetchAlerts,
       severityMeta,
-      SEVERITY_META,
       formatRelativeTime,
       formatTimestamp,
       escapeHtml,
@@ -110,21 +119,22 @@ const apiProtocol = protocol.apiProtocol ?? "";
       type Severity,
     } from "../../lib/monitoring";
 
-    const root = document.getElementById("alert-history");
+    const table = document.getElementById("alert-table") as HTMLTableElement | null;
+    const tbody = document.getElementById("alert-tbody") as HTMLTableSectionElement | null;
+    const emptyDiv = document.getElementById("history-empty");
     const statusEl = document.getElementById("history-status");
     const moreWrap = document.getElementById("history-more");
     const moreBtn = document.getElementById("load-more") as HTMLButtonElement | null;
     const sevSel = document.getElementById("filter-severity") as HTMLSelectElement | null;
     const srcSel = document.getElementById("filter-source") as HTMLSelectElement | null;
-    const proto = root?.dataset.apiProtocol || "";
+    const proto = table?.dataset.apiProtocol || "";
 
     const PAGE = 20;
     const REFRESH_MS = 60000;
 
     let cursor: string | null = null;
     let maxId = 0;
-    let generation = 0; // bumped on each (re)load so stale fetches can't write to the DOM
-    let listEl: HTMLUListElement | null = null;
+    let generation = 0;
 
     function filters(): { protocol: string; severity?: Severity; source?: string } {
       return {
@@ -136,35 +146,28 @@ const apiProtocol = protocol.apiProtocol ?? "";
 
     function renderAlert(alert: AlertEvent): string {
       const meta = severityMeta(alert.severity);
-      const known = Boolean(SEVERITY_META[alert.severity]);
-      // Only show parts that carry signal. Most alerts have a null severity and source
-      // "protocol", so rendering those verbatim ("Unknown · protocol") is just noise — show the
-      // severity chip only for a known level, and the source only when it isn't the default.
-      const parts: string[] = [];
-      if (known) {
-        parts.push(
-          `<span class="alert-sev" style="color:${meta.color}">${meta.emoji} ${escapeHtml(meta.label)}</span>`,
-        );
+
+      let msg: string;
+      if (alert.plain_text) {
+        msg = escapeHtml(alert.message);
+      } else {
+        msg = marked.parse(alert.message, { async: false }) as string;
       }
-      if (alert.source && alert.source !== "protocol") {
-        parts.push(`<span>${escapeHtml(alert.source)}</span>`);
-      }
-      parts.push(
-        `<time datetime="${escapeHtml(alert.created_at)}" title="${escapeHtml(formatTimestamp(alert.created_at))}">${escapeHtml(formatRelativeTime(alert.created_at))}</time>`,
-      );
+
+      const timeTitle = escapeHtml(formatTimestamp(alert.created_at));
+      const timeLabel = escapeHtml(formatRelativeTime(alert.created_at));
+
       return `
-        <li class="alert-row">
-          <span class="alert-dot" style="background:${meta.color}"${known ? ` title="${escapeHtml(meta.label)}"` : ""}></span>
-          <div class="alert-body">
-            <p class="alert-message">${escapeHtml(alert.message)}</p>
-            <div class="alert-meta">${parts.join('<span class="alert-sep">·</span>')}</div>
-          </div>
-        </li>`;
+        <tr class="alert-row">
+          <td class="alert-cell alert-cell--msg">${msg}</td>
+          <td class="alert-cell alert-cell--sev">${escapeHtml(meta.label)}</td>
+          <td class="alert-cell alert-cell--time"><time datetime="${escapeHtml(alert.created_at)}" title="${timeTitle}">${timeLabel}</time></td>
+        </tr>`;
     }
 
     function setStatus() {
       if (statusEl) {
-        const n = listEl?.children.length ?? 0;
+        const n = tbody?.children.length ?? 0;
         statusEl.textContent = n ? `${n} shown` : "";
       }
     }
@@ -178,15 +181,37 @@ const apiProtocol = protocol.apiProtocol ?? "";
       }
     }
 
-    function showState(cls: string, html: string) {
-      if (root) root.innerHTML = `<div class="${cls}">${html}</div>`;
-      listEl = null;
+    function showEmpty(html: string) {
+      if (table) table.hidden = true;
+      if (emptyDiv) {
+        emptyDiv.innerHTML = html;
+        emptyDiv.hidden = false;
+        emptyDiv.className = "history-empty";
+      }
+      if (tbody) tbody.innerHTML = "";
       if (moreWrap) moreWrap.hidden = true;
       setStatus();
     }
 
+    function showError(html: string) {
+      if (table) table.hidden = true;
+      if (emptyDiv) {
+        emptyDiv.innerHTML = html;
+        emptyDiv.hidden = false;
+        emptyDiv.className = "history-error";
+      }
+      if (tbody) tbody.innerHTML = "";
+      if (moreWrap) moreWrap.hidden = true;
+      setStatus();
+    }
+
+    function showTable() {
+      if (table) table.hidden = false;
+      if (emptyDiv) emptyDiv.hidden = true;
+    }
+
     async function loadFirst() {
-      if (!root) return;
+      if (!tbody) return;
       const gen = ++generation;
       if (statusEl) statusEl.textContent = "Loading…";
       if (moreWrap) moreWrap.hidden = true;
@@ -195,31 +220,26 @@ const apiProtocol = protocol.apiProtocol ?? "";
         resp = await fetchAlerts({ ...filters(), limit: PAGE });
       } catch {
         if (gen === generation) {
-          showState("history-error", "Couldn't load alert history right now. Please try again later.");
+          showError("Couldn't load alert history right now. Please try again later.");
         }
         return;
       }
-      if (gen !== generation) return; // superseded by a newer filter change
+      if (gen !== generation) return;
       if (!resp.data.length) {
         maxId = 0;
         cursor = null;
-        showState(
-          "history-empty",
-          "No alerts match — this protocol is monitored but nothing has fired for this filter.",
-        );
+        showEmpty("No alerts match — this protocol is monitored but nothing has fired for this filter.");
         return;
       }
-      root.innerHTML = '<ul class="alert-list"></ul>';
-      listEl = root.querySelector(".alert-list");
-      if (listEl) listEl.innerHTML = resp.data.map(renderAlert).join("");
+      showTable();
+      tbody.innerHTML = resp.data.map(renderAlert).join("");
       maxId = resp.data[0].id;
       setMore(resp.next_cursor);
       setStatus();
     }
 
     async function loadMore() {
-      // The disabled button is the re-entrancy guard (loadMore is only fired by its click).
-      if (!moreBtn || moreBtn.disabled || !listEl || !cursor) return;
+      if (!moreBtn || moreBtn.disabled || !tbody || !cursor) return;
       const gen = generation;
       moreBtn.disabled = true;
       moreBtn.textContent = "Loading…";
@@ -231,15 +251,14 @@ const apiProtocol = protocol.apiProtocol ?? "";
         moreBtn.disabled = false;
         return;
       }
-      if (gen !== generation || !listEl) return; // superseded by a filter change (which resets the button)
-      listEl.insertAdjacentHTML("beforeend", resp.data.map(renderAlert).join(""));
-      setMore(resp.next_cursor); // re-enables the button
+      if (gen !== generation || !tbody) return;
+      tbody.insertAdjacentHTML("beforeend", resp.data.map(renderAlert).join(""));
+      setMore(resp.next_cursor);
       setStatus();
     }
 
-    // Poll the newest page and prepend alerts above the current top, respecting active filters.
     async function pollNew() {
-      if (!listEl) return;
+      if (!tbody) return;
       const gen = generation;
       let resp;
       try {
@@ -247,18 +266,18 @@ const apiProtocol = protocol.apiProtocol ?? "";
       } catch {
         return;
       }
-      if (gen !== generation || !listEl) return;
+      if (gen !== generation || !tbody) return;
       const fresh = resp.data.filter((a) => a.id > maxId);
       if (!fresh.length) return;
-      listEl.insertAdjacentHTML("afterbegin", fresh.map(renderAlert).join(""));
+      tbody.insertAdjacentHTML("afterbegin", fresh.map(renderAlert).join(""));
       maxId = fresh[0].id;
       setStatus();
     }
 
     function start() {
-      if (!root) return;
+      if (!tbody && !emptyDiv) return;
       if (!proto) {
-        showState("history-empty", "Live alert history is not yet available for this protocol.");
+        showEmpty("Live alert history is not yet available for this protocol.");
         return;
       }
       loadFirst();
@@ -340,12 +359,6 @@ const apiProtocol = protocol.apiProtocol ?? "";
     font-weight: 500;
     font-variant-numeric: tabular-nums;
   }
-  .meta-pill--blue {
-    background: color-mix(in srgb, var(--brand-blue) 12%, transparent);
-    color: #7eb4ff;
-    border: 1px solid color-mix(in srgb, var(--brand-blue) 25%, transparent);
-  }
-
   /* === Sections === */
   .section {
     margin-bottom: 2.5rem;
@@ -405,50 +418,63 @@ const apiProtocol = protocol.apiProtocol ?? "";
   }
 
   /* === Alert history === */
-  .alert-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+  .alert-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+  }
+  .alert-table thead {
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+  }
+  .alert-table th {
+    text-align: left;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+    padding: 0.3rem 0.5rem 0.5rem;
+    white-space: nowrap;
   }
   .alert-row {
-    display: flex;
-    gap: 0.75rem;
-    padding: 0.85rem 0;
-    border-bottom: 1px solid color-mix(in srgb, var(--border) 45%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 30%, transparent);
   }
   .alert-row:last-child {
     border-bottom: none;
   }
-  .alert-dot {
-    width: 9px;
-    height: 9px;
-    border-radius: 50%;
-    margin-top: 0.4rem;
-    flex-shrink: 0;
+  .alert-cell {
+    padding: 0.55rem 0.5rem;
+    vertical-align: top;
   }
-  .alert-body {
-    min-width: 0;
-  }
-  .alert-message {
-    margin: 0 0 0.3rem;
-    font-size: 0.9rem;
-    line-height: 1.45;
+  .alert-cell--msg {
     color: var(--text-primary);
+    line-height: 1.45;
     word-break: break-word;
   }
-  .alert-meta {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    flex-wrap: wrap;
-    font-size: 0.76rem;
+  .alert-cell--msg p {
+    margin: 0;
+  }
+  .alert-cell--msg code {
+    font-size: 0.8rem;
+    background: color-mix(in srgb, var(--bg-secondary) 70%, transparent);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+  }
+  .alert-cell--msg a {
+    color: var(--brand-blue);
+  }
+  .alert-cell--sev {
+    white-space: nowrap;
+    font-size: 0.8rem;
     color: var(--text-secondary);
   }
-  .alert-sev {
-    font-weight: 600;
-  }
-  .alert-sep {
-    opacity: 0.4;
+  .alert-cell--time {
+    white-space: nowrap;
+    text-align: right;
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+    min-width: 80px;
   }
 
   .history-empty,

--- a/src/pages/reports.astro
+++ b/src/pages/reports.astro
@@ -37,10 +37,6 @@ const tierCounts = tierOrder.map((t) => ({
 
 <BaseLayout title="Reports — Yearn Curation" ogUrl="/reports/" ogImage="/og/default.png">
   <section class="reports-hero">
-    <div class="section-eyebrow">
-      <span class="pulse-dot"></span>
-      All assessments
-    </div>
     <h1>Risk Assessment Reports</h1>
     <p class="reports-sub">
       Independent assessments across DeFi protocols, vaults and assets.
@@ -273,30 +269,6 @@ const tierCounts = tierOrder.map((t) => ({
   .reports-hero {
     padding: 2rem 0 1.5rem;
     text-align: center;
-  }
-  .section-eyebrow {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    color: var(--brand-blue);
-    font-size: 0.72rem;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-  }
-  .pulse-dot {
-    width: 6px;
-    height: 6px;
-    background: var(--brand-blue);
-    border-radius: 50%;
-    box-shadow: 0 0 0 0 rgba(6, 117, 249, 0.6);
-    animation: pulse 2s ease-out infinite;
-  }
-  @keyframes pulse {
-    0% { box-shadow: 0 0 0 0 rgba(6, 117, 249, 0.6); }
-    70% { box-shadow: 0 0 0 8px rgba(6, 117, 249, 0); }
-    100% { box-shadow: 0 0 0 0 rgba(6, 117, 249, 0); }
   }
   .reports-hero h1 {
     font-size: clamp(1.75rem, 3.4vw, 2.4rem);
@@ -727,7 +699,4 @@ const tierCounts = tierOrder.map((t) => ({
     color: var(--text-secondary);
   }
 
-  @media (prefers-reduced-motion: reduce) {
-    .pulse-dot { animation: none; }
-  }
 </style>

--- a/src/pages/tokens.astro
+++ b/src/pages/tokens.astro
@@ -60,10 +60,6 @@ const uniqueTokens = [...new Set(dependencies.map((d: any) => d.asset))].sort();
 
 <BaseLayout title="Token Exposures — Yearn Curation" ogUrl="/tokens/" ogImage="/og/default.png">
   <section class="page-hero">
-    <div class="section-eyebrow">
-      <span class="pulse-dot"></span>
-      Cross-protocol exposure
-    </div>
     <h1>Token Exposures</h1>
     <p class="page-sub">
       Where assets in curated protocols overlap. If a shared token depegs or


### PR DESCRIPTION
## Summary

### Report links on monitoring cards
Adds a `reportSlug` field to monitoring protocols, mapping to existing risk report slugs. Monitoring card accordion panels now show a "View risk report" link next to "View alert history" when a report exists.

Protocols with linked reports (10):
| Protocol | Report |
|---|---|
| 3Jane | `3jane-usd3` |
| Aave V3 | `aave-sgho` |
| CAP | `cap-stcusd` |
| Fluid | `fluid` |
| Infinifi | `infinifi` |
| Maker DAO | `sky-usds` |
| Maple Finance | `maple-syrupusdc` |
| RToken (ETH+) | `reserve-ethplus` |
| Strata | `strata-srusde` |
| Superstate USTB | `superstate-ustb` |

Mapping is in `SLUG_TO_REPORT` in `src/data/monitoring.ts` — works for both API-fetched and static fallback data paths.

### Alert history page table layout
`/monitoring/[id]/` pages now render alerts in a table:

| Message | Severity | Time |
|---|---|---|
| ...markdown rendered... | Critical / High / Medium / Low | 2h ago |

- Messages render as **markdown** via `marked` when `plain_text: false`
- Severity shows **plain text label** — no colored dots, no emoji
- Severity and source filters remain functional

### Chores
- Remove "All assessments" eyebrow from `/reports/` hero
- Remove "Cross-protocol exposure" eyebrow from `/tokens/` hero
- Remove unused `.section-eyebrow`/`.pulse-dot` CSS from reports page

## Files changed
| File | Change |
|---|---|
| `src/data/monitoring.ts` | Added `reportSlug` to `Protocol` interface, `SLUG_TO_REPORT` mapping, wired into `transformApiProtocols` and all `FALLBACK_PROTOCOLS` entries |
| `src/pages/monitoring.astro` | Added "View risk report" link in accordion panels, CSS for `.monitor-links` and `.report-link` |
| `src/pages/monitoring/[id].astro` | Replaced `<ul>` alert list with `<table>` — Message/Severity/Time columns. Markdown rendering via `marked`. Removed severity coloring/icons. Removed unused `frequency` reference and `.meta-pill--blue` CSS. |
| `src/pages/reports.astro` | Removed "All assessments" eyebrow + orphaned CSS |
| `src/pages/tokens.astro` | Removed "Cross-protocol exposure" eyebrow |

## Validation
- [x] `npm run build` passes with 101 pages
- [x] 10 report links rendered in `/monitoring/`
- [x] Alert detail pages render table structure
- [x] No `frequency` references remain in monitoring pages