### PR TITLE
Fix reassessment status tag handling

### DIFF
--- a/.github/ISSUE_TEMPLATE/risk-assessment-request.yml
+++ b/.github/ISSUE_TEMPLATE/risk-assessment-request.yml
@@ -1,7 +1,7 @@
 name: Risk Assessment Request
 description: Request a risk assessment for a protocol or asset
 title: "Risk Assessment: "
-labels: ["Report Request"]
+labels: ["Report Requested"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/risk-assessment-request.yml
+++ b/.github/ISSUE_TEMPLATE/risk-assessment-request.yml
@@ -1,7 +1,7 @@
 name: Risk Assessment Request
 description: Request a risk assessment for a protocol or asset
 title: "Risk Assessment: "
-labels: ["risk-assessment"]
+labels: ["Report Request"]
 body:
   - type: markdown
     attributes:

--- a/scripts/check_stale_reports.py
+++ b/scripts/check_stale_reports.py
@@ -29,6 +29,7 @@ PUBLIC_REPORT_BASE_URL = "https://risk.yearn.farm/report"
 
 ASSESSMENT_LINE_RE = re.compile(r"\*\*Assessment Date:\*\*\s*([^\n]+)", re.IGNORECASE)
 WARNING_LINE_RE = re.compile(r"\*\*Warning:\*\*\s*([^\n]+)", re.IGNORECASE)
+STATUS_LINE_RE = re.compile(r"\*\*Status:\*\*\s*([^\n]+)", re.IGNORECASE)
 DATE_RE = re.compile(
     r"\b("
     r"January|February|March|April|May|June|July|August|September|October|November|December"
@@ -36,6 +37,13 @@ DATE_RE = re.compile(
 )
 TITLE_RE = re.compile(r"^#\s+(.+)$", re.MULTILINE)
 SCORE_RE = re.compile(r"\*\*Final Score:\s*([\d.]+)\s*/\s*5\.0\*\*")
+TERMINAL_STATUSES = {
+    "HACKED",
+    "DEAD",
+    "DEPRECATED",
+    "WIND-DOWN",
+    "WINDDOWN",
+}
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger("stale-reports")
@@ -64,6 +72,28 @@ def parse_assessment_date(content: str) -> datetime | None:
     return max(dates) if dates else None
 
 
+def header_block(content: str) -> str:
+    """Return the title/metadata block before the first report section."""
+    return content.split("\n## ", 1)[0]
+
+
+def normalize_status(raw: str | None) -> str | None:
+    """Return the normalized status tag, matching the website parser."""
+    if not raw:
+        return None
+    status = re.split(r"[\s(]", raw.strip().upper(), maxsplit=1)[0]
+    status = re.sub(r"[^A-Z-]", "", status)
+    return status or None
+
+
+def terminal_status(header: str) -> str | None:
+    match = STATUS_LINE_RE.search(header)
+    status = normalize_status(match.group(1) if match else None)
+    if status in TERMINAL_STATUSES:
+        return status
+    return None
+
+
 def git_last_modified(path: Path) -> datetime | None:
     try:
         out = subprocess.check_output(
@@ -79,11 +109,12 @@ def git_last_modified(path: Path) -> datetime | None:
 
 def parse_report(path: Path) -> dict:
     content = path.read_text()
+    header = header_block(content)
     title_match = TITLE_RE.search(content)
     title = title_match.group(1).strip() if title_match else path.stem
-    score_match = SCORE_RE.search(content)
+    score_match = SCORE_RE.search(header)
     score = score_match.group(1) if score_match else None
-    warning_match = WARNING_LINE_RE.search(content)
+    warning_match = WARNING_LINE_RE.search(header)
     warning = warning_match.group(1).strip() if warning_match else None
 
     date = parse_assessment_date(content)
@@ -100,6 +131,7 @@ def parse_report(path: Path) -> dict:
         "date": date,
         "date_source": source,
         "warning": warning,
+        "terminal_status": terminal_status(header),
     }
 
 
@@ -231,6 +263,14 @@ def main() -> int:
     failed_count = 0
     for path in sorted(REPORTS_DIR.glob("*.md")):
         report = parse_report(path)
+        if report["terminal_status"]:
+            log.info(
+                "SKIP %s — terminal status: %s",
+                report["slug"],
+                report["terminal_status"],
+            )
+            skipped_count += 1
+            continue
         if report["warning"]:
             log.info(
                 "SKIP %s — terminal warning: %s",

--- a/scripts/check_stale_reports.py
+++ b/scripts/check_stale_reports.py
@@ -28,7 +28,6 @@ DEFAULT_REPO = "yearn/risk-score"
 PUBLIC_REPORT_BASE_URL = "https://risk.yearn.farm/report"
 
 ASSESSMENT_LINE_RE = re.compile(r"\*\*Assessment Date:\*\*\s*([^\n]+)", re.IGNORECASE)
-WARNING_LINE_RE = re.compile(r"\*\*Warning:\*\*\s*([^\n]+)", re.IGNORECASE)
 STATUS_LINE_RE = re.compile(r"\*\*Status:\*\*\s*([^\n]+)", re.IGNORECASE)
 DATE_RE = re.compile(
     r"\b("
@@ -114,9 +113,6 @@ def parse_report(path: Path) -> dict:
     title = title_match.group(1).strip() if title_match else path.stem
     score_match = SCORE_RE.search(header)
     score = score_match.group(1) if score_match else None
-    warning_match = WARNING_LINE_RE.search(header)
-    warning = warning_match.group(1).strip() if warning_match else None
-
     date = parse_assessment_date(content)
     source = "report-header"
     if date is None:
@@ -130,7 +126,6 @@ def parse_report(path: Path) -> dict:
         "score": score,
         "date": date,
         "date_source": source,
-        "warning": warning,
         "terminal_status": terminal_status(header),
     }
 
@@ -268,14 +263,6 @@ def main() -> int:
                 "SKIP %s — terminal status: %s",
                 report["slug"],
                 report["terminal_status"],
-            )
-            skipped_count += 1
-            continue
-        if report["warning"]:
-            log.info(
-                "SKIP %s — terminal warning: %s",
-                report["slug"],
-                report["warning"],
             )
             skipped_count += 1
             continue

--- a/tests/test_check_stale_reports.py
+++ b/tests/test_check_stale_reports.py
@@ -1,6 +1,8 @@
 import os
+import tempfile
 import unittest
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest import mock
 
 import scripts.check_stale_reports as stale_reports
@@ -57,6 +59,58 @@ class BuildIssueBodyTests(unittest.TestCase):
             ),
         ):
             self.assertEqual(stale_reports.repo_slug(), "yearn/risk-score")
