### PR TITLE
feat(web): new/updated tag + score history on report pages

### DIFF
--- a/reports/TEMPLATE.md
+++ b/reports/TEMPLATE.md
@@ -1,6 +1,14 @@
 # Protocol Risk Assessment: [Protocol Name]
 
 - **Assessment Date:** [Month Day, Year]
+<!--
+  Keep the ORIGINAL assessment date here. When a report is reassessed/updated,
+  do NOT overwrite it — append the new date in parentheses, e.g.:
+    - **Assessment Date:** May 27, 2026 (Updated: June 17, 2026)
+  The website reads both: the earliest date becomes "Original", the latest
+  becomes "Latest", and the page is tagged "Updated report". Overwriting the
+  single date loses that history and the report shows as brand new.
+-->
 - **Token:** [Token Name]
 - **Chain:** [Chain Name]
 - **Token Address:** [`[Token Address]`]([Token Explorer Link])
@@ -393,3 +401,17 @@ Not Rated: for terminal reports (Status: HACKED / DEAD), set Final Score to
 - **Time-based**: Reassess in [X months]
 - **TVL-based**: Reassess if TVL changes by more than [X%]
 - **Incident-based**: Reassess after any exploit, governance change, or collateral modification
+
+## Assessment History
+
+<!--
+  One row per assessment, oldest first. Add a new row on every reassessment —
+  never edit past rows. The website renders this table at the bottom of the
+  report so score changes are traceable over time. Keep the date format
+  consistent with the header "Assessment Date". Score is the Final Score at that
+  point in time (or the status tag, e.g. HACKED, for Not Rated reports).
+-->
+
+| Date | Score | Notes |
+| --- | --- | --- |
+| [Month Day, Year] | [X.X] | Initial assessment |

--- a/reports/reassessment/SKILL.md
+++ b/reports/reassessment/SKILL.md
@@ -50,7 +50,10 @@ Do not spend time redoing static background unless a mutable fact changed. Do no
    - mint authority or privileged supply paths
    If any changed, update `reports/graph/<slug>.yaml` using `reports/graph/SKILL.md`. If no graph exists, create one when the report has enough data; otherwise mark the missing graph inputs as `TODO`.
 6. Patch only affected sections **in place**. Do not add a "Reassessment Notes", changelog, or "what changed" section to the report body. Common sections:
-   - header assessment date / updated date
+   - header assessment date: keep the original date and append the new one in
+     parentheses, e.g. `- **Assessment Date:** May 27, 2026 (Updated: June 17, 2026)`.
+     Never overwrite the original date — the website derives "Original" vs
+     "Latest" and the "Updated report" tag from both dates.
    - Overview + Links
    - Contract Addresses
    - Funds Management
@@ -59,6 +62,11 @@ Do not spend time redoing static background unless a mutable fact changed. Do no
    - Risk Summary
    - Risk Score Assessment
    - Reassessment Triggers
+   - Assessment History — append one new row (`| Date | Score | Notes |`) for
+     this reassessment; never edit prior rows. Use the same date as the header
+     and the new Final Score (or status tag for Not Rated). If the report has no
+     "## Assessment History" section yet, add one (see `reports/TEMPLATE.md`),
+     seeding a row for the original assessment before the new one.
    - appendices with allocation tables or role tables
 7. If a value cannot be verified, mark it `TODO` and say what source/function is missing.
 8. Summarize:

--- a/reports/report/3jane-usd3.md
+++ b/reports/report/3jane-usd3.md
@@ -596,3 +596,10 @@ The tier is **Medium** (3.4/5.0). Risk drivers: (1) the April 2026 shutdown demo
 - **Dependency-based:** Reassess if Aave V3, EigenLayer AVS, or Hypernative experience significant security events
 - **Phase-based:** Reassess when Phase 1 bootstrapping ends and full unsecured lending is active
 
