### PR TITLE
fix(web): pin canonical URL to curation.yearn.fi

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,8 @@ import vercel from "@astrojs/vercel";
 export default defineConfig({
   output: "static",
   adapter: vercel(),
-  site: process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : "https://curation.yearn.fi",
+  // Always the stable production domain. Using VERCEL_URL here leaks the
+  // per-deployment hostname (e.g. risk-score-<hash>-yearn.vercel.app) into
+  // canonical/og URLs, splitting SEO signal across throwaway aliases.
+  site: "https://curation.yearn.fi",
 });


### PR DESCRIPTION
## Problem

Production pages emitted a deployment-specific canonical:

```html
<link rel="canonical" href="https://risk-score-3odp0enl5-yearn.vercel.app/">
```

The Astro `site` config used `https://${VERCEL_URL}` when `VERCEL_URL` was set. On Vercel that variable is the **per-deployment** hostname (`risk-score-<hash>-yearn.vercel.app`), so every production build baked a throwaway alias into `<link rel="canonical">` and `og:url` (both derived from `Astro.site` in `src/layouts/BaseLayout.astro`). This splits SEO signal across deployment hostnames instead of consolidating on the real domain.

## Fix

Pin `site` to the stable production domain `https://curation.yearn.fi`.

## Validation

- Rebuilt with `VERCEL_URL=risk-score-3odp0enl5-yearn.vercel.app` set — deployment hostname no longer leaks:
  - `/` → `rel="canonical" href="https://curation.yearn.fi/"`
  - `/report/yearn-yvusdc/` → `href="https://curation.yearn.fi/report/yearn-yvusdc/"`
  - `og:url` matches the canonical.

## Note on `risk.yearn.fi`

The old `risk.yearn.fi` alias already `301`-redirects to `curation.yearn.fi` and is **not referenced anywhere in the current codebase**. Cross-org check confirmed no Yearn consumer depends on it — `ydaemon`, `kong`, `yearn.fi`, `governance-apps`, `yearn-devdocs`, and `monitoring` all already point at `curation.yearn.fi`. It can be safely deprecated/removed at the infra level (Vercel Domains + Cloudflare DNS); no repo change is needed for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)