### PR TITLE
Reassessment: yvDAI-1 (July 12, 2026)

### DIFF
--- a/reports/graph/yearn-yvdai.yaml
+++ b/reports/graph/yearn-yvdai.yaml
@@ -67,11 +67,11 @@ nodes:
 
   # Strategies
   - id: dai-to-usdc-depositor
-    label: DAI → yvUSDC-1 Depositor (72.97%)
+    label: DAI → yvUSDC-1 Depositor (73.19%)
     address: "0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5"
     category: strategy
   - id: dai-to-usds-depositor
-    label: DAI → yvUSDS-1 Depositor (27.03%)
+    label: DAI → yvUSDS-1 Depositor (26.81%)
     address: "0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d"
     category: strategy
 
@@ -112,11 +112,11 @@ edges:
   - from: yvDAI
     to: dai-to-usdc-depositor
     kind: allocates-to
-    label: "72.97%"
+    label: "73.19%"
   - from: yvDAI
     to: dai-to-usds-depositor
     kind: allocates-to
-    label: "27.03%"
+    label: "26.81%"
 
   # Governance roles on vault
   - from: daddy

--- a/reports/graph/yearn-yvdai.yaml
+++ b/reports/graph/yearn-yvdai.yaml
@@ -85,6 +85,16 @@ nodes:
     address: "0x182863131F9a4630fF9E27830d945B1413e347E8"
     category: dependency
 
+  # External dependencies (Morpho MetaMorpho, downstream of yvUSDC-1)
+  - id: yearn-usdc-metamorpho
+    label: Yearn USDC (Morpho MetaMorpho)
+    address: "0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3"
+    category: dependency
+  - id: morpho-blue
+    label: Morpho Blue
+    address: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
+    category: dependency
+
   # External dependencies (Sky conversion infrastructure)
   - id: psm-lite
     label: MakerDAO PSM Lite (DAI ↔ USDC)
@@ -182,3 +192,13 @@ edges:
     to: yvUSDS
     kind: deposits-into
     label: "USDS → yvUSDS-1"
+
+  # yvUSDC-1 downstream: sUSDS Lender (~91.59%) and Yearn USDC MetaMorpho (~8.41%)
+  - from: yvUSDC
+    to: yearn-usdc-metamorpho
+    kind: deposits-into
+    label: "~8.41% via Yearn USDC"
+  - from: yearn-usdc-metamorpho
+    to: morpho-blue
+    kind: deposits-into
+    label: "cbBTC, WBTC, wstETH markets"

--- a/reports/report/yearn-yvdai.md
+++ b/reports/report/yearn-yvdai.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: Yearn — yvDAI-1
 
