### PR TITLE
Add first-party Plausible analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "risk-score-frontend",
       "dependencies": {
         "@astrojs/vercel": "10.0.8",
+        "@plausible-analytics/tracker": "0.4.5",
         "@resvg/resvg-js": "2.6.2",
         "astro": "6.4.2",
         "cytoscape": "3.33.4",
@@ -1131,6 +1132,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
+    },
+    "node_modules/@plausible-analytics/tracker": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@plausible-analytics/tracker/-/tracker-0.4.5.tgz",
+      "integrity": "sha512-6BfAGejXY+YA3Cw6LYT2Zpn4hTxDtPQAawFsYUsQCOg78wIS5C4deAGXTfJffa5VleMWITv5lpJ/EYuQBl1tPA==",
       "license": "MIT"
     },
     "node_modules/@resvg/resvg-js": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@astrojs/vercel": "10.0.8",
+    "@plausible-analytics/tracker": "0.4.5",
     "@resvg/resvg-js": "2.6.2",
     "astro": "6.4.2",
     "cytoscape": "3.33.4",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -75,6 +75,9 @@ const ogImageUrl = new URL(ogImage, Astro.site ?? Astro.url.origin).href;
         document.documentElement.classList.add("light");
       }
     </script>
+    <script>
+      import "../scripts/plausible";
+    </script>
   </head>
   <body class={bare ? "is-bare" : "has-bg"}>
     {!bare && (

--- a/src/scripts/plausible.ts
+++ b/src/scripts/plausible.ts
@@ -1,0 +1,11 @@
+import { init } from "@plausible-analytics/tracker";
+
+// First-party analytics: events post to a same-origin path that a
+// vercel.json rewrite proxies to plausible.io, so domain-based blockers
+// never see a third-party request. Localhost capture is off by default.
+init({
+  domain: "curation.yearn.fi",
+  endpoint: "/proxy/plausible/api/event",
+  autoCapturePageviews: true,
+  outboundLinks: true,
+});

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,10 @@
     {
       "source": "/api/monitoring/:path*",
       "destination": "/api/monitoring"
+    },
+    {
+      "source": "/proxy/plausible/:path*",
+      "destination": "https://plausible.io/:path*"
     }
   ],
   "installCommand": "npm ci"


### PR DESCRIPTION
### Summary
The site currently has no analytics, so traffic to curation.yearn.fi can't be measured. This adds Plausible the way yearn.fi runs it: the tracker is bundled into the app (`@plausible-analytics/tracker@0.4.5`, no third-party script fetch) and events POST to a same-origin path, `/proxy/plausible/api/event`, which a `vercel.json` rewrite proxies to plausible.io.

### How to review
Four small changes, in suggested order:
1. `vercel.json` — the new `/proxy/plausible/:path*` rewrite (same pattern as the existing `/cdn` and `/api/monitoring` rewrites)
2. `src/scripts/plausible.ts` — the init module (domain, endpoint, auto pageviews, outbound links)
3. `src/layouts/BaseLayout.astro` — one bundled `<script>` in the shared `<head>`, covering all pages including bare report/graph pages
4. `package.json` — one new dependency; `package-lock.json` is mechanical

Smoke test: open any page on the preview deployment and confirm the browser POSTs to `/proxy/plausible/api/event` (not to plausible.io directly).

### Test plan
- [x] Automated: `npm run build` passes; built pages load the BaseLayout module bundle containing the init with the proxy endpoint and `curation.yearn.fi` domain
- [x] Manual: on the Vercel preview deployment, `POST /proxy/plausible/api/event` returns a plausible.io response (400 for an empty payload), not a Vercel 404 — the rewrite merges cleanly with the `@astrojs/vercel` adapter output
- [ ] Manual (post-merge): visit curation.yearn.fi and confirm a pageview appears in the Plausible dashboard

### Risk / impact
Low. Analytics only — no funds, auth, or data-model changes. Plausible is cookieless and collects no PII. Rollback is a single revert. One operational prerequisite: the site `curation.yearn.fi` must be added in the Plausible dashboard; until then events are dropped harmlessly, so this can merge first.