+## Assessment History
+
+| Date | Score | Notes |
+| --- | --- | --- |
+| March 4, 2026 | 3.5 | Initial assessment |
+| July 3, 2026 | 3.4 | Reassessment after April 2026 emergency shutdown |
+

--- a/reports/report/infinifi.md
+++ b/reports/report/infinifi.md
@@ -711,5 +711,5 @@ Treat current InfiniFi exposure as primarily a credit exposure to **(a) a tokeni
 | Date | Score | Notes |
 | --- | --- | --- |
 | February 4, 2026 | 2.3 | Initial assessment |
-| May 18, 2026 | 3.2 | Reassessment — Liquidity 2.0→4.0: iUSD redemption queue-only pending maturity wave; multisig gained EXECUTOR_ROLE on Long Timelock |
+| May 18, 2026 | 3.2 | Reassessment — Liquidity 2.0→4.0: iUSD redemption queue-only pending maturity wave |
 | July 4, 2026 | 3.4 | Reassessment — offchain concentration up, TVL down |

--- a/reports/report/infinifi.md
+++ b/reports/report/infinifi.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: InfiniFi
 
-- **Assessment Date:** July 4, 2026
+- **Assessment Date:** February 4, 2026 (Updated: July 4, 2026)
 - **Token:** siUSD (Staked iUSD)
 - **Chain:** Ethereum Mainnet
 - **Token Address:** [`0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB`](https://etherscan.io/address/0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB)
@@ -705,3 +705,11 @@ Treat current InfiniFi exposure as primarily a credit exposure to **(a) a tokeni
 - Onchain: `FarmRegistry.getFarms()` / `getTypeFarms()`, per-farm `assets()` and `maturity()`, per-escrow `receiver()`/`totalAssets()`, `Accounting.totalAssetsValue()` and `.totalAssetsValueOf(uint256)` (verified 2026-07-04).
 - [DefiLlama](https://defillama.com/protocol/infinifi) — TVL cross-check ($65.3M on 2026-07-04).
 - [InfiniFi Transparency Dashboard](https://stats.infinifi.xyz/) — cross-checked but not used as the primary source.
+
+## Assessment History
+
+| Date | Score | Notes |
+| --- | --- | --- |
+| February 4, 2026 | 2.3 | Initial assessment |
+| May 18, 2026 | 3.2 | Reassessment |
+| July 4, 2026 | 3.4 | Reassessment — offchain concentration up, TVL down |

--- a/reports/report/infinifi.md
+++ b/reports/report/infinifi.md
@@ -711,5 +711,5 @@ Treat current InfiniFi exposure as primarily a credit exposure to **(a) a tokeni
 | Date | Score | Notes |
 | --- | --- | --- |
 | February 4, 2026 | 2.3 | Initial assessment |
-| May 18, 2026 | 3.2 | Reassessment |
+| May 18, 2026 | 3.2 | Reassessment — high concentration in APYX (apxUSD) |
 | July 4, 2026 | 3.4 | Reassessment — offchain concentration up, TVL down |

--- a/reports/report/infinifi.md
+++ b/reports/report/infinifi.md
@@ -711,5 +711,5 @@ Treat current InfiniFi exposure as primarily a credit exposure to **(a) a tokeni
 | Date | Score | Notes |
 | --- | --- | --- |
 | February 4, 2026 | 2.3 | Initial assessment |
-| May 18, 2026 | 3.2 | Reassessment — high concentration in APYX (apxUSD) |
+| May 18, 2026 | 3.2 | Reassessment — Liquidity 2.0→4.0: iUSD redemption queue-only pending maturity wave; multisig gained EXECUTOR_ROLE on Long Timelock |
 | July 4, 2026 | 3.4 | Reassessment — offchain concentration up, TVL down |

--- a/src/lib/parseReport.ts
+++ b/src/lib/parseReport.ts
@@ -36,6 +36,12 @@ export interface ReportMeta {
   date: string;
   /** Effective date for sorting (uses (Updated: ...) when present). 0 if unparseable. */
   dateSortable: number;
+  /** Earliest (original) assessment date, human-readable. Falls back to `date`. */
+  originalDate: string;
+  /** Most recent assessment/reassessment date, human-readable. Falls back to `date`. */
+  latestDate: string;
+  /** True when the report has been reassessed/updated at least once. */
+  isUpdated: boolean;
   token: string;
   chain: string;
   /** null when Not Rated: a terminal status (HACKED/DEAD) or an explicit "Final Score: N/A". */
@@ -56,11 +62,20 @@ export interface CategoryScore {
   weighted: number;
 }
 
+/** One row of the "Assessment History" table — a point-in-time score snapshot. */
+export interface HistoryEntry {
+  date: string;
+  score: string;
+  notes: string;
+}
+
 export interface ReportData extends ReportMeta {
   overviewHtml: string;
   scoreTable: CategoryScore[];
   riskSummaryHtml: string;
   fullReportHtml: string;
+  /** Chronological score history (oldest first). Synthesized from meta when the report has no table yet. */
+  history: HistoryEntry[];
 }
 
 const TYPE_OVERRIDES: Record<string, "Protocol" | "Asset"> = {
@@ -112,6 +127,41 @@ function parseDateSortable(raw: string): number {
   return Number.isNaN(t) ? 0 : t;
 }
 
+// Keywords that flag a report as reassessed/updated even when the parenthetical
+// carries no explicit second date (e.g. "(reassessment; vault unpaused ...)").
+const REASSESS_KEYWORDS = /updated|reassess|recheck|refresh|prior assessment|previous/i;
+// Matches month-name dates like "July 3, 2026", "Feb 12, 2026", "April 22, 2026".
+const HUMAN_DATE = /[A-Z][a-z]+\.?\s+\d{1,2},?\s+\d{4}/g;
+
+/**
+ * Splits an "Assessment Date" value into its original and most-recent dates and
+ * decides whether the report is an update of an earlier assessment. Handles the
+ * varied conventions in the reports: "(Updated: X)", "(reassessed X)",
+ * "(reassessment; prior assessments A; B)", "(rechecked A; refreshed B)", etc.
+ * Uses the earliest date found as the original and the latest as the current one,
+ * which is correct whether the new date sits before or inside the parenthetical.
+ */
+function parseAssessmentDates(raw: string): {
+  originalDate: string;
+  latestDate: string;
+  isUpdated: boolean;
+} {
+  const fallback = raw.trim();
+  const hasKeyword = REASSESS_KEYWORDS.test(raw);
+  const dated = (raw.match(HUMAN_DATE) ?? [])
+    .map((s) => ({ s, t: Date.parse(s) }))
+    .filter((d) => !Number.isNaN(d.t))
+    .sort((a, b) => a.t - b.t);
+
+  if (dated.length === 0) {
+    return { originalDate: fallback, latestDate: fallback, isUpdated: hasKeyword };
+  }
+  const originalDate = dated[0].s;
+  const latestDate = dated[dated.length - 1].s;
+  const isUpdated = hasKeyword || dated[0].t !== dated[dated.length - 1].t;
+  return { originalDate, latestDate, isUpdated };
+}
+
 
 function parseMeta(slug: string, content: string): ReportMeta {
   const titleMatch = content.match(
@@ -151,11 +201,15 @@ function parseMeta(slug: string, content: string): ReportMeta {
   const chainStr = chainMatch?.[1]?.trim() ?? "";
 
   const dateRaw = dateMatch?.[1]?.trim() ?? "";
+  const { originalDate, latestDate, isUpdated } = parseAssessmentDates(dateRaw);
   return {
     slug,
     name,
     date: dateRaw,
     dateSortable: parseDateSortable(dateRaw),
+    originalDate,
+    latestDate,
+    isUpdated,
     token: tokenMatch?.[1]?.trim() ?? "",
     chain: chainStr,
     finalScore,
@@ -241,11 +295,44 @@ function extractFullBody(content: string): string {
     "Overview + Links",
     "Risk Summary",
     "Risk Score Assessment",
+    "Assessment History",
   ];
   const bodySections = sections
     .slice(1) // skip title/metadata block
     .filter((s) => !skipHeadings.some((h) => s.startsWith(`## ${h}`)));
   return bodySections.join("\n").trim();
+}
+
+/**
+ * Parses the optional "## Assessment History" table (Date | Score | Notes) into
+ * structured rows. When a report has no such table yet, synthesizes a single
+ * current-state row from the header so every report shows a seed to grow from.
+ */
+function parseHistory(content: string, meta: ReportMeta): HistoryEntry[] {
+  const section = extractSection(content, "Assessment History");
+  const rows = section
+    .split("\n")
+    .filter((r) => r.trim().startsWith("|"))
+    .slice(2) // skip header + separator
+    .map((row): HistoryEntry | null => {
+      const cells = row.split("|").slice(1, -1).map((c) => c.trim());
+      if (!cells[0]) return null;
+      return { date: cells[0], score: cells[1] ?? "", notes: cells[2] ?? "" };
+    })
+    .filter((r): r is HistoryEntry => r !== null);
+
+  if (rows.length > 0) return rows;
+
+  // Fallback: seed a single row from the current header.
+  const score =
+    meta.finalScore != null ? meta.finalScore.toFixed(1) : (meta.status ?? "N/A");
+  return [
+    {
+      date: meta.latestDate,
+      score,
+      notes: meta.isUpdated ? "Reassessment" : "Initial assessment",
+    },
+  ];
 }
 
 export function parseReport(slug: string, content: string): ReportData {
@@ -255,6 +342,7 @@ export function parseReport(slug: string, content: string): ReportData {
   const riskSummaryMd = extractSection(content, "Risk Summary");
   const scoreTable = parseScoreTable(content);
   const fullBodyMd = extractFullBody(content);
+  const history = parseHistory(content, meta);
 
   return {
     ...meta,
@@ -262,5 +350,6 @@ export function parseReport(slug: string, content: string): ReportData {
     scoreTable,
     riskSummaryHtml: marked.parse(riskSummaryMd, { async: false }) as string,
     fullReportHtml: marked.parse(fullBodyMd, { async: false }) as string,
+    history,
   };
 }

--- a/src/pages/report/[slug].astro
+++ b/src/pages/report/[slug].astro
@@ -45,6 +45,11 @@ const reportIssueUrl = (() => {
 >
   <a href="/reports/" class="back-link">&larr; All Reports</a>
 
+  <div class:list={["assessment-badge", report.isUpdated ? "updated" : "new"]}>
+    <span class="dot" aria-hidden="true"></span>
+    <strong>{report.isUpdated ? "Updated report" : "New report"}</strong>
+  </div>
+
   {report.status && (
     <div class:list={["status-banner", report.statusKind]}>
       <strong>
@@ -77,7 +82,19 @@ const reportIssueUrl = (() => {
       <span class="sep">/</span>
       <span>{report.chain}</span>
       <span class="sep">/</span>
-      <span>{report.date}</span>
+      {report.isUpdated ? (
+        <>
+          <span>Latest: {report.latestDate}</span>
+          {report.originalDate !== report.latestDate && (
+            <>
+              <span class="sep">/</span>
+              <span>Original: {report.originalDate}</span>
+            </>
+          )}
+        </>
+      ) : (
+        <span>{report.latestDate}</span>
+      )}
     </div>
     <div class="header-links">
       <a
@@ -142,6 +159,32 @@ const reportIssueUrl = (() => {
     <div class="prose" set:html={report.fullReportHtml} />
   </details>
 
+  {report.history.length > 0 && (
+    <section class="section">
+      <h2>Assessment History</h2>
+      <div class="history-wrap">
+        <table class="history-table">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Score</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {report.history.map((h) => (
+              <tr>
+                <td class="history-date">{h.date}</td>
+                <td class="history-score">{h.score}</td>
+                <td>{h.notes}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )}
+
   <div class="report-footer">
     <a href={reportIssueUrl} class="report-issue-btn" target="_blank" rel="noopener noreferrer">
       <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
@@ -154,6 +197,43 @@ const reportIssueUrl = (() => {
 </BaseLayout>
 
 <style>
+  .assessment-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    line-height: 1.3;
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+  }
+  .assessment-badge strong {
+    color: var(--text-primary);
+  }
+  .assessment-badge .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--text-secondary);
+  }
+  .assessment-badge.updated {
+    border-color: color-mix(in srgb, var(--brand-blue) 40%, transparent);
+    background: color-mix(in srgb, var(--brand-blue) 10%, transparent);
+  }
+  .assessment-badge.updated .dot {
+    background: var(--brand-blue);
+  }
+  .assessment-badge.new {
+    border-color: color-mix(in srgb, #16a34a 40%, transparent);
+    background: color-mix(in srgb, #16a34a 10%, transparent);
+  }
+  .assessment-badge.new .dot {
+    background: #16a34a;
+  }
   .status-banner {
     background: #dc2626;
     color: #fff;
@@ -376,6 +456,42 @@ const reportIssueUrl = (() => {
     font-weight: 600;
     font-size: 0.75rem;
     text-transform: uppercase;
+  }
+  .history-wrap {
+    overflow-x: auto;
+  }
+  .history-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+  }
+  .history-table th,
+  .history-table td {
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+    vertical-align: top;
+  }
+  .history-table th {
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    font-weight: 600;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+  .history-date {
+    white-space: nowrap;
+    color: var(--text-secondary);
+  }
+  .history-score {
+    white-space: nowrap;
+    font-weight: 700;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+  }
+  .history-table tbody tr:last-child td {
+    border-bottom: none;
   }
   .report-footer {
     margin-top: 1rem;


### PR DESCRIPTION
## Summary

Surfaces reassessment history that was previously buried inside the report markdown, answering a recurring website question: *"Is this report new or an updated version of an old one?"*

### Report page changes
- **New/Updated tag** at the top of each report (`New report` / `Updated report`).
- **Meta line splits the date** into `Latest:` / `Original:` instead of dumping the raw string. Dates are parsed from the varied conventions in the reports (`(Updated: X)`, `(reassessed X)`, `(reassessment; prior assessments A; B)`, `(rechecked A; refreshed B)`, …) by taking the earliest date as original and the latest as current.
- **`## Assessment History` table** (`Date | Score | Notes`) rendered at the bottom of each report so score changes are traceable over time. Falls back to a single current-state row (score, or status tag like `DEAD` for Not Rated) when a report has no table yet.

### Conventions (so it stays maintained)
- `reports/TEMPLATE.md` — documents the Assessment History table and the keep-the-original-date rule on `Assessment Date`.
- `reports/reassessment/SKILL.md` — reassessment workflow now appends a history row each time.

### Seeded data (verified, not guessed)
Scores/dates pulled from git history via `git show` at the relevant commits:
- `3jane-usd3`: 3.5 (Mar 4) → 3.4 (Jul 3, post emergency shutdown)
- `infinifi`: 2.3 (Feb 4) → 3.2 (May 18) → 3.4 (Jul 4)

While seeding infinifi I found it had been reassessed (2.3 → 3.2 → 3.4) but its header carried only a single date, so it wrongly showed as a new report. Fixed its `Assessment Date` to `February 4, 2026 (Updated: July 4, 2026)`.

## Validation
- `npm run build` passes (103 pages).
- Date parser verified against all 8 real-world `Assessment Date` formats found in the reports.
- Rendered history tables confirmed on the dev server for `3jane-usd3`, `infinifi`, and `buck` (terminal/fallback case).

## Follow-up
Other reports may share infinifi's header bug (reassessed but single-dated) — a repo-wide audit could flag/fix them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)