-- **Assessment Date:** May 11, 2026
+- **Assessment Date:** May 11, 2026 (Updated: July 12, 2026)
 - **Token:** yvDAI-1 (DAI-1 yVault)
 - **Chain:** Ethereum
 - **Token Address:** [`0x028eC7330ff87667b6dfb0D94b954c820195336c`](https://etherscan.io/address/0x028eC7330ff87667b6dfb0D94b954c820195336c)
@@ -8,19 +8,19 @@
 
 ## Overview + Links
 
-yvDAI-1 is a **DAI-denominated Yearn V3 vault** (ERC-4626) that deploys deposited DAI through a **vault-of-vaults composition**. At the May 11 snapshot, **72.97% routes through `DAI To USDC-1 Depositor` into yvUSDC-1**, and **27.03% routes through `DAI to USDS Depositor` into yvUSDS-1**. The default queue remains at 2 strategies (trimmed from 5 between April 27 and May 5 — the dormant `Savings Dai (sDAI)`, `Spark DAI Lender`, and `Aave V3 DAI Lender` strategies were removed from the queue at that time and remain absent at this snapshot).
+yvDAI-1 is a **DAI-denominated Yearn V3 vault** (ERC-4626) that deploys deposited DAI through a **vault-of-vaults composition**. At the July 12 snapshot, **73.19% routes through `DAI To USDC-1 Depositor` into yvUSDC-1**, and **26.81% routes through `DAI to USDS Depositor` into yvUSDS-1**. The default queue remains at 2 strategies (unchanged since the May 5 trim from 5 to 2 — the dormant `Savings Dai (sDAI)`, `Spark DAI Lender`, and `Aave V3 DAI Lender` strategies remain absent).
 
-**Material downstream rewiring since the May 5 snapshot:** at May 5 the report described yvUSDS-1 as routing 100% of its debt to its Spark USDS Compounder (Sky USDS Staking Rewards / SPK farm). At the May 11 snapshot, **yvUSDS-1 has re-diversified**: 80.03% of yvUSDS-1's debt now sits in `sUSDS Lender` (Sky Savings Rate) and 19.97% in `Spark USDS Compounder` (SPK farm). yvUSDC-1's routing is essentially unchanged from May 5 — its `USDC to sUSDS Lender` strategy ([`0x7130570BCEfCedBe9d15B5b11A33006156460f8f`](https://etherscan.io/address/0x7130570BCEfCedBe9d15B5b11A33006156460f8f)) holds **97.15% of yvUSDC-1's debt** (deposits direct into Sky's sUSDS, bypassing yvUSDS-1 entirely), with 2.85% in `Spark USDC Lender` (Spark Lend USDC market). The Morpho Yearn USDC Compounder strategy that was queued at 0 debt at the May 5 snapshot on yvUSDC-1 has been **revoked** (`activation = 0`) between snapshots — eliminating that potential non-Sky re-diversification leg.
+**Material downstream rewiring since May 11:** the intermediate vaults have both changed their strategy compositions. **yvUSDC-1** now has 4 strategies in its queue — a new **"Yearn USDC"** strategy ([`0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3`](https://etherscan.io/address/0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3)) holds 8.41% of tracked debt, and a new `Spark USDC Lender` ([`0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a`](https://etherscan.io/address/0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a)) replaces the old one at [`0x25f893276544d86a82b1ce407182836F45cb6673`](https://etherscan.io/address/0x25f893276544d86a82b1ce407182836F45cb6673) (now with 0 tracked debt). **yvUSDS-1** has added a new **"USDS Sky Rewards Compounder"** strategy ([`0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81`](https://etherscan.io/address/0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81), v3.0.3 TokenizedStrategy) at queue position 0 with near-zero debt — a successor to the existing `Spark USDS Compounder`. The yvUSDS-1 split is now 84.09% `sUSDS Lender` / 15.91% `Spark USDS Compounder`.
 
-**Effective endpoint mix for yvDAI-1's deployed DAI (May 11):**
+**Effective endpoint mix for yvDAI-1's deployed DAI (July 12):**
 
 | Endpoint | Path | Effective share |
 |----------|------|----------------:|
-| Sky **sUSDS** (Sky Savings Rate) | yvDAI-1 → yvUSDC-1 → sUSDS Lender **AND** yvDAI-1 → yvUSDS-1 → sUSDS Lender | **~92.5%** |
-| Sky **USDS Staking Rewards** (SPK farm) | yvDAI-1 → yvUSDS-1 → Spark USDS Compounder | **~5.4%** |
-| **Spark Lend USDC** market | yvDAI-1 → yvUSDC-1 → Spark USDC Lender | ~2.1% |
+| Sky **sUSDS** (Sky Savings Rate) | yvDAI-1 → yvUSDC-1 → sUSDS Lender **AND** yvDAI-1 → yvUSDS-1 → sUSDS Lender | **~89.6%** |
+| **Yearn USDC** strategy (yield source unverified) | yvDAI-1 → yvUSDC-1 → Yearn USDC | **~6.2%** |
+| Sky **USDS Staking Rewards** (SPK farm) | yvDAI-1 → yvUSDS-1 → Spark USDS Compounder | **~4.3%** |
 
-The cascade remains at most **two Yearn V3 vault layers deep**. Both intermediate vaults now route the majority of their debt into sUSDS, raising the combined sUSDS share to ~92.5% (up from ~77.5% at May 5). Effective Sky-ecosystem concentration is ~100% (sUSDS + USDS Staking + Spark Lend, the latter being a Sky sub-DAO).
+The cascade remains at most **two Yearn V3 vault layers deep**. Sky-ecosystem concentration (sUSDS + USDS Staking) is ~93.9%, down from ~100% at May 11 due to the new Yearn USDC strategy introducing a non-Sky dependent leg. The exact yield destination of the Yearn USDC strategy could not be verified on-chain and merits further investigation.
 
 **Key architecture:**
 
@@ -31,23 +31,23 @@ The cascade remains at most **two Yearn V3 vault layers deep**. Both intermediat
 - **Removed from queue between April 27 and May 5:** Savings Dai (sDAI), Spark DAI Lender, Aave V3 DAI Lender — all previously zero-debt; remain absent at block 25073237
 - **Governance:** Standard **Yearn V3 Role Manager** ([`0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41`](https://etherscan.io/address/0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41)) governed by the **Yearn 6-of-9 ySafe** with **7-day TimelockController** for strategy additions
 
-**Key metrics (May 11, 2026, snapshot at block 25073237, timestamp 1778519075 = 17:04:35 UTC):**
+**Key metrics (July 12, 2026, snapshot at block 25519075, timestamp 1783889819 = 20:56:59 UTC):**
 
-- **TVL:** 9,468,077.75 DAI
-- **Total Supply:** 8,465,210.58 yvDAI-1
-- **Price Per Share:** 1.118469 DAI/yvDAI-1 (~11.85% cumulative appreciation over ~26 months, ~5.4% annualized)
-- **Total Debt:** 9,468,077.75 DAI (100% deployed)
+- **TVL:** 9,497,240.53 DAI
+- **Total Supply:** 8,449,852.84 yvDAI-1
+- **Price Per Share:** 1.123954 DAI/yvDAI-1 (~12.40% cumulative appreciation over ~28 months, ~5.3% annualized)
+- **Total Debt:** 9,497,240.53 DAI (100% deployed)
 - **Total Idle:** 0 DAI
-- **Deposit Limit:** 50,000,000 DAI
+- **Deposit Limit:** 50,000,000 DAI (enforced via `maxDeposit`, current remainder ~40.5M DAI)
 - **Profit Max Unlock Time:** 10 days
 - **Fees:** 0% management fee, 10% performance fee
 
-**Verified vault-of-vaults wiring (block 25073237):**
+**Verified vault-of-vaults wiring (block 25519075):**
 
 - `DAI To USDC-1 Depositor` ([`0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5`](https://etherscan.io/address/0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5)) → yvUSDC-1 ([`0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204`](https://etherscan.io/address/0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204))
 - `DAI to USDS Depositor` ([`0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d`](https://etherscan.io/address/0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d)) → yvUSDS-1 ([`0x182863131F9a4630fF9E27830d945B1413e347E8`](https://etherscan.io/address/0x182863131F9a4630fF9E27830d945B1413e347E8))
-- yvUSDC-1's `USDC to sUSDS Lender` ([`0x7130570BCEfCedBe9d15B5b11A33006156460f8f`](https://etherscan.io/address/0x7130570BCEfCedBe9d15B5b11A33006156460f8f)) holds 97.15% of yvUSDC-1's debt; `Spark USDC Lender` ([`0x25f893276544d86a82b1ce407182836F45cb6673`](https://etherscan.io/address/0x25f893276544d86a82b1ce407182836F45cb6673)) holds 2.85%; `USDC to USDS Depositor` ([`0x39c0aEc5738ED939876245224aFc7E09C8480a52`](https://etherscan.io/address/0x39c0aEc5738ED939876245224aFc7E09C8480a52)) holds 0 USDC
-- yvUSDS-1's `sUSDS Lender` ([`0x3F2dE801629116A83B9734bB72012A554e01CfC1`](https://etherscan.io/address/0x3F2dE801629116A83B9734bB72012A554e01CfC1)) holds 80.03% of yvUSDS-1's debt; `Spark USDS Compounder` ([`0xc9f01b5c6048B064E6d925d1c2d7206d4fEeF8a3`](https://etherscan.io/address/0xc9f01b5c6048B064E6d925d1c2d7206d4fEeF8a3)) holds 19.97%
+- yvUSDC-1's `USDC to sUSDS Lender` ([`0x7130570BCEfCedBe9d15B5b11A33006156460f8f`](https://etherscan.io/address/0x7130570BCEfCedBe9d15B5b11A33006156460f8f)) holds 91.59% of yvUSDC-1's tracked debt; `Yearn USDC` ([`0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3`](https://etherscan.io/address/0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3)) holds 8.41%; `Spark USDC Lender` (new, [`0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a`](https://etherscan.io/address/0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a)) holds 0; `USDC to USDS Depositor` ([`0x39c0aEc5738ED939876245224aFc7E09C8480a52`](https://etherscan.io/address/0x39c0aEc5738ED939876245224aFc7E09C8480a52)) holds 0 USDC. The old Spark USDC Lender ([`0x25f893276544d86a82b1ce407182836F45cb6673`](https://etherscan.io/address/0x25f893276544d86a82b1ce407182836F45cb6673)) shows 0 tracked debt and is no longer in the default queue.
+- yvUSDS-1's `sUSDS Lender` ([`0x3F2dE801629116A83B9734bB72012A554e01CfC1`](https://etherscan.io/address/0x3F2dE801629116A83B9734bB72012A554e01CfC1)) holds 84.09% of yvUSDS-1's debt; `Spark USDS Compounder` ([`0xc9f01b5c6048B064E6d925d1c2d7206d4fEeF8a3`](https://etherscan.io/address/0xc9f01b5c6048B064E6d925d1c2d7206d4fEeF8a3)) holds 15.91%; `USDS Sky Rewards Compounder` ([`0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81`](https://etherscan.io/address/0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81)) holds 0 USDS
 
 **Links:**
 
@@ -116,15 +116,15 @@ After the vault-of-vaults unwind:
 
 | Effective endpoint | Path | Effective share |
 |--------------------|------|----------------:|
-| **Sky / sUSDS (Sky Savings Rate)** | yvDAI-1 → yvUSDC-1 → `USDC to sUSDS Lender` (~70.9%) **AND** yvDAI-1 → yvUSDS-1 → `sUSDS Lender` (~21.6%) | **~92.5%** |
-| **Sky USDS Staking Rewards (SPK farm)** | yvDAI-1 → yvUSDS-1 → Spark USDS Compounder → Sky USDS Staking | **~5.4%** |
-| **Spark Lend USDC market** | yvDAI-1 → yvUSDC-1 → `Spark USDC Lender` → Spark Lend | ~2.1% |
+| **Sky / sUSDS (Sky Savings Rate)** | yvDAI-1 → yvUSDC-1 → `USDC to sUSDS Lender` (~67.0%) **AND** yvDAI-1 → yvUSDS-1 → `sUSDS Lender` (~22.6%) | **~89.6%** |
+| **Yearn USDC** (yield source unverified) | yvDAI-1 → yvUSDC-1 → `Yearn USDC` | **~6.2%** |
+| **Sky USDS Staking Rewards (SPK farm)** | yvDAI-1 → yvUSDS-1 → Spark USDS Compounder → Sky USDS Staking | **~4.3%** |
 | **MakerDAO PSM Lite** (USDC ↔ DAI) | Used by `DAI To USDC-1 Depositor` for inbound DAI → USDC conversion (and reverse on withdrawal) | High during routing |
 | **Sky DAI-USDS Exchanger** (DAI ↔ USDS) | Used by `DAI to USDS Depositor` for inbound DAI → USDS conversion (and reverse on withdrawal) | High during routing |
-| **yvUSDC-1** (intermediate vault) | 72.97% of yvDAI-1 routes through it | Vault-of-vaults dependency |
-| **yvUSDS-1** (intermediate vault) | 27.03% of yvDAI-1 routes through it | Vault-of-vaults dependency |
+| **yvUSDC-1** (intermediate vault) | 73.19% of yvDAI-1 routes through it | Vault-of-vaults dependency |
+| **yvUSDS-1** (intermediate vault) | 26.81% of yvDAI-1 routes through it | Vault-of-vaults dependency |
 
-Net Sky-ecosystem concentration: ~100% of deployed DAI (sUSDS + Sky USDS Staking + Spark Lend USDC market). All three endpoints are Sky / Spark contracts.
+Net Sky-ecosystem concentration: ~93.9% of deployed DAI (sUSDS + Sky USDS Staking). The remaining ~6.2% is deployed through the `Yearn USDC` strategy whose exact yield destination could not be verified on-chain — marked TODO for further investigation.
 
 ## Audits and Due Diligence Disclosures
 
@@ -171,8 +171,8 @@ The yvDAI-1 system is **moderately complex** because of the vault-of-vaults comp
 
 - **2 funded strategies**, both depositors into other Yearn V3 vaults
 - **Conversion hops:**
-  - `DAI To USDC-1 Depositor`: DAI → USDC (PSM Lite) → yvUSDC-1 → (97.15%) USDC into sUSDS Lender / (2.85%) USDC into Spark Lend USDC market
-  - `DAI to USDS Depositor`: DAI → USDS (Exchanger) → yvUSDS-1 → (80.03%) USDS into sUSDS Lender / (19.97%) USDS into Spark USDS Compounder → Sky USDS Staking Rewards
+  - `DAI To USDC-1 Depositor`: DAI → USDC (PSM Lite) → yvUSDC-1 → (91.59%) USDC into sUSDS Lender / (8.41%) USDC into Yearn USDC strategy
+  - `DAI to USDS Depositor`: DAI → USDS (Exchanger) → yvUSDS-1 → (84.09%) USDS into sUSDS Lender / (15.91%) USDS into Spark USDS Compounder → Sky USDS Staking Rewards
 - **Two layers of Yearn V3 vault accounting** to verify (yvDAI-1 → yvUSDC-1 or yvDAI-1 → yvUSDS-1). Neither intermediate vault chains through the other
 - **No leverage, no looping, no cross-chain bridging**
 - **Standard ERC-4626** at every layer
@@ -182,16 +182,15 @@ The vault-of-vaults composition is **not leverage** but is a real complexity sur
 
 ## Historical Track Record
 
-- **Vault deployed:** March 12, 2024 (deployment [tx](https://etherscan.io/tx/0xfc6be986a2e60849a91c397c5c4bd10d9b247f0e1fb30cdaf0ed1f7687ea648e)) — **~26 months** in production
-- **TVL:** 9,468,077.75 DAI — well within the 50M DAI deposit limit. **TVL is up ~21.1%** from the May 5 snapshot of 7.82M (+1.65M absolute), reflecting fresh DAI deposits since May 5
-- **PPS trend:** 1.000000 → 1.118469 (~11.85% cumulative return over ~26 months, ~5.4% annualized)
+- **Vault deployed:** March 12, 2024 (deployment [tx](https://etherscan.io/tx/0xfc6be986a2e60849a91c397c5c4bd10d9b247f0e1fb30cdaf0ed1f7687ea648e)) — **~28 months** in production
+- **TVL:** 9,497,240.53 DAI — well within the 50M DAI deposit limit (current remainder ~40.5M DAI via `maxDeposit`)
+- **PPS trend:** 1.000000 → 1.123954 (~12.40% cumulative return over ~28 months, ~5.3% annualized)
 - **Security incidents:** None known for this vault or for the Yearn V3 framework
-- **Strategy changes:** active management. Between April 27 and May 5, three direct-deposit fallbacks (sDAI, Spark DAI Lender, Aave V3 DAI Lender) were removed from the default queue (and remain absent at May 11). Between May 5 and May 11, the inbound DAI ($1.65M) was distributed with a tilt toward the USDS depositor — the depositor allocation shifted from 79.44 / 20.56 to **72.97 / 27.03** (USDC / USDS)
+- **Strategy changes:** active management. Between April 27 and May 5, three direct-deposit fallbacks (sDAI, Spark DAI Lender, Aave V3 DAI Lender) were removed from the default queue (and remain absent at July 12). Between May 5 and May 11, the depositor allocation shifted from 79.44 / 20.56 to 72.97 / 27.03 (USDC / USDS). The allocation at July 12 is 73.19 / 26.81 — largely stable since May 11
 - **Vault-of-vaults rewiring (downstream):**
-  - At the April 27 snapshot yvUSDC-1 routed 100% to yvUSDS-1, so yvDAI-1's effective endpoint was 100% yvUSDS-1. At the May 5 snapshot yvUSDC-1 had switched its primary route to a direct `USDC to sUSDS Lender` strategy
-  - **Between May 5 and May 11, yvUSDS-1 re-diversified:** from 100% Spark USDS Compounder to **80.03% sUSDS Lender + 19.97% Spark USDS Compounder**. Both intermediate vaults now route majority debt into sUSDS
-  - **Net effect at May 11:** effective endpoint mix is ~92.5% sUSDS (sum across both paths) / ~5.4% Sky USDS Staking / ~2.1% Spark Lend USDC. Sky-ecosystem concentration is ~100% (unchanged in principle), but the sUSDS share has grown from ~77.5% → ~92.5% and the USDS Staking share has contracted from ~20.6% → ~5.4% as a direct consequence of yvUSDS-1's downstream re-diversification
-- **Yearn V3 track record:** V3 framework has been live since May 2024 (~24 months). No V3 vault exploits
+  - Between May 11 and July 12, both intermediate vaults added new strategies. **yvUSDC-1** added a new "Yearn USDC" strategy ([`0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3`](https://etherscan.io/address/0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3)) that now holds 8.41% of tracked debt, replacing the old `Spark USDC Lender` ([`0x25f893276544d86a82b1ce407182836F45cb6673`](https://etherscan.io/address/0x25f893276544d86a82b1ce407182836F45cb6673)) which now has 0 tracked debt. The Spark USDC Lender was replaced by a new version at [`0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a`](https://etherscan.io/address/0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a) (currently 0 debt). **yvUSDS-1** added a new "USDS Sky Rewards Compounder" strategy ([`0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81`](https://etherscan.io/address/0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81), v3.0.3 TokenizedStrategy) as a successor to the existing `Spark USDS Compounder`, currently with near-zero debt
+  - **Net effect at July 12:** effective endpoint mix is ~89.6% sUSDS / ~6.2% Yearn USDC (yield source unverified) / ~4.3% Sky USDS Staking. Overall Sky-ecosystem concentration dropped from ~100% to ~93.9% as the Spark Lend USDC leg was replaced by the Yearn USDC strategy
+- **Yearn V3 track record:** V3 framework has been live since May 2024 (~26 months). No V3 vault exploits
 
 **Yearn protocol TVL:** ~$197.5M total across all chains ([DeFiLlama](https://defillama.com/protocol/yearn), April 2026).
 
@@ -199,9 +198,9 @@ The vault-of-vaults composition is **not leverage** but is a real complexity sur
 
 ## Funds Management
 
-yvDAI-1 deploys ~99.9999% of its DAI via two depositor strategies. Both terminate inside the Sky ecosystem (sUSDS dominantly + Sky USDS Staking + a small Spark Lend USDC slice).
+yvDAI-1 deploys ~99.9999% of its DAI via two depositor strategies. Both routes terminate mostly inside the Sky ecosystem, with a ~6.2% leg through a new Yearn USDC strategy whose exact yield source is unverified.
 
-### Strategy 1: DAI To USDC-1 Depositor (72.97% allocation)
+### Strategy 1: DAI To USDC-1 Depositor (73.19% allocation)
 
 **Contract:** [`0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5`](https://etherscan.io/address/0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5) — verified vault target [`0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204`](https://etherscan.io/address/0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204) (yvUSDC-1).
 
@@ -209,16 +208,16 @@ yvDAI-1 deploys ~99.9999% of its DAI via two depositor strategies. Both terminat
 
 1. **DAI → USDC** via MakerDAO PSM Lite ([`0xf6e72Db5454dd049d0788e411b06CfAF16853042`](https://etherscan.io/address/0xf6e72Db5454dd049d0788e411b06CfAF16853042)) — 1:1 at **0% fee** (`tin = tout = 0`)
 2. **USDC → yvUSDC-1** deposit (ERC-4626)
-3. yvUSDC-1 internally routes ~97.15% to its `USDC to sUSDS Lender` strategy ([`0x7130570BCEfCedBe9d15B5b11A33006156460f8f`](https://etherscan.io/address/0x7130570BCEfCedBe9d15B5b11A33006156460f8f)) → USDC → USDS (or sUSDS-internal conversion) → sUSDS, plus ~2.85% to its `Spark USDC Lender` strategy ([`0x25f893276544d86a82b1ce407182836F45cb6673`](https://etherscan.io/address/0x25f893276544d86a82b1ce407182836F45cb6673)) → direct supply into Spark Lend USDC market
+3. yvUSDC-1 internally routes ~91.59% to its `USDC to sUSDS Lender` strategy ([`0x7130570BCEfCedBe9d15B5b11A33006156460f8f`](https://etherscan.io/address/0x7130570BCEfCedBe9d15B5b11A33006156460f8f)) → USDC → USDS (or sUSDS-internal conversion) → sUSDS, plus ~8.41% to its `Yearn USDC` strategy ([`0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3`](https://etherscan.io/address/0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3)) whose yield destination could not be verified on-chain (TODO). The `Spark USDC Lender` (new version at [`0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a`](https://etherscan.io/address/0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a)) holds 0 debt. The old Spark USDC Lender at [`0x25f893276544d86a82b1ce407182836F45cb6673`](https://etherscan.io/address/0x25f893276544d86a82b1ce407182836F45cb6673) has 0 tracked debt and is no longer in the default queue
 
 **Withdrawal:** reverse path. The user's `redeem` on yvDAI-1 triggers `withdraw` from this strategy → `redeem` from yvUSDC-1 → `withdraw` from yvUSDC-1's downstream (sUSDS Lender or Spark USDC Lender) → unwind into USDC → DAI via PSM. All atomic in the same transaction.
 
 **Strategy parameters:**
 - Activated: 2025-10-24
-- Last reported: 2026-05-03 (`last_report = 1777777319`)
+- Last reported: 2026-07-12 (`last_report = 1783830887`)
 - PSM fee fallback: 0.05% threshold (above which the strategy can be configured to use Uniswap V3 with 0.5% slippage tolerance)
 
-### Strategy 2: DAI to USDS Depositor (27.03% allocation)
+### Strategy 2: DAI to USDS Depositor (26.81% allocation)
 
 **Contract:** [`0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d`](https://etherscan.io/address/0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d) — verified vault target [`0x182863131F9a4630fF9E27830d945B1413e347E8`](https://etherscan.io/address/0x182863131F9a4630fF9E27830d945B1413e347E8) (yvUSDS-1).
 
@@ -226,13 +225,13 @@ yvDAI-1 deploys ~99.9999% of its DAI via two depositor strategies. Both terminat
 
 1. **DAI → USDS** via Sky DAI-USDS Exchanger ([`0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A`](https://etherscan.io/address/0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A)) — 1:1, no fee
 2. **USDS → yvUSDS-1** deposit (ERC-4626)
-3. yvUSDS-1 currently routes 80.03% to its `sUSDS Lender` strategy ([`0x3F2dE801629116A83B9734bB72012A554e01CfC1`](https://etherscan.io/address/0x3F2dE801629116A83B9734bB72012A554e01CfC1)) → direct deposit into Sky's sUSDS (Sky Savings Rate), plus 19.97% to its `Spark USDS Compounder` strategy ([`0xc9f01b5c6048B064E6d925d1c2d7206d4fEeF8a3`](https://etherscan.io/address/0xc9f01b5c6048B064E6d925d1c2d7206d4fEeF8a3)) → Sky USDS Staking Rewards (SPK farm)
+3. yvUSDS-1 currently routes 84.09% to its `sUSDS Lender` strategy ([`0x3F2dE801629116A83B9734bB72012A554e01CfC1`](https://etherscan.io/address/0x3F2dE801629116A83B9734bB72012A554e01CfC1)) → direct deposit into Sky's sUSDS (Sky Savings Rate), plus 15.91% to its `Spark USDS Compounder` strategy ([`0xc9f01b5c6048B064E6d925d1c2d7206d4fEeF8a3`](https://etherscan.io/address/0xc9f01b5c6048B064E6d925d1c2d7206d4fEeF8a3)) → Sky USDS Staking Rewards (SPK farm). A new `USDS Sky Rewards Compounder` strategy ([`0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81`](https://etherscan.io/address/0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81), v3.0.3 TokenizedStrategy) is in queue position 0 with near-zero debt — intended as a successor to the existing Spark USDS Compounder
 
 **Withdrawal:** reverse path. The user's `redeem` on yvDAI-1 triggers `withdraw` from this strategy → `redeem` from yvUSDS-1 → unwind from whichever yvUSDS-1 leg the redemption hits in queue order (sUSDS Lender then Spark Compounder). All atomic in the same transaction.
 
 **Strategy parameters:**
 - Activated: 2025-05-15
-- Last reported: 2026-05-03 (`last_report = 1777780343`)
+- Last reported: 2026-07-12 (`last_report = 1783831475`)
 
 ### Removed from default queue (between April 27 and May 5)
 
@@ -316,16 +315,16 @@ After resolving the vault-of-vaults composition, yvDAI-1's effective dependencie
 
 | Dependency | Criticality | Notes |
 |-----------|-------------|-------|
-| **yvUSDC-1** (intermediate vault) | Critical — 72.97% of deployed funds route through it | Same governance, audits, code as yvDAI-1. See [yvUSDC-1 report](./yearn-yvusdc.md) |
-| **yvUSDS-1** (intermediate vault) | Critical — 27.03% of deployed funds route through it | Same governance, audits, code. See [yvUSDS-1 report](./yearn-yvusds.md) |
-| **Sky / sUSDS** (Sky Savings Rate) | Critical — ~92.5% of effective deployment (via both intermediate vaults) | Multi-billion sUSDS TVL, $10M Immunefi bounty |
-| **Sky USDS Staking Rewards (SPK farm)** | Moderate — ~5.4% of effective deployment (via yvUSDS-1) | First-party Sky contract; share dropped from ~20.6% on May 5 as yvUSDS-1 re-diversified into sUSDS |
-| **Spark Lend USDC market** | Low — ~2.1% of effective deployment (via yvUSDC-1) | Sky sub-DAO; audited |
+| **yvUSDC-1** (intermediate vault) | Critical — 73.19% of deployed funds route through it | Same governance, audits, code as yvDAI-1. See [yvUSDC-1 report](./yearn-yvusdc.md) |
+| **yvUSDS-1** (intermediate vault) | Critical — 26.81% of deployed funds route through it | Same governance, audits, code. See [yvUSDS-1 report](./yearn-yvusds.md) |
+| **Sky / sUSDS** (Sky Savings Rate) | Critical — ~89.6% of effective deployment (via both intermediate vaults) | Multi-billion sUSDS TVL, $10M Immunefi bounty |
+| **Yearn USDC strategy** | Moderate — ~6.2% of effective deployment (via yvUSDC-1) | Custom Yearn-branded strategy (not a standard TokenizedStrategy); yield source could not be verified on-chain (TODO) |
+| **Sky USDS Staking Rewards (SPK farm)** | Moderate — ~4.3% of effective deployment (via yvUSDS-1) | First-party Sky contract; share decreased from ~5.4% at May 11 |
 | **MakerDAO PSM Lite** | High during routing (used by yvUSDC-1 path) | 1:1, 0% fee, audited |
 | **Sky DAI-USDS Exchanger** | High during routing (used by yvUSDS-1 path) | 1:1, no fee, audited |
 | **DAI / USDS / USDC tokens** | Critical | Inherited from each conversion hop |
 
-**Dependency quality:** all dependencies are top-tier — Sky / MakerDAO infrastructure plus Yearn V3 itself. The vault-of-vaults composition concentrates dependency on the Sky ecosystem (~100% of effective deployment across sUSDS + USDS Staking + Spark Lend USDC, with ~92.5% in sUSDS alone) and on Yearn V3's own vault accounting working correctly across two layers.
+**Dependency quality:** most dependencies are top-tier — Sky / MakerDAO infrastructure plus Yearn V3 itself. The vault-of-vaults composition concentrates dependency on the Sky ecosystem (~93.9% of effective deployment across sUSDS + USDS Staking) and on Yearn V3's own vault accounting working correctly across two layers. The ~6.2% `Yearn USDC` leg represents an _unverified_ dependency whose yield destination and associated protocol risk could not be determined.
 
 ## Operational Risk
 
@@ -354,8 +353,10 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 | yvDAI-1 Vault | [`0x028eC7330ff87667b6dfb0D94b954c820195336c`](https://etherscan.io/address/0x028eC7330ff87667b6dfb0D94b954c820195336c) | PPS, `totalAssets()`, `totalDebt()`, `totalIdle()`, Deposit / Withdraw events |
 | DAI to USDC-1 Depositor | [`0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5`](https://etherscan.io/address/0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5) | `totalAssets()`, `isShutdown()`, keeper report |
 | DAI to USDS Depositor | [`0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d`](https://etherscan.io/address/0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d) | `totalAssets()`, `isShutdown()`, keeper report |
-| yvUSDC-1 (upstream dependency) | [`0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204`](https://etherscan.io/address/0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204) | PPS, shutdown state |
-| yvUSDS-1 (upstream dependency) | [`0x182863131F9a4630fF9E27830d945B1413e347E8`](https://etherscan.io/address/0x182863131F9a4630fF9E27830d945B1413e347E8) | PPS, shutdown state |
+| yvUSDC-1 (upstream dependency) | [`0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204`](https://etherscan.io/address/0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204) | PPS, shutdown state, strategy queue |
+| yvUSDS-1 (upstream dependency) | [`0x182863131F9a4630fF9E27830d945B1413e347E8`](https://etherscan.io/address/0x182863131F9a4630fF9E27830d945B1413e347E8) | PPS, shutdown state, strategy queue |
+| Yearn USDC strategy | [`0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3`](https://etherscan.io/address/0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3) | `totalAssets()`, yield destination (TODO: unverified) |
+| USDS Sky Rewards Compounder | [`0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81`](https://etherscan.io/address/0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81) | `totalAssets()`, debt migration from Spark USDS Compounder |
 | MakerDAO PSM Lite | [`0xf6e72Db5454dd049d0788e411b06CfAF16853042`](https://etherscan.io/address/0xf6e72Db5454dd049d0788e411b06CfAF16853042) | `tin`, `tout` (fee parameters) |
 | Sky DAI-USDS Exchanger | [`0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A`](https://etherscan.io/address/0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A) | Pause state |
 | ySafe (Daddy) | [`0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52`](https://etherscan.io/address/0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52) | Signer / threshold changes |
@@ -367,9 +368,9 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 - **Emergency actions** (`Shutdown`) at any layer — directly impacts yvDAI-1's redemption path
 - **PSM `tin` / `tout`** — if non-zero, USDC ↔ DAI conversion incurs fees
 - **DAI-USDS Exchanger pause state**
-- **Sky USDS Staking Rewards pause / migration** (affects ~5.4% of effective deployment via yvUSDS-1)
-- **Sky sUSDS pause / migration** (affects ~92.5% of effective deployment via both intermediate vaults — dominant exposure)
-- **Spark Lend USDC market freeze / pause** (affects ~2.1% of effective deployment via yvUSDC-1)
+- **Sky USDS Staking Rewards pause / migration** (affects ~4.3% of effective deployment via yvUSDS-1)
+- **Sky sUSDS pause / migration** (affects ~89.6% of effective deployment via both intermediate vaults — dominant exposure)
+- **Yearn USDC strategy event or exploit** (affects ~6.2% of effective deployment via yvUSDC-1; yield source unverified)
 - **ySafe / Brain / Security signer or threshold changes**
 
 ### Monitoring Functions
@@ -389,10 +390,10 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 
 ### Key Strengths
 
-- **Battle-tested Yearn V3 infrastructure:** 3 audits by top firms, ~24 months of clean V3 production. Immutable vault contract eliminates proxy upgrade risk
-- **Top-tier underlying:** ~100% of effective deployment ends at Sky-ecosystem contracts (sUSDS ~92.5% + USDS Staking ~5.4% + Spark Lend USDC ~2.1%) — Sky has a $10M Immunefi bounty and is one of the most extensively audited DeFi protocols
+- **Battle-tested Yearn V3 infrastructure:** 3 audits by top firms, ~26 months of clean V3 production. Immutable vault contract eliminates proxy upgrade risk
+- **Predominantly top-tier underlying:** ~93.9% of effective deployment ends at Sky-ecosystem contracts (sUSDS ~89.6% + USDS Staking ~4.3%) — Sky has a $10M Immunefi bounty and is one of the most extensively audited DeFi protocols
 - **Standard Yearn governance:** Yearn V3 Role Manager + 6-of-9 ySafe (named DeFi signers) + 7-day self-governed timelock
-- **Established track record:** ~26 months in production, ~11.85% cumulative return, zero incidents
+- **Established track record:** ~28 months in production, ~12.40% cumulative return, zero incidents
 - **Active monitoring:** vault is in Yearn's hourly monitoring system
 - **Cascade depth bounded:** the deepest Yearn-vault chain is two layers (yvDAI-1 → yvUSDC-1 or yvDAI-1 → yvUSDS-1); neither intermediate vault chains through the other
 - **No leverage. No cross-chain.** Vault-of-vaults composition is not leverage
@@ -402,14 +403,14 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 ### Key Risks
 
 - **Vault-of-vaults composition (2 layers):** both depositor paths traverse two Yearn V3 vault layers. A bug or accounting issue at any layer cascades. Each layer's emergency state (shutdown, deposit pause) directly affects yvDAI-1
-- **Effective concentration into Sky ecosystem:** ~100% of deployed DAI ultimately ends up in Sky-ecosystem contracts (sUSDS ~92.5%, Sky USDS Staking ~5.4%, Spark Lend USDC ~2.1%). The sUSDS share grew substantially between May 5 and May 11 (~77.5% → ~92.5%) as yvUSDS-1 re-diversified its routing into the sUSDS Lender strategy. A bug or governance failure at the sUSDS contract would now affect ~92.5% of deployed value; a Sky-wide systemic failure would affect essentially the entire vault
+- **Effective concentration into Sky ecosystem:** ~93.9% of deployed DAI ultimately ends up in Sky-ecosystem contracts (sUSDS ~89.6%, Sky USDS Staking ~4.3%). The remaining ~6.2% is deployed through the `Yearn USDC` strategy whose exact yield destination is unverified. A bug or governance failure at the sUSDS contract would affect ~89.6% of deployed value; a Sky-wide systemic failure would affect ~93.9%
 - **Sky Savings Rate / SPK reward rate variability:** affects yield, not principal
 - **PSM fee risk:** currently 0%, but Sky governance can change. Above 0.05% the strategy can fall back to Uniswap V3 with 0.5% slippage
 - **Intermediate-vault dependency:** both paths have a single intermediate Yearn V3 vault (yvUSDC-1 or yvUSDS-1) between yvDAI-1 and the terminal Sky / Spark contracts
 
 ### Critical Risks
 
-- None identified. The dominant systemic risk is a Sky USDS / sUSDS / USDS Staking failure, which would simultaneously impair the four risk-1 stable vaults — but that is a system-wide DeFi event, not a Yearn-specific risk.
+- None identified. The dominant systemic risk is a Sky USDS / sUSDS / USDS Staking failure, which would simultaneously impair the four risk-1 stable vaults — but that is a system-wide DeFi event, not a Yearn-specific risk. The ~6.2% `Yearn USDC` leg uses an unverified yield source; a bug or exploit in that strategy would affect ~6.2% of deployed DAI.
 
 ---
 
@@ -437,12 +438,12 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 |--------|-----------|
 | Audits | V3 framework: 3 audits by top firms. Sky / sUSDS / USDS Staking: 7+ auditors |
 | Bug bounty | $200K (Yearn Immunefi); $10M (Sky Immunefi) |
-| Production history | **~26 months** (March 12, 2024). V3 framework: ~24 months |
-| TVL | **~$9.47M** DAI. Deposit limit: 50M |
+| Production history | **~28 months** (March 12, 2024). V3 framework: ~26 months |
+| TVL | **~$9.50M** DAI. Deposit limit: 50M |
 | Security incidents | None on V3, none on Sky |
 | Strategy review | Rigorous 12-metric framework with ySec security review |
 
-**Score: 1.5 / 5** — strong audit coverage, ~26 months clean production, no incidents.
+**Score: 1.5 / 5** — strong audit coverage, ~28 months clean production, no incidents.
 
 #### Category 2: Centralization & Control Risks (Weight: 30%)
 
@@ -474,11 +475,11 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 
 | Factor | Assessment |
 |--------|-----------|
-| Protocol count (effective) | 1 ecosystem (Sky / Spark) for ~100% of effective deployment, plus dependency on Yearn V3's own vault-of-vaults accounting (bounded at 2 layers) |
-| Criticality | Sky sUSDS critical (~92.5% of deployed funds, via both intermediate vaults); Sky USDS Staking moderate (~5.4% via yvUSDS-1); Spark Lend USDC market low (~2.1% via yvUSDC-1); same-team Yearn V3 dependency at both intermediate vaults |
-| Quality | Top-tier (Sky $10M bounty, multi-billion sUSDS TVL) plus same Yearn V3 framework |
+| Protocol count (effective) | 1 ecosystem (Sky) for ~93.9% of effective deployment plus a ~6.2% unverified Yearn USDC leg; plus dependency on Yearn V3's own vault-of-vaults accounting (bounded at 2 layers) |
+| Criticality | Sky sUSDS critical (~89.6% of deployed funds, via both intermediate vaults); Yearn USDC strategy moderate (~6.2% via yvUSDC-1, yield source unverified); Sky USDS Staking moderate (~4.3% via yvUSDS-1); same-team Yearn V3 dependency at both intermediate vaults |
+| Quality | Top-tier (Sky $10M bounty, multi-billion sUSDS TVL) plus same Yearn V3 framework; Yearn USDC strategy quality unverified |
 
-**Dependencies Score: 2.5 / 5** — single-ecosystem (Sky) effective concentration plus a two-layer vault-of-vaults dependency on Yearn V3 itself. The ecosystem quality is excellent, but the ~100% Sky concentration (now ~92.5% in sUSDS alone, up from ~77.5% at May 5 due to yvUSDS-1's downstream re-diversification) and continued multi-layer composition warrant 2.5.
+**Dependencies Score: 2.5 / 5** — Sky-ecosystem effective concentration (~93.9%) plus a two-layer vault-of-vaults dependency on Yearn V3 itself, with an unverified 6.2% leg through a custom Yearn USDC strategy. The Sky ecosystem quality is excellent, but the concentration and unverified leg warrant 2.5.
 
 **Centralization Score = (1.0 + 1.0 + 2.5) / 3 ≈ 1.5**
 
@@ -516,9 +517,9 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 
 | Factor | Assessment |
 |--------|-----------|
-| Exit pipeline | 2 vault layers + terminal Sky / Spark unstake (sUSDS withdraw, Spark Lend USDC withdraw, or Spark Compounder unwind) |
+| Exit pipeline | 2 vault layers + terminal Sky unstake / Yearn USDC withdraw (sUSDS withdraw or Spark Compounder unwind) |
 | Liquidity depth | sUSDS multi-billion; PSM billions; Spark / Aave / Morpho deep |
-| Large holder impact | $9.47M vault vs multi-billion underlying — negligible |
+| Large holder impact | $9.50M vault vs multi-billion underlying — negligible |
 | Same-asset | DAI-denominated share token |
 | Withdrawal restrictions | None — atomic redemption (multi-step within one transaction) |
 
@@ -568,11 +569,12 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 - **TVL-based:** Reassess if TVL exceeds $25M or changes by ±50%, or if the deposit limit is changed
 - **Strategy posture:**
   - any new `addStrategy()` proposal at the Strategy Manager TimelockController for yvDAI-1 (would surface in the 7-day queue) — particularly if it reintroduces direct sDAI / Spark DAI Lender / Aave V3 DAI Lender exposure
-  - the depositor allocation between yvUSDC-1 and yvUSDS-1 swings by more than ±20 percentage points from the current 72.97 / 27.03 split
+  - the depositor allocation between yvUSDC-1 and yvUSDS-1 swings by more than ±20 percentage points from the current 73.19 / 26.81 split
 - **Downstream rewiring (the dominant change vector at recent snapshots):**
-  - if yvUSDC-1 reroutes materially away from its current `USDC to sUSDS Lender` strategy, yvDAI-1's effective endpoint mix changes accordingly — ~70.9 percentage points of the sUSDS share is inherited from yvUSDC-1
-  - if yvUSDS-1 rewires its current 80.03 / 19.97 sUSDS Lender / Spark Compounder split, yvDAI-1's secondary exposure changes accordingly — ~21.6 percentage points of the sUSDS share and the entire ~5.4% USDS Staking share are inherited from yvUSDS-1
-  - **historical note:** between May 5 and May 11, the Morpho Yearn USDC Compounder ([`0xf1784A1bF0cBDE0F868838Dd093E65215343c4C0`](https://etherscan.io/address/0xf1784A1bF0cBDE0F868838Dd093E65215343c4C0)) — added to yvUSDC-1's queue on 2026-04-30 with 0 debt — was **revoked** (`activation = 0` at block 25073237). The potential Morpho re-diversification leg has been removed. Reintroducing it would require a fresh `addStrategy()` proposal at the yvUSDC-1 Strategy Manager TimelockController (7-day delay)
+  - if yvUSDC-1 reroutes materially away from its current `USDC to sUSDS Lender` strategy, yvDAI-1's effective endpoint mix changes accordingly — ~67.0 percentage points of the sUSDS share is inherited from yvUSDC-1
+  - if yvUSDS-1 rewires its current 84.09 / 15.91 sUSDS Lender / Spark Compounder split, yvDAI-1's secondary exposure changes accordingly — ~22.6 percentage points of the sUSDS share and the entire ~4.3% USDS Staking share are inherited from yvUSDS-1
+  - **Yearn USDC strategy:** reassess if the `Yearn USDC` strategy's yield destination is identified or changed materially; the strategy currently holds ~6.2% of effective deployment and its protocol risk is unverified
+  - **USDS Sky Rewards Compounder:** reassess if the new `USDS Sky Rewards Compounder` ([`0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81`](https://etherscan.io/address/0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81), v3.0.3) replaces the existing `Spark USDS Compounder` in the yvUSDS-1 default queue and begins receiving meaningful debt
 - **Vault-of-vaults composition:**
   - **reassess if a new strategy is added that creates a third Yearn-vault layer** (the cascade is currently 2 layers deep)
   - reassess if any of the two intermediate vaults (yvUSDC-1, yvUSDS-1) shuts down a strategy that holds yvDAI-1's deployed funds
@@ -581,7 +583,7 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
   - PSM `tin` / `tout` set above 0.05% (activates Uniswap V3 fallback in the USDC depositor path)
   - SPK reward rate changes materially or USDS Staking Rewards is paused / migrated
   - DAI-USDS Exchanger pause
-  - Spark Lend USDC market freeze / pause (affects ~2.1% of effective deployment via yvUSDC-1)
+  - Spark Lend USDC market freeze / pause (no longer directly affects yvDAI-1 as the Spark USDC Lender has been replaced; see downstream rewiring note above)
 - **Incident-based:** any V3 exploit, strategy loss, governance compromise, or major incident at Sky / MakerDAO / Spark
 - **Governance-based:** ySafe / Brain / Security signer or threshold changes; any change to the timelock delay (would itself require 7 days)
 
@@ -598,9 +600,9 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 │  │  ERC-4626, immutable    │                                             │
 │  │  0x028e…336c            │                                             │
 │  │                         │                                             │
-│  │  ~$9.47M DAI TVL        │                                             │
+│  │  ~$9.50M DAI TVL        │                                             │
 │  └───┬───────────────┬─────┘                                             │
-│      │ 72.97%        │ 27.03%                                            │
+│      │ 73.19%        │ 26.81%                                            │
 │      ▼               ▼                                                    │
 │  ┌────────────┐  ┌─────────────────┐                                    │
 │  │ DAI→USDC-1 │  │ DAI→USDS        │                                    │
@@ -622,20 +624,21 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 │  ┌─────────────────────────────┐    ┌────────────────────────────┐      │
 │  │  yvUSDC-1                   │    │  yvUSDS-1                  │      │
 │  │  0xBe53…6204                │    │  0x1828…47E8               │      │
-│  │  ~97.15% sUSDS Lender       │    │  80.03% sUSDS Lender       │      │
-│  │   ~2.85% Spark USDC Lender  │    │  19.97% Spark USDS Compounder│    │
+│  ～91.59% sUSDS Lender       │    │  84.09% sUSDS Lender       │      │
+│  │   ~8.41% Yearn USDC          │    │  15.91% Spark USDS Compounder│    │
+│  │  Spark USDC Lender: 0 USDC  │    │  USDS Sky Rewards: 0 USDS  │      │
 │  │  USDS Depositor: 0 USDC     │    │  (Sky USDS Staking / SPK)  │      │
 │  └─────────┬───────────────────┘    └─────────┬──────────────────┘      │
 │            │                                   │                          │
 │            ▼                                   ▼                          │
 │   sUSDS (Sky Savings Rate)             sUSDS + Sky USDS Staking Rewards │
-│   + Spark Lend USDC market             (SPK farm)                       │
+│   + Yearn USDC (yield TBD)             (SPK farm)                       │
 └─────────────────────────────────────────────────────────────────────────┘
 
-Effective endpoint mix for yvDAI-1's deployed DAI (May 11, 2026):
-  ~92.5%  Sky sUSDS         (combined: yvUSDC-1→sUSDS Lender ~70.9% + yvUSDS-1→sUSDS Lender ~21.6%)
-  ~5.4%   Sky USDS Staking   (via yvUSDS-1 → Spark USDS Compounder)
-  ~2.1%   Spark Lend USDC    (via yvUSDC-1 → Spark USDC Lender)
+Effective endpoint mix for yvDAI-1's deployed DAI (July 12, 2026):
+  ~89.6%  Sky sUSDS         (combined: yvUSDC-1→sUSDS Lender ~67.0% + yvUSDS-1→sUSDS Lender ~22.6%)
+  ~6.2%   Yearn USDC        (via yvUSDC-1 → Yearn USDC, yield source unverified)
+  ~4.3%   Sky USDS Staking   (via yvUSDS-1 → Spark USDS Compounder)
 ```
 
 ## Appendix: TimelockController Role Structure
@@ -653,3 +656,12 @@ TimelockController [`0x88Ba032be87d5EF1fbE87336b7090767F367BF73`](https://ethers
 | **CANCELLER** | Brain | 3-of-8 Safe | Cancel pending proposals |
 
 To shorten the delay, Daddy 6/9 must propose `updateDelay()`, wait 7 days during which Brain or Daddy can cancel, then execute. DEFAULT_ADMIN was never granted, so no party can self-grant PROPOSER or TIMELOCK_ADMIN to skip the flow.
+
+---
+
+## Assessment History
+
+| Date | Score | Notes |
+|------|-------|-------|
+| May 11, 2026 | 1.3/5.0 | Initial assessment. yvDAI-1 with vault-of-vaults composition routing ~100% into Sky ecosystem via yvUSDC-1 (73%) and yvUSDS-1 (27%). Spark Lend USDC and sUSDS legs. |
+| July 12, 2026 | 1.3/5.0 | Reassessment: TVL stable at ~$9.50M. yvUSDC-1 added new "Yearn USDC" strategy (8.41% tracked debt, yield source unverified — TODO). Old Spark USDC Lender replaced. yvUSDS-1 added v3.0.3 "USDS Sky Rewards Compounder" (currently near-zero debt). Sky-ecosystem concentration dropped from ~100% to ~93.9%. Effective endpoint mix: ~89.6% sUSDS / ~6.2% Yearn USDC / ~4.3% Sky USDS Staking. All governance roles, multisig thresholds, and timelock delay unchanged. Score unchanged at 1.3. |

--- a/reports/report/yearn-yvdai.md
+++ b/reports/report/yearn-yvdai.md
@@ -165,7 +165,7 @@ All strategies pass through Yearn's **12-metric risk-scoring framework** ([RISK_
 - **Yearn (Immunefi):** active, **$200,000** max payout (Critical). https://immunefi.com/bounty/yearnfinance/
 - **Yearn (Sherlock):** also listed at https://audits.sherlock.xyz/bug-bounties/30
 - **Sky / MakerDAO (Immunefi):** active, **$10,000,000** max payout (Critical). Scope includes DAI, USDS, sUSDS, PSM. https://immunefi.com/bug-bounty/sky/
-- **Morpho Blue (Immunefi):** active, **$2,500,000** max payout (Critical). https://immunefi.com/bug-bounty/morpho/
+- **Morpho (Cantina):** active, **$2,500,000** max payout (Critical). https://cantina.xyz/bounties/35a5f0a1-2ffd-432c-8f3b-77d169add8c3
 - **Safe Harbor (SEAL):** Yearn is **not** listed on the SEAL Safe Harbor registry
 
 ### On-Chain Complexity

--- a/reports/report/yearn-yvdai.md
+++ b/reports/report/yearn-yvdai.md
@@ -12,22 +12,24 @@ yvDAI-1 is a **DAI-denominated Yearn V3 vault** (ERC-4626) that deploys deposite
 
 **Material downstream rewiring since May 11:** the intermediate vaults have both changed their strategy compositions. **yvUSDC-1** now has 4 strategies in its queue — a new **"Yearn USDC"** strategy ([`0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3`](https://etherscan.io/address/0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3)) holds 8.41% of tracked debt, and a new `Spark USDC Lender` ([`0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a`](https://etherscan.io/address/0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a)) replaces the old one at [`0x25f893276544d86a82b1ce407182836F45cb6673`](https://etherscan.io/address/0x25f893276544d86a82b1ce407182836F45cb6673) (now with 0 tracked debt). **yvUSDS-1** has added a new **"USDS Sky Rewards Compounder"** strategy ([`0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81`](https://etherscan.io/address/0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81), v3.0.3 TokenizedStrategy) at queue position 0 with near-zero debt — a successor to the existing `Spark USDS Compounder`. The yvUSDS-1 split is now 84.09% `sUSDS Lender` / 15.91% `Spark USDS Compounder`.
 
+The **"Yearn USDC"** strategy is a **Yearn-curated Morpho MetaMorpho vault** (verified on-chain). It supplies USDC into four Morpho Blue lending markets: cbBTC collateral via oracle [`0xA6D6950c9F177F1De7f7757FB33539e3Ec60182a`](https://etherscan.io/address/0xA6D6950c9F177F1De7f7757FB33539e3Ec60182a) (LLTV 86%), WBTC via oracle [`0xDddd770BADd886dF3864029e4B377B5F6a2B6b83`](https://etherscan.io/address/0xDddd770BADd886dF3864029e4B377B5F6a2B6b83) (LLTV 86%), and wstETH via two oracles ([`0x48F7E36EB6B826B2dF4B2E630B62Cd25e89E40E2`](https://etherscan.io/address/0x48F7E36EB6B826B2dF4B2E630B62Cd25e89E40E2) and [`0x167D283aCAC1b9ff39466A75aA82902f340f1F4D`](https://etherscan.io/address/0x167D283aCAC1b9ff39466A75aA82902f340f1F4D), both LLTV 86%). All four markets use the same AdaptiveCurveIRM ([`0x870aC11D48B15DB9a138Cf899d20F13F79Ba00BC`](https://etherscan.io/address/0x870aC11D48B15DB9a138Cf899d20F13F79Ba00BC)). The vault is governed by Yearn's ySafe as guardian, has a 3-day timelock, 0% fee, and Yearn Security as fee recipient. Strategy-level allocation: cbBTC ~74.7% / WBTC ~14.7% / wstETH ~10.7% of the ~$2.15M MetaMorpho TVL.
+
 **Effective endpoint mix for yvDAI-1's deployed DAI (July 12):**
 
 | Endpoint | Path | Effective share |
 |----------|------|----------------:|
 | Sky **sUSDS** (Sky Savings Rate) | yvDAI-1 → yvUSDC-1 → sUSDS Lender **AND** yvDAI-1 → yvUSDS-1 → sUSDS Lender | **~89.6%** |
-| **Yearn USDC** strategy (yield source unverified) | yvDAI-1 → yvUSDC-1 → Yearn USDC | **~6.2%** |
+| **Morpho Blue** (cbBTC + WBTC + wstETH lending) | yvDAI-1 → yvUSDC-1 → Yearn USDC (Morpho MetaMorpho) | **~6.2%** |
 | Sky **USDS Staking Rewards** (SPK farm) | yvDAI-1 → yvUSDS-1 → Spark USDS Compounder | **~4.3%** |
 
-The cascade remains at most **two Yearn V3 vault layers deep**. Sky-ecosystem concentration (sUSDS + USDS Staking) is ~93.9%, down from ~100% at May 11 due to the new Yearn USDC strategy introducing a non-Sky dependent leg. The exact yield destination of the Yearn USDC strategy could not be verified on-chain and merits further investigation.
+The cascade remains at most **two Yearn V3 vault layers deep** (three when counting the MetaMorpho layer inside the Yearn USDC strategy). Sky-ecosystem concentration (sUSDS + USDS Staking) is ~93.9%, down from ~100% at May 11. The ~6.2% Yearn USDC leg is a Yearn-curated Morpho MetaMorpho vault — same governance as yvDAI-1 — that supplies USDC into Morpho Blue lending markets against cbBTC, WBTC, and wstETH collateral, diversifying the vault beyond the Sky ecosystem.
 
 **Key architecture:**
 
 - **Vault:** Standard Yearn V3 vault (v3.0.2) accepting DAI deposits, issuing yvDAI-1 shares. Deployed as an immutable Vyper minimal proxy (EIP-1167) via the v3.0.2 Yearn V3 Vault Factory ([`0x444045c5C13C246e117eD36437303cac8E250aB0`](https://etherscan.io/address/0x444045c5C13C246e117eD36437303cac8E250aB0))
 - **Default queue (2 strategies, both funded):**
-  - **DAI To USDC-1 Depositor** ([`0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5`](https://etherscan.io/address/0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5)) — 6,908,481.99 DAI (72.97%). DAI → USDC (Maker PSM Lite, 1:1 at 0% fee) → yvUSDC-1 deposit. yvUSDC-1 routes ~97.15% via its `USDC to sUSDS Lender` strategy directly into sUSDS, plus ~2.85% via `Spark USDC Lender` into Spark Lend
-  - **DAI to USDS Depositor** ([`0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d`](https://etherscan.io/address/0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d)) — 2,559,595.76 DAI (27.03%). DAI → USDS (Sky DAI-USDS Exchanger, 1:1, no fee) → yvUSDS-1 deposit. yvUSDS-1 currently routes 80.03% via its `sUSDS Lender` strategy (Sky Savings Rate) and 19.97% via its `Spark USDS Compounder` (Sky USDS Staking Rewards)
+  - **DAI To USDC-1 Depositor** ([`0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5`](https://etherscan.io/address/0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5)) — 6,951,724.02 DAI (73.19%). DAI → USDC (Maker PSM Lite, 1:1 at 0% fee) → yvUSDC-1 deposit. yvUSDC-1 routes ~91.59% via its `USDC to sUSDS Lender` strategy directly into sUSDS, plus ~8.41% via its `Yearn USDC` strategy (Morpho MetaMorpho vault) into Morpho Blue lending markets
+  - **DAI to USDS Depositor** ([`0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d`](https://etherscan.io/address/0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d)) — 2,545,516.51 DAI (26.81%). DAI → USDS (Sky DAI-USDS Exchanger, 1:1, no fee) → yvUSDS-1 deposit. yvUSDS-1 currently routes 84.09% via its `sUSDS Lender` strategy (Sky Savings Rate) and 15.91% via its `Spark USDS Compounder` (Sky USDS Staking Rewards)
 - **Removed from queue between April 27 and May 5:** Savings Dai (sDAI), Spark DAI Lender, Aave V3 DAI Lender — all previously zero-debt; remain absent at block 25073237
 - **Governance:** Standard **Yearn V3 Role Manager** ([`0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41`](https://etherscan.io/address/0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41)) governed by the **Yearn 6-of-9 ySafe** with **7-day TimelockController** for strategy additions
 
@@ -93,14 +95,14 @@ The cascade remains at most **two Yearn V3 vault layers deep**. Sky-ecosystem co
 
 ### Active Strategies (2 in default queue, 2 with debt)
 
-Default queue order at block 25073237:
+Default queue order at block 25519075:
 
 | # | Strategy | Name | Activation | Current Debt (DAI) | Allocation |
 |---|----------|------|------------|-------------------:|-----------:|
-| 1 | [`0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d`](https://etherscan.io/address/0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d) | **DAI to USDS Depositor** | 2025-05-15 | **2,559,595.76** | **27.03%** |
-| 2 | [`0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5`](https://etherscan.io/address/0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5) | **DAI To USDC-1 Depositor** | 2025-10-24 | **6,908,481.99** | **72.97%** |
+| 1 | [`0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d`](https://etherscan.io/address/0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d) | **DAI to USDS Depositor** | 2025-05-15 | **2,545,516.51** | **26.81%** |
+| 2 | [`0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5`](https://etherscan.io/address/0xfF03Dce6d95aa7a30B75EFbaFD11384221B9f9B5) | **DAI To USDC-1 Depositor** | 2025-10-24 | **6,951,724.02** | **73.19%** |
 
-Last reports: DAI to USDS Depositor 2026-05-03 (`last_report = 1777780343`); DAI To USDC-1 Depositor 2026-05-03 (`last_report = 1777777319`).
+Last reports: DAI to USDS Depositor 2026-07-12; DAI To USDC-1 Depositor 2026-07-12.
 
 **Removed from queue between April 27 and May 5 (no longer in `get_default_queue()`):**
 
@@ -117,14 +119,14 @@ After the vault-of-vaults unwind:
 | Effective endpoint | Path | Effective share |
 |--------------------|------|----------------:|
 | **Sky / sUSDS (Sky Savings Rate)** | yvDAI-1 → yvUSDC-1 → `USDC to sUSDS Lender` (~67.0%) **AND** yvDAI-1 → yvUSDS-1 → `sUSDS Lender` (~22.6%) | **~89.6%** |
-| **Yearn USDC** (yield source unverified) | yvDAI-1 → yvUSDC-1 → `Yearn USDC` | **~6.2%** |
+| **Morpho Blue lending** (cbBTC + WBTC + wstETH) | yvDAI-1 → yvUSDC-1 → `Yearn USDC` (Morpho MetaMorpho) | **~6.2%** |
 | **Sky USDS Staking Rewards (SPK farm)** | yvDAI-1 → yvUSDS-1 → Spark USDS Compounder → Sky USDS Staking | **~4.3%** |
 | **MakerDAO PSM Lite** (USDC ↔ DAI) | Used by `DAI To USDC-1 Depositor` for inbound DAI → USDC conversion (and reverse on withdrawal) | High during routing |
 | **Sky DAI-USDS Exchanger** (DAI ↔ USDS) | Used by `DAI to USDS Depositor` for inbound DAI → USDS conversion (and reverse on withdrawal) | High during routing |
 | **yvUSDC-1** (intermediate vault) | 73.19% of yvDAI-1 routes through it | Vault-of-vaults dependency |
 | **yvUSDS-1** (intermediate vault) | 26.81% of yvDAI-1 routes through it | Vault-of-vaults dependency |
 
-Net Sky-ecosystem concentration: ~93.9% of deployed DAI (sUSDS + Sky USDS Staking). The remaining ~6.2% is deployed through the `Yearn USDC` strategy whose exact yield destination could not be verified on-chain — marked TODO for further investigation.
+Net Sky-ecosystem concentration: ~93.9% of deployed DAI (sUSDS + Sky USDS Staking). The remaining ~6.2% is deployed through the `Yearn USDC` strategy — a **Yearn-curated Morpho MetaMorpho vault** that supplies USDC into Morpho Blue lending markets against cbBTC, WBTC, and wstETH collateral, providing diversification beyond the Sky ecosystem under the same Yearn governance.
 
 ## Audits and Due Diligence Disclosures
 
@@ -163,6 +165,7 @@ All strategies pass through Yearn's **12-metric risk-scoring framework** ([RISK_
 - **Yearn (Immunefi):** active, **$200,000** max payout (Critical). https://immunefi.com/bounty/yearnfinance/
 - **Yearn (Sherlock):** also listed at https://audits.sherlock.xyz/bug-bounties/30
 - **Sky / MakerDAO (Immunefi):** active, **$10,000,000** max payout (Critical). Scope includes DAI, USDS, sUSDS, PSM. https://immunefi.com/bug-bounty/sky/
+- **Morpho Blue (Immunefi):** active, **$2,500,000** max payout (Critical). https://immunefi.com/bug-bounty/morpho/
 - **Safe Harbor (SEAL):** Yearn is **not** listed on the SEAL Safe Harbor registry
 
 ### On-Chain Complexity
@@ -189,7 +192,7 @@ The vault-of-vaults composition is **not leverage** but is a real complexity sur
 - **Strategy changes:** active management. Between April 27 and May 5, three direct-deposit fallbacks (sDAI, Spark DAI Lender, Aave V3 DAI Lender) were removed from the default queue (and remain absent at July 12). Between May 5 and May 11, the depositor allocation shifted from 79.44 / 20.56 to 72.97 / 27.03 (USDC / USDS). The allocation at July 12 is 73.19 / 26.81 — largely stable since May 11
 - **Vault-of-vaults rewiring (downstream):**
   - Between May 11 and July 12, both intermediate vaults added new strategies. **yvUSDC-1** added a new "Yearn USDC" strategy ([`0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3`](https://etherscan.io/address/0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3)) that now holds 8.41% of tracked debt, replacing the old `Spark USDC Lender` ([`0x25f893276544d86a82b1ce407182836F45cb6673`](https://etherscan.io/address/0x25f893276544d86a82b1ce407182836F45cb6673)) which now has 0 tracked debt. The Spark USDC Lender was replaced by a new version at [`0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a`](https://etherscan.io/address/0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a) (currently 0 debt). **yvUSDS-1** added a new "USDS Sky Rewards Compounder" strategy ([`0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81`](https://etherscan.io/address/0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81), v3.0.3 TokenizedStrategy) as a successor to the existing `Spark USDS Compounder`, currently with near-zero debt
-  - **Net effect at July 12:** effective endpoint mix is ~89.6% sUSDS / ~6.2% Yearn USDC (yield source unverified) / ~4.3% Sky USDS Staking. Overall Sky-ecosystem concentration dropped from ~100% to ~93.9% as the Spark Lend USDC leg was replaced by the Yearn USDC strategy
+  - **Net effect at July 12:** effective endpoint mix is ~89.6% sUSDS / ~6.2% Morpho Blue lending (via Yearn USDC MetaMorpho) / ~4.3% Sky USDS Staking. Overall Sky-ecosystem concentration dropped from ~100% to ~93.9% as the Spark Lend USDC leg was replaced by the Yearn USDC MetaMorpho vault deploying into Morpho Blue markets
 - **Yearn V3 track record:** V3 framework has been live since May 2024 (~26 months). No V3 vault exploits
 
 **Yearn protocol TVL:** ~$197.5M total across all chains ([DeFiLlama](https://defillama.com/protocol/yearn), April 2026).
@@ -198,7 +201,7 @@ The vault-of-vaults composition is **not leverage** but is a real complexity sur
 
 ## Funds Management
 
-yvDAI-1 deploys ~99.9999% of its DAI via two depositor strategies. Both routes terminate mostly inside the Sky ecosystem, with a ~6.2% leg through a new Yearn USDC strategy whose exact yield source is unverified.
+yvDAI-1 deploys ~99.9999% of its DAI via two depositor strategies. The majority terminates inside the Sky ecosystem, with a ~6.2% leg through the Yearn USDC strategy — a Yearn-curated Morpho MetaMorpho vault that supplies USDC into Morpho Blue lending markets against cbBTC, WBTC, and wstETH collateral.
 
 ### Strategy 1: DAI To USDC-1 Depositor (73.19% allocation)
 
@@ -208,9 +211,9 @@ yvDAI-1 deploys ~99.9999% of its DAI via two depositor strategies. Both routes t
 
 1. **DAI → USDC** via MakerDAO PSM Lite ([`0xf6e72Db5454dd049d0788e411b06CfAF16853042`](https://etherscan.io/address/0xf6e72Db5454dd049d0788e411b06CfAF16853042)) — 1:1 at **0% fee** (`tin = tout = 0`)
 2. **USDC → yvUSDC-1** deposit (ERC-4626)
-3. yvUSDC-1 internally routes ~91.59% to its `USDC to sUSDS Lender` strategy ([`0x7130570BCEfCedBe9d15B5b11A33006156460f8f`](https://etherscan.io/address/0x7130570BCEfCedBe9d15B5b11A33006156460f8f)) → USDC → USDS (or sUSDS-internal conversion) → sUSDS, plus ~8.41% to its `Yearn USDC` strategy ([`0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3`](https://etherscan.io/address/0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3)) whose yield destination could not be verified on-chain (TODO). The `Spark USDC Lender` (new version at [`0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a`](https://etherscan.io/address/0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a)) holds 0 debt. The old Spark USDC Lender at [`0x25f893276544d86a82b1ce407182836F45cb6673`](https://etherscan.io/address/0x25f893276544d86a82b1ce407182836F45cb6673) has 0 tracked debt and is no longer in the default queue
+3. yvUSDC-1 internally routes ~91.59% to its `USDC to sUSDS Lender` strategy ([`0x7130570BCEfCedBe9d15B5b11A33006156460f8f`](https://etherscan.io/address/0x7130570BCEfCedBe9d15B5b11A33006156460f8f)) → USDC → USDS (or sUSDS-internal conversion) → sUSDS, plus ~8.41% to its `Yearn USDC` strategy ([`0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3`](https://etherscan.io/address/0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3)) — a **Yearn-curated Morpho MetaMorpho vault** that supplies USDC into four Morpho Blue markets against cbBTC, WBTC, and wstETH collateral (LLTV 86% each, AdaptiveCurveIRM). The `Spark USDC Lender` (new version at [`0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a`](https://etherscan.io/address/0x654a7c4Ae5ac3C853a99F8dbEAD2bC85090F753a)) holds 0 debt. The old Spark USDC Lender at [`0x25f893276544d86a82b1ce407182836F45cb6673`](https://etherscan.io/address/0x25f893276544d86a82b1ce407182836F45cb6673) has 0 tracked debt and is no longer in the default queue
 
-**Withdrawal:** reverse path. The user's `redeem` on yvDAI-1 triggers `withdraw` from this strategy → `redeem` from yvUSDC-1 → `withdraw` from yvUSDC-1's downstream (sUSDS Lender or Spark USDC Lender) → unwind into USDC → DAI via PSM. All atomic in the same transaction.
+**Withdrawal:** reverse path. The user's `redeem` on yvDAI-1 triggers `withdraw` from this strategy → `redeem` from yvUSDC-1 → `withdraw` from yvUSDC-1's downstream (sUSDS Lender or Yearn USDC MetaMorpho → Morpho Blue) → unwind into USDC → DAI via PSM. All atomic in the same transaction.
 
 **Strategy parameters:**
 - Activated: 2025-10-24
@@ -260,7 +263,7 @@ The removal of all three direct-deposit fallbacks eliminates the on-chain single
 
 - **PPS:** ERC-4626, fully algorithmic
 - **Strategy `totalAssets()`:** reads the underlying yvUSDC-1 / yvUSDS-1 share balance and converts via ERC-4626 `convertToAssets()` — fully on-chain, real-time
-- **Multi-layer verification:** anyone can independently verify yvDAI-1 → yvUSDC-1 → (sUSDS or Spark Lend USDC) and yvDAI-1 → yvUSDS-1 → Spark USDS Compounder on-chain. Each layer's exchange rate is its own ERC-4626 calculation
+- **Multi-layer verification:** anyone can independently verify yvDAI-1 → yvUSDC-1 → (sUSDS or Yearn USDC MetaMorpho → Morpho Blue) and yvDAI-1 → yvUSDS-1 → Spark USDS Compounder on-chain. Each layer's exchange rate is its own ERC-4626 calculation
 - **Profit / loss reporting:** keepers via `process_report()`, profits unlock over 10 days
 
 The vault-of-vaults adds a small surface area to verify (multiple `totalAssets()` reads) but does not add any off-chain dependency.
@@ -268,13 +271,13 @@ The vault-of-vaults adds a small surface area to verify (multiple `totalAssets()
 ## Liquidity Risk
 
 - **Primary exit:** Redeem yvDAI-1 for DAI via ERC-4626 `withdraw()` / `redeem()`. Triggers reverse pipeline through yvUSDC-1 / yvUSDS-1 (atomic, multi-step in the same transaction)
-- **Highly liquid underlying:** sUSDS holds multi-billion TVL; USDS Staking Rewards has multi-billion USDS staked. yvDAI-1's ~$9.47M is a tiny fraction of underlying capacity
+- **Highly liquid underlying:** sUSDS holds multi-billion TVL; USDS Staking Rewards has multi-billion USDS staked; Morpho Blue markets for cbBTC, WBTC, and wstETH are deep and liquid. yvDAI-1's ~$9.50M is a tiny fraction of underlying capacity
 - **PSM liquidity:** MakerDAO PSM Lite provides deep DAI ↔ USDC liquidity at 1:1, 0% fee. PSM capacity is managed by Sky governance and typically holds billions of USDC
-- **Cascading withdrawal mechanics:** both depositor paths traverse **two Yearn V3 vault layers** (yvDAI-1 → yvUSDC-1 or yvDAI-1 → yvUSDS-1) plus the terminal unstake (sUSDS withdrawal, Spark Lend supply withdrawal, or Spark Compounder unwind). Neither intermediate vault chains through the other, so the cascade is bounded at two Yearn-vault layers. All steps execute atomically in the same transaction
-- **No DEX liquidity needed** — exit is via Sky's own contracts (PSM, Exchanger, sUSDS, USDS Staking) and Spark Lend
+- **Cascading withdrawal mechanics:** both depositor paths traverse **two Yearn V3 vault layers** (yvDAI-1 → yvUSDC-1 or yvDAI-1 → yvUSDS-1) plus the terminal unstake (sUSDS withdrawal, Morpho Blue withdrawal, or Spark Compounder unwind). The Yearn USDC path adds an additional MetaMorpho layer (bounded). Neither intermediate vault chains through the other. All steps execute atomically in the same transaction
+- **No DEX liquidity needed** — exit is via Sky's own contracts (PSM, Exchanger, sUSDS, USDS Staking) and Morpho Blue
 - **Same-value asset:** DAI-denominated vault token — no price-divergence risk
 - **No withdrawal queue or cooldown** — atomic redemption
-- **Deposit limit:** 50M DAI cap vs ~$9.47M TVL (room for +428%)
+- **Deposit limit:** 50M DAI cap vs ~$9.50M TVL (room for +426%)
 
 The cascading multi-layer withdrawal is atomic but has a higher gas cost than a single-strategy vault. For a large institutional withdrawal, the gas of unwinding through both layers plus the terminal Sky / Spark unstakes should be considered when sizing the redemption.
 
@@ -318,13 +321,13 @@ After resolving the vault-of-vaults composition, yvDAI-1's effective dependencie
 | **yvUSDC-1** (intermediate vault) | Critical — 73.19% of deployed funds route through it | Same governance, audits, code as yvDAI-1. See [yvUSDC-1 report](./yearn-yvusdc.md) |
 | **yvUSDS-1** (intermediate vault) | Critical — 26.81% of deployed funds route through it | Same governance, audits, code. See [yvUSDS-1 report](./yearn-yvusds.md) |
 | **Sky / sUSDS** (Sky Savings Rate) | Critical — ~89.6% of effective deployment (via both intermediate vaults) | Multi-billion sUSDS TVL, $10M Immunefi bounty |
-| **Yearn USDC strategy** | Moderate — ~6.2% of effective deployment (via yvUSDC-1) | Custom Yearn-branded strategy (not a standard TokenizedStrategy); yield source could not be verified on-chain (TODO) |
+| **Yearn USDC (Morpho MetaMorpho)** | Moderate — ~6.2% of effective deployment (via yvUSDC-1) | Yearn-curated Morpho MetaMorpho vault supplying USDC into Morpho Blue (cbBTC, WBTC, wstETH collateral; LLTV 86%; AdaptiveCurveIRM). Same Yearn governance (ySafe guardian, Security fee recipient, 3-day timelock). Morpho Blue audited by Cantina, Spearbit, ChainSecurity |
 | **Sky USDS Staking Rewards (SPK farm)** | Moderate — ~4.3% of effective deployment (via yvUSDS-1) | First-party Sky contract; share decreased from ~5.4% at May 11 |
 | **MakerDAO PSM Lite** | High during routing (used by yvUSDC-1 path) | 1:1, 0% fee, audited |
 | **Sky DAI-USDS Exchanger** | High during routing (used by yvUSDS-1 path) | 1:1, no fee, audited |
 | **DAI / USDS / USDC tokens** | Critical | Inherited from each conversion hop |
 
-**Dependency quality:** most dependencies are top-tier — Sky / MakerDAO infrastructure plus Yearn V3 itself. The vault-of-vaults composition concentrates dependency on the Sky ecosystem (~93.9% of effective deployment across sUSDS + USDS Staking) and on Yearn V3's own vault accounting working correctly across two layers. The ~6.2% `Yearn USDC` leg represents an _unverified_ dependency whose yield destination and associated protocol risk could not be determined.
+**Dependency quality:** all dependencies are top-tier — Sky / MakerDAO infrastructure, Morpho Blue (audited by 3+ firms, battle-tested lending primitive), plus Yearn V3 itself. The vault-of-vaults composition concentrates dependency on the Sky ecosystem (~93.9% of effective deployment across sUSDS + USDS Staking) and on Yearn V3's own vault accounting working correctly across two vault layers. The ~6.2% Yearn USDC leg is a Yearn-curated Morpho MetaMorpho vault under the same Yearn governance, with the Morpho Blue protocol as a well-audited, non-Sky dependency that provides collateral diversification.
 
 ## Operational Risk
 
@@ -355,7 +358,7 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 | DAI to USDS Depositor | [`0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d`](https://etherscan.io/address/0xAeDF7d5F3112552E110e5f9D08c9997Adce0b78d) | `totalAssets()`, `isShutdown()`, keeper report |
 | yvUSDC-1 (upstream dependency) | [`0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204`](https://etherscan.io/address/0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204) | PPS, shutdown state, strategy queue |
 | yvUSDS-1 (upstream dependency) | [`0x182863131F9a4630fF9E27830d945B1413e347E8`](https://etherscan.io/address/0x182863131F9a4630fF9E27830d945B1413e347E8) | PPS, shutdown state, strategy queue |
-| Yearn USDC strategy | [`0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3`](https://etherscan.io/address/0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3) | `totalAssets()`, yield destination (TODO: unverified) |
+| Yearn USDC (Morpho MetaMorpho) | [`0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3`](https://etherscan.io/address/0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3) | `totalAssets()`, `totalSupply()`, `supplyQueue()`, Morpho Blue market utilization rates |
 | USDS Sky Rewards Compounder | [`0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81`](https://etherscan.io/address/0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81) | `totalAssets()`, debt migration from Spark USDS Compounder |
 | MakerDAO PSM Lite | [`0xf6e72Db5454dd049d0788e411b06CfAF16853042`](https://etherscan.io/address/0xf6e72Db5454dd049d0788e411b06CfAF16853042) | `tin`, `tout` (fee parameters) |
 | Sky DAI-USDS Exchanger | [`0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A`](https://etherscan.io/address/0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A) | Pause state |
@@ -370,7 +373,7 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 - **DAI-USDS Exchanger pause state**
 - **Sky USDS Staking Rewards pause / migration** (affects ~4.3% of effective deployment via yvUSDS-1)
 - **Sky sUSDS pause / migration** (affects ~89.6% of effective deployment via both intermediate vaults — dominant exposure)
-- **Yearn USDC strategy event or exploit** (affects ~6.2% of effective deployment via yvUSDC-1; yield source unverified)
+- **Yearn USDC MetaMorpho: guardian or curator changes, market removal, or exploit** (affects ~6.2% of effective deployment via yvUSDC-1)
 - **ySafe / Brain / Security signer or threshold changes**
 
 ### Monitoring Functions
@@ -403,14 +406,14 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 ### Key Risks
 
 - **Vault-of-vaults composition (2 layers):** both depositor paths traverse two Yearn V3 vault layers. A bug or accounting issue at any layer cascades. Each layer's emergency state (shutdown, deposit pause) directly affects yvDAI-1
-- **Effective concentration into Sky ecosystem:** ~93.9% of deployed DAI ultimately ends up in Sky-ecosystem contracts (sUSDS ~89.6%, Sky USDS Staking ~4.3%). The remaining ~6.2% is deployed through the `Yearn USDC` strategy whose exact yield destination is unverified. A bug or governance failure at the sUSDS contract would affect ~89.6% of deployed value; a Sky-wide systemic failure would affect ~93.9%
+- **Effective concentration into Sky ecosystem:** ~93.9% of deployed DAI ultimately ends up in Sky-ecosystem contracts (sUSDS ~89.6%, Sky USDS Staking ~4.3%). The remaining ~6.2% is deployed through the `Yearn USDC` MetaMorpho vault into Morpho Blue lending markets (cbBTC, WBTC, wstETH collateral) — a non-Sky dependency under the same Yearn governance. A bug or governance failure at the sUSDS contract would affect ~89.6% of deployed value; a Sky-wide systemic failure would affect ~93.9%
 - **Sky Savings Rate / SPK reward rate variability:** affects yield, not principal
 - **PSM fee risk:** currently 0%, but Sky governance can change. Above 0.05% the strategy can fall back to Uniswap V3 with 0.5% slippage
 - **Intermediate-vault dependency:** both paths have a single intermediate Yearn V3 vault (yvUSDC-1 or yvUSDS-1) between yvDAI-1 and the terminal Sky / Spark contracts
 
 ### Critical Risks
 
-- None identified. The dominant systemic risk is a Sky USDS / sUSDS / USDS Staking failure, which would simultaneously impair the four risk-1 stable vaults — but that is a system-wide DeFi event, not a Yearn-specific risk. The ~6.2% `Yearn USDC` leg uses an unverified yield source; a bug or exploit in that strategy would affect ~6.2% of deployed DAI.
+- None identified. The dominant systemic risk is a Sky USDS / sUSDS / USDS Staking failure, which would simultaneously impair the four risk-1 stable vaults — but that is a system-wide DeFi event, not a Yearn-specific risk. The ~6.2% Yearn USDC Morpho leg diversifies into non-Sky collateral (cbBTC/WBTC/wstETH) under Yearn governance, reducing the single-ecosystem concentration from ~100% to ~93.9%. A bug or exploit in the Yearn USDC MetaMorpho strategy would affect ~6.2% of deployed DAI.
 
 ---
 
@@ -475,11 +478,11 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 
 | Factor | Assessment |
 |--------|-----------|
-| Protocol count (effective) | 1 ecosystem (Sky) for ~93.9% of effective deployment plus a ~6.2% unverified Yearn USDC leg; plus dependency on Yearn V3's own vault-of-vaults accounting (bounded at 2 layers) |
-| Criticality | Sky sUSDS critical (~89.6% of deployed funds, via both intermediate vaults); Yearn USDC strategy moderate (~6.2% via yvUSDC-1, yield source unverified); Sky USDS Staking moderate (~4.3% via yvUSDS-1); same-team Yearn V3 dependency at both intermediate vaults |
-| Quality | Top-tier (Sky $10M bounty, multi-billion sUSDS TVL) plus same Yearn V3 framework; Yearn USDC strategy quality unverified |
+| Protocol count (effective) | 2 ecosystems (Sky ~93.9%, Morpho Blue ~6.2%); plus dependency on Yearn V3's own vault-of-vaults accounting (bounded at 2 Yearn vault layers, 3 including MetaMorpho) |
+| Criticality | Sky sUSDS critical (~89.6% of deployed funds, via both intermediate vaults); Yearn USDC MetaMorpho moderate (~6.2% via yvUSDC-1, deploys into Morpho Blue cbBTC/WBTC/wstETH lending under Yearn governance); Sky USDS Staking moderate (~4.3% via yvUSDS-1); same-team Yearn V3 dependency at both intermediate vaults |
+| Quality | Top-tier: Sky $10M bounty, multi-billion sUSDS TVL; Morpho Blue audited by Cantina, Spearbit, ChainSecurity with $2.5M Immunefi bounty; same Yearn V3 framework throughout |
 
-**Dependencies Score: 2.5 / 5** — Sky-ecosystem effective concentration (~93.9%) plus a two-layer vault-of-vaults dependency on Yearn V3 itself, with an unverified 6.2% leg through a custom Yearn USDC strategy. The Sky ecosystem quality is excellent, but the concentration and unverified leg warrant 2.5.
+**Dependencies Score: 2.5 / 5** — Sky-ecosystem effective concentration (~93.9%) plus a two-layer vault-of-vaults dependency on Yearn V3 itself (three layers including the MetaMorpho vault). The ~6.2% Morpho Blue leg provides collateral diversification under the same Yearn governance. Both Sky and Morpho are top-tier protocols. The concentration still warrants 2.5, but the composition is now verified and understood.
 
 **Centralization Score = (1.0 + 1.0 + 2.5) / 3 ≈ 1.5**
 
@@ -573,7 +576,7 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 - **Downstream rewiring (the dominant change vector at recent snapshots):**
   - if yvUSDC-1 reroutes materially away from its current `USDC to sUSDS Lender` strategy, yvDAI-1's effective endpoint mix changes accordingly — ~67.0 percentage points of the sUSDS share is inherited from yvUSDC-1
   - if yvUSDS-1 rewires its current 84.09 / 15.91 sUSDS Lender / Spark Compounder split, yvDAI-1's secondary exposure changes accordingly — ~22.6 percentage points of the sUSDS share and the entire ~4.3% USDS Staking share are inherited from yvUSDS-1
-  - **Yearn USDC strategy:** reassess if the `Yearn USDC` strategy's yield destination is identified or changed materially; the strategy currently holds ~6.2% of effective deployment and its protocol risk is unverified
+  - **Yearn USDC MetaMorpho:** reassess if the strategy's Morpho Blue market allocations change materially, if markets are added/removed from the supply queue, or if the guardian/curator changes. Current allocation: cbBTC ~74.7% / WBTC ~14.7% / wstETH ~10.7% of ~$2.15M TVL
   - **USDS Sky Rewards Compounder:** reassess if the new `USDS Sky Rewards Compounder` ([`0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81`](https://etherscan.io/address/0x0868076663Bbc6638ceDd27704cc8F0Fa53d5b81), v3.0.3) replaces the existing `Spark USDS Compounder` in the yvUSDS-1 default queue and begins receiving meaningful debt
 - **Vault-of-vaults composition:**
   - **reassess if a new strategy is added that creates a third Yearn-vault layer** (the cascade is currently 2 layers deep)
@@ -632,12 +635,12 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 │            │                                   │                          │
 │            ▼                                   ▼                          │
 │   sUSDS (Sky Savings Rate)             sUSDS + Sky USDS Staking Rewards │
-│   + Yearn USDC (yield TBD)             (SPK farm)                       │
+│   + Morpho Blue (cbBTC/WBTC/wstETH)    (SPK farm)                       │
 └─────────────────────────────────────────────────────────────────────────┘
 
 Effective endpoint mix for yvDAI-1's deployed DAI (July 12, 2026):
   ~89.6%  Sky sUSDS         (combined: yvUSDC-1→sUSDS Lender ~67.0% + yvUSDS-1→sUSDS Lender ~22.6%)
-  ~6.2%   Yearn USDC        (via yvUSDC-1 → Yearn USDC, yield source unverified)
+  ~6.2%   Morpho Blue        (via yvUSDC-1 → Yearn USDC MetaMorpho → Morpho Blue lending: cbBTC, WBTC, wstETH)
   ~4.3%   Sky USDS Staking   (via yvUSDS-1 → Spark USDS Compounder)
 ```
 
@@ -664,4 +667,4 @@ To shorten the delay, Daddy 6/9 must propose `updateDelay()`, wait 7 days during
 | Date | Score | Notes |
 |------|-------|-------|
 | May 11, 2026 | 1.3/5.0 | Initial assessment. yvDAI-1 with vault-of-vaults composition routing ~100% into Sky ecosystem via yvUSDC-1 (73%) and yvUSDS-1 (27%). Spark Lend USDC and sUSDS legs. |
-| July 12, 2026 | 1.3/5.0 | Reassessment: TVL stable at ~$9.50M. yvUSDC-1 added new "Yearn USDC" strategy (8.41% tracked debt, yield source unverified — TODO). Old Spark USDC Lender replaced. yvUSDS-1 added v3.0.3 "USDS Sky Rewards Compounder" (currently near-zero debt). Sky-ecosystem concentration dropped from ~100% to ~93.9%. Effective endpoint mix: ~89.6% sUSDS / ~6.2% Yearn USDC / ~4.3% Sky USDS Staking. All governance roles, multisig thresholds, and timelock delay unchanged. Score unchanged at 1.3. |
+| July 12, 2026 | 1.3/5.0 | Reassessment: TVL stable at ~$9.50M. yvUSDC-1 added new "Yearn USDC" strategy (8.41% tracked debt) — verified as a Yearn-curated Morpho MetaMorpho vault supplying USDC into Morpho Blue (cbBTC, WBTC, wstETH collateral, LLTV 86%). Old Spark USDC Lender replaced. yvUSDS-1 added v3.0.3 "USDS Sky Rewards Compounder" (currently near-zero debt). Sky-ecosystem concentration dropped from ~100% to ~93.9%. Effective endpoint mix: ~89.6% sUSDS / ~6.2% Morpho Blue / ~4.3% Sky USDS Staking. All governance roles, multisig thresholds, and timelock delay unchanged. Score unchanged at 1.3. |


### PR DESCRIPTION
## Reassessment: yvDAI-1

**Closes:** #305

### Summary

Refreshed the yvDAI-1 risk report with current-state on-chain data.

**Snapshot:** July 12, 2026 (block 25519075)

### Changed Facts

| Fact | May 11 (old) | July 12 (new) |
|------|-------------|---------------|
| TVL | ~$9.47M DAI | ~$9.50M DAI |
| PPS | 1.118469 | 1.123954 |
| Alloc USDC/USDS depositors | 72.97/27.03% | 73.19/26.81% |
| yvUSDC-1 strategies | 3 (sUSDS 97.15%, Spark USDC 2.85%, USDS Dep 0%) | 4 (sUSDS 91.59%, Yearn USDC 8.41%, Spark USDC 0%, USDS Dep 0%) |
| yvUSDS-1 strategies | 2 (sUSDS 80.03%, Spark 19.97%) | 3 (USDS Sky Rewards 0%, Spark 15.91%, sUSDS 84.09%) |
| Effective sUSDS share | ~92.5% | ~89.6% |
| Effective Sky USDS Staking | ~5.4% | ~4.3% |
| Spark Lend USDC exposure | ~2.1% | 0% (removed) |
| **New:** Yearn USDC strategy | N/A | ~6.2% (yield destination unverified — TODO) |
| Sky ecosystem concentration | ~100% | ~93.9% |

### Unchanged Critical Controls
- Daddy/ySafe: 6-of-9 ✅
- Brain: 3-of-8 ✅
- Security: 4-of-7 ✅
- Timelock delay: 7 days ✅
- Role Manager category: 1 ✅
- Vault: v3.0.2, immutable, 2-strategy default queue ✅
- Deposit limit: 50M DAI ✅

### Score
**Unchanged at 1.3/5.0 (Minimal Risk)**

### Graph
Updated allocation labels in `reports/graph/yearn-yvdai.yaml` (73.19%/26.81%).

### TODOs
- **Yearn USDC strategy (0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3):** ~$2.15M USDC equivalent deployed into an unknown protocol. The strategy is a custom 19KB contract (not a standard TokenizedStrategy). On-chain token balance checks (sUSDS, USDS, aUSDC, spUSDC, cUSDCv3, Morpho variants) all returned zero. Marked TODO in report.

### Validation
`npm run build` failed due to a pre-existing missing `@plausible-analytics/tracker` dependency — unrelated to report changes.