+
+
+class ParseReportTests(unittest.TestCase):
+    def parse_content(self, content: str) -> dict:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "sample.md"
+            path.write_text(content)
+            return stale_reports.parse_report(path)
+
+    def test_terminal_status_in_header_is_extracted(self):
+        report = self.parse_content(
+            "# Protocol Risk Assessment: Dead Project\n\n"
+            "- **Assessment Date:** March 3, 2026\n"
+            "- **Final Score: N/A**\n"
+            "- **Status:** DEAD\n\n"
+            "## Overview + Links\n"
+        )
+
+        self.assertEqual(report["terminal_status"], "DEAD")
+
+    def test_hacked_status_with_annotation_is_extracted(self):
+        report = self.parse_content(
+            "# Protocol Risk Assessment: Hacked Project\n\n"
+            "- **Assessment Date:** February 8, 2026 (Updated: March 22, 2026)\n"
+            "- **Final Score: N/A**\n"
+            "- **Status:** HACKED (March 22, 2026)\n\n"
+            "## Overview + Links\n"
+        )
+
+        self.assertEqual(report["terminal_status"], "HACKED")
+
+    def test_caution_status_does_not_skip_reassessment(self):
+        report = self.parse_content(
+            "# Protocol Risk Assessment: Gated Project\n\n"
+            "- **Assessment Date:** March 3, 2026\n"
+            "- **Final Score: 3.2/5.0**\n"
+            "- **Status:** GATED -- score capped by a critical gate\n\n"
+            "## Overview + Links\n"
+        )
+
+        self.assertIsNone(report["terminal_status"])
+
+    def test_body_status_line_is_ignored(self):
+        report = self.parse_content(
+            "# Protocol Risk Assessment: Active Project\n\n"
+            "- **Assessment Date:** March 3, 2026\n"
+            "- **Final Score: 2.4/5.0**\n\n"
+            "## Overview + Links\n\n"
+            "**Status:** HACKED appears in quoted third-party content.\n"
+        )
+
+        self.assertIsNone(report["terminal_status"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Skip stale reassessment issue creation for terminal report statuses such as HACKED and DEAD
- Scope status, warning, and score parsing to the report header metadata
- Apply the new Report Requested label to Risk Assessment Request issue forms

## Validation
- PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q tests/test_check_stale_reports.py
- uv run ruff check scripts/check_stale_reports.py tests/test_check_stale_reports.py
- DRY_RUN=true uv run scripts/check_stale_reports.py