### PR TITLE
Reassess yvWBTC-1 (yearn-yvwbtc): MetaMorpho strategy activated, score 1.2→1.4

### DIFF
--- a/reports/graph/yearn-yvdai.yaml
+++ b/reports/graph/yearn-yvdai.yaml
@@ -122,7 +122,7 @@ edges:
   - from: daddy
     to: yvDAI
     kind: holds-role
-    label: "all 14 roles"
+    label: "12 of 14 roles"
   - from: brain
     to: yvDAI
     kind: holds-role

--- a/reports/graph/yearn-yvusdc.yaml
+++ b/reports/graph/yearn-yvusdc.yaml
@@ -128,7 +128,7 @@ edges:
   - from: daddy
     to: yvUSDC
     kind: holds-role
-    label: "all 14 roles"
+    label: "12 of 14 roles"
   - from: brain
     to: yvUSDC
     kind: holds-role

--- a/reports/graph/yearn-yvusds.yaml
+++ b/reports/graph/yearn-yvusds.yaml
@@ -124,7 +124,7 @@ edges:
   - from: daddy
     to: yvUSDS
     kind: holds-role
-    label: "all 14 roles"
+    label: "12 of 14 roles"
   - from: brain
     to: yvUSDS
     kind: holds-role

--- a/reports/graph/yearn-yvusdt.yaml
+++ b/reports/graph/yearn-yvusdt.yaml
@@ -124,7 +124,7 @@ edges:
   - from: daddy
     to: yvUSDT
     kind: holds-role
-    label: "all 14 roles"
+    label: "12 of 14 roles"
   - from: brain
     to: yvUSDT
     kind: holds-role

--- a/reports/graph/yearn-yvwbtc.yaml
+++ b/reports/graph/yearn-yvwbtc.yaml
@@ -5,6 +5,8 @@ chain: ethereum
 categories:
   - id: vault
     label: Vault
+  - id: strategy
+    label: Strategy
   - id: governance
     label: Governance / Multisig
   - id: infra
@@ -15,7 +17,7 @@ categories:
 nodes:
   # Vault layer
   - id: yvWBTC
-    label: yvWBTC-1 (100% idle, empty queue)
+    label: yvWBTC-1 (100% deployed)
     address: "0x751F0cC6115410A3eE9eC92d08f46Ff6Da98b708"
     category: vault
   - id: accountant
@@ -26,6 +28,13 @@ nodes:
     label: Fee Recipient (Dumper)
     address: "0x590Dd9399bB53f1085097399C3265C7137c1C4Cf"
     category: vault
+
+  # Strategy
+  - id: ymv-wbtc
+    label: ymv-WBTC (MetaMorpho)
+    address: "0x2bB005127069A0F0325Fb7370967E8A2b64FB77E"
+    category: strategy
+    note: "Immutable MetaMorpho V1_1 ERC-4626 vault. Owner: Security 4-of-7 / Guardian: ySafe 6-of-9 / Curator: 2-of-3 Safe. Fee: 0%, 3-day curator timelock."
 
   # Governance
   - id: daddy
@@ -48,6 +57,10 @@ nodes:
     label: Yearn V3 Role Manager
     address: "0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41"
     category: governance
+  - id: curator
+    label: Curator (2-of-3)
+    address: "0x90D0f26025571295D18a6c041E47450B81886B51"
+    category: governance
 
   # Infra / bots
   - id: keeper
@@ -63,12 +76,27 @@ nodes:
     address: "0x770D0d1Fb036483Ed4AbB6d53c1C88fb277D812F"
     category: infra
 
-  # Underlying asset (only dependency at snapshot)
+  # External dependencies
   - id: wbtc
     label: WBTC (BitGo-custodied)
     address: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
     category: dependency
-    note: Underlying asset only — no strategies attached at the snapshot
+    note: Underlying asset for vault and Morpho Blue loan token
+  - id: morpho-blue
+    label: Morpho Blue
+    address: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
+    category: dependency
+    note: Immutable lending primitive (v1). Holds 100% of strategy TVL (82% idle market, 18% WBTC/LBTC market).
+  - id: lbtc
+    label: LBTC (Lombard BTC)
+    address: "0x8236a87084f8B84306f72007F36F2618A5634494"
+    category: dependency
+    note: Collateral token in active WBTC/LBTC market (94.5% LLTV)
+  - id: cbbtc
+    label: cbBTC (Coinbase BTC)
+    address: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+    category: dependency
+    note: Collateral token in queued WBTC/cbBTC market (no current position)
 
 edges:
   # Deployment / vault infrastructure
@@ -83,11 +111,25 @@ edges:
     to: dumper
     kind: routes-fees-to
 
-  # Vault holds underlying directly (100% idle)
+  # Capital flow: vault → strategy → Morpho Blue
   - from: yvWBTC
-    to: wbtc
+    to: ymv-wbtc
+    kind: allocates-to
+    label: "100%"
+  - from: ymv-wbtc
+    to: morpho-blue
     kind: deposits-into
-    label: "100% idle (held at vault)"
+    label: "82% idle / 18% WBTC-LBTC"
+
+  # Morpho Blue dependency chain
+  - from: morpho-blue
+    to: lbtc
+    kind: routes-through
+    label: "collateral (active)"
+  - from: morpho-blue
+    to: cbbtc
+    kind: routes-through
+    label: "collateral (queued)"
 
   # Governance roles on vault
   - from: daddy
@@ -135,3 +177,17 @@ edges:
     to: timelock
     kind: cancels-on
     label: CANCELLER
+
+  # MetaMorpho governance
+  - from: security
+    to: ymv-wbtc
+    kind: holds-role
+    label: "owner"
+  - from: daddy
+    to: ymv-wbtc
+    kind: holds-role
+    label: "guardian"
+  - from: curator
+    to: ymv-wbtc
+    kind: holds-role
+    label: "curator"

--- a/reports/graph/yearn-yvwbtc.yaml
+++ b/reports/graph/yearn-yvwbtc.yaml
@@ -135,7 +135,7 @@ edges:
   - from: daddy
     to: yvWBTC
     kind: holds-role
-    label: "all 14 roles"
+    label: "12 of 14 roles"
   - from: brain
     to: yvWBTC
     kind: holds-role

--- a/reports/graph/yearn-yvweth.yaml
+++ b/reports/graph/yearn-yvweth.yaml
@@ -132,7 +132,7 @@ edges:
   - from: daddy
     to: yvWETH
     kind: holds-role
-    label: "all 14 roles"
+    label: "12 of 14 roles"
   - from: brain
     to: yvWETH
     kind: holds-role

--- a/reports/report/yearn-yvwbtc.md
+++ b/reports/report/yearn-yvwbtc.md
@@ -102,13 +102,6 @@ The MetaMorpho strategy allocates capital to **Morpho Blue** lending markets:
 | Morpho Blue | [`0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb`](https://etherscan.io/address/0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb) | Immutable lending primitive (v1) |
 | WBTC/LBTC Market (94.5% LLTV) | `0xf6a056627a51e511ec7f48332421432ea6971fc148d8f3c451e14ea108026549` | Active: 18.0% of TVL |
 | WBTC/cbBTC Market (94.5% LLTV) | `0x39d6cc9211d023cc16708a2378d821d394d8cfaa3640e3a4d4638d292e10035d` | In queue, cap 500 WBTC, no position |
-| LBTC (Lombard BTC) | [`0x8236a87084f8B84306f72007F36F2618A5634494`](https://etherscan.io/address/0x8236a87084f8B84306f72007F36F2618A5634494) | Collateral token in active market |
-| cbBTC (Coinbase BTC) | [`0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf`](https://etherscan.io/address/0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf) | Collateral token in queued market |
-| MorphoChainlinkOracleV2 (LBTC) | [`0xa98105B8227E0f2157816Feb7A331364A9B74F80`](https://etherscan.io/address/0xa98105B8227E0f2157816Feb7A331364A9B74F80) | Chainlink LBTC/USD oracle |
-| MorphoChainlinkOracleV2 (cbBTC) | [`0x3eF1F71723d633deE9834c5a7577c39B13C17aeb`](https://etherscan.io/address/0x3eF1F71723d633deE9834c5a7577c39B13C17aeb) | Chainlink cbBTC/USD oracle |
-| AdaptiveCurveIrm | [`0x870aC11D48B15DB9a138Cf899d20F13F79Ba00BC`](https://etherscan.io/address/0x870aC11D48B15DB9a138Cf899d20F13F79Ba00BC) | Interest rate model (shared by both markets) |
-
-**Note:** yvWBTC-1 remains **outside the Sky/USDS concentration** affecting yvUSDC-1 / yvUSDS-1 / yvDAI-1. The strategy routes exclusively through WBTC-native Morpho Blue markets with BTC-collateral pairs.
 
 ## Audits and Due Diligence Disclosures
 
@@ -203,21 +196,6 @@ yvWBTC-1 deploys all WBTC through a single MetaMorpho V1_1 strategy (ymv-WBTC). 
 | Morpho Blue WBTC/LBTC (94.5% LLTV) | 8.55 | 18.0% | 79.4% | 95.2% |
 | Morpho Blue WBTC/cbBTC (94.5% LLTV) | 0 | 0% | ~0% | N/A |
 
-**LBTC market context:** The active WBTC/LBTC market has 8.98 WBTC total supply with 7.13 WBTC borrowed (79.4% utilization). The yvWBTC-1 strategy provides 95.2% of all supply — it is the dominant (and essentially sole) liquidity provider. At 79.4% utilization, ~1.85 WBTC of available liquidity remains; large withdrawals from this market would require borrower repayments or new depositor inflows. However, 82% of TVL is in the idle market (immediately redeemable), so redemptions up to ~82% of TVL can be serviced without touching the LBTC market.
-
-**Morpho market parameters:**
-
-| Parameter | WBTC/LBTC Market | WBTC/cbBTC Market |
-|-----------|------------------|--------------------|
-| Market ID | `0xf6a056…` | `0x39d6cc…` |
-| Loan token | WBTC | WBTC |
-| Collateral token | LBTC (Lombard BTC) | cbBTC (Coinbase BTC) |
-| Oracle | MorphoChainlinkOracleV2 (LBTC/USD) | MorphoChainlinkOracleV2 (cbBTC/USD) |
-| IRM | AdaptiveCurveIrm | AdaptiveCurveIrm |
-| LLTV | 94.5% | 94.5% |
-| MetaMorpho supply cap | 250 WBTC | 500 WBTC |
-| Strategy position | 8.55 WBTC | 0 WBTC |
-
 ### Accessibility
 
 - **Deposits:** Permissionless ERC-4626. Subject to 100,000 WBTC deposit limit (cap remains oversized — see Reassessment Triggers)
@@ -305,15 +283,12 @@ The strategy introduces a structured dependency chain. The complete external dep
 | **Chainlink (cbBTC/USD oracle)** | Low (no current exposure) | Identical architecture to LBTC oracle. Currently unused |
 | **LBTC (Lombard BTC)** | Moderate (collateral) | Bitcoin liquid staking derivative. Newer than cbBTC/wBTC. Used as collateral at 94.5% LLTV. If LBTC depegs or has custody issues, borrowers face liquidation, which would release WBTC back to the market (beneficial for lenders) unless the oracle lags |
 | **cbBTC (Coinbase BTC)** | Low (no current exposure) | Coinbase wrapped Bitcoin. Well-established, strong custody. In supply queue but no position |
-| **AdaptiveCurveIrm** | Low (interest rate model) | Morpho's standard adaptive IRM. Battle-tested, no known issues |
 
 **Concentration note:** The strategy is currently single-market for its deployed portion (100% of deployed capital → one WBTC/LBTC market). While only 18% of TVL is deployed, this is a single-point dependency within the deployed segment. The available-but-unused cbBTC market provides a diversification path that the curator can activate.
 
 **Oracle dependency depth:** Both markets use a two-layer oracle stack:
 1. MorphoChainlinkOracleV2 — adapter contract (immutable, Morpho-maintained)
 2. Chainlink AggregatorV3 — the underlying price feed
-
-Chainlink oracle failure is a systemic risk shared by most DeFi lending protocols. For the LBTC/USD feed specifically, it has less historical data than BTC/USD or ETH/USD, but the feed architecture is identical.
 
 ## Operational Risk
 
@@ -394,7 +369,6 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 - **Standard Yearn governance:** Yearn V3 Role Manager + 6-of-9 ySafe (named DeFi signers) + 7-day self-governed timelock
 - **Morpho Blue is immutable and heavily audited:** 3 top-tier audits, ~30 months of production, $1B+ markets, no exploits
 - **Conservative allocation:** 82% idle within MetaMorpho provides substantial redemption buffer. Only 18% deployed to a single Morpho Blue market
-- **No Sky / USDS exposure:** Pure WBTC → Morpho Blue → WBTC lending markets. No routing through the Sky/USDS stack that creates concentration risk in yvUSDC-1 / yvUSDS-1 / yvDAI-1
 - **No leverage. No cross-chain. No conversion hops** — WBTC-native throughout
 - **7-day Yearn timelock + 3-day MetaMorpho timelock** — dual-delay guard on strategy changes and market cap adjustments
 - **Good yield resumption:** PPS moved from 1.000037 to 1.000305 in ~49 days since strategy activation
@@ -406,11 +380,10 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 - **Market dominance:** The strategy is 95.2% of the LBTC market supply — large withdrawals from the deployed portion would face significant friction at the current 79.4% utilization
 - **Vault immaturity:** ~14 months old, with only ~49 days of yield-bearing history. The vault itself is still the youngest in the mainnet risk-1 set
 - **Oversized deposit cap:** 100,000 WBTC cap vs 47.5 WBTC TVL remains a governance hygiene concern
-- **Missing monitoring:** yvWBTC-1 is still not in `alert_large_flows.py`
 
 ### Critical Risks
 
-- None identified. All gates pass. The current posture — 82% idle, 18% in over-collateralized lending at a blue-chip protocol (Morpho Blue) with conservative LLTV and dual-timelock governance — presents a well-structured risk profile.
+- None identified.
 
 ---
 

--- a/reports/report/yearn-yvwbtc.md
+++ b/reports/report/yearn-yvwbtc.md
@@ -1,43 +1,54 @@
 # Protocol Risk Assessment: Yearn — yvWBTC-1
 
-- **Assessment Date:** May 11, 2026
+- **Assessment Date:** May 11, 2026 (Updated: July 12, 2026)
 - **Token:** yvWBTC-1 (WBTC-1 yVault)
 - **Chain:** Ethereum
 - **Token Address:** [`0x751F0cC6115410A3eE9eC92d08f46Ff6Da98b708`](https://etherscan.io/address/0x751F0cC6115410A3eE9eC92d08f46Ff6Da98b708)
-- **Final Score: 1.2/5.0**
+- **Final Score: 1.4/5.0**
 
 ## Overview + Links
 
-yvWBTC-1 is a **WBTC-denominated Yearn V3 vault** (ERC-4626) on Ethereum mainnet. The vault holds **47.5051 WBTC** (≈ $3.87M at the snapshot) and currently deploys **0% of it** — `totalDebt = 0`, `totalIdle = totalAssets`. The vault's **default queue is empty** (`get_default_queue() == []`): the previously-attached Aave V3 WBTC Lender strategy was **revoked from the vault** (`activation = 0` on-chain) between the April 27 and May 5 snapshots and remains revoked at this snapshot.
+yvWBTC-1 is a **WBTC-denominated Yearn V3 vault** (ERC-4626) on Ethereum mainnet. The vault holds **47.5099 WBTC** (~$3.05M at the snapshot) deployed through a single **MetaMorpho V1_1 strategy** (ymv-WBTC) that allocates capital to **Morpho Blue** lending markets. The vault was fully idle at the May 11, 2026 snapshot but a new strategy was **activated May 24, 2026** (after a 7-day timelock proposal) and the vault is now **100% deployed** (`totalDebt = totalAssets`, `totalIdle = 0`).
 
-Per the Yearn team, the broader risk-1 vault posture during late April was a **precautionary deallocation following the April 18, 2026 rsETH (KelpDAO) bridge exploit** on the LayerZero OFT bridge layer (the rsETH event itself is documented in the [hgETH reassessment report](./kerneldao-hgeth.md)). For yvWBTC-1 specifically, the strategy revocation goes further than a temporary pull — there is now no strategy on the vault at all. Whether this is a permanent deprecation or a precursor to re-onboarding a different strategy under the 7-day timelock is not on-chain verifiable; the team's specific intent has not been independently verified.
+Within the strategy, capital is split: **~82% idle** within MetaMorpho's Morpho Blue idle market and **~18% supplied** to a Morpho Blue WBTC/LBTC (Lombard BTC) lending market at 94.5% LLTV. A second Morpho Blue WBTC/cbBTC market is available in the supply queue but currently holds no position. The strategy's max debt on the Yearn V3 vault is **1,000 WBTC**.
 
-yvWBTC-1 is also the **newest and least mature vault** in the mainnet risk-1 set — deployed May 13, 2025, ~11.9 months at the snapshot. PPS has barely moved (1.000037), reflecting that the vault has spent essentially all of its life undeployed.
+yvWBTC-1 was deployed May 13, 2025 and is now **~14 months** in production. PPS has risen from 1.000000 at deployment to 1.000305, reflecting ~49 days of yield generation since the strategy was activated.
 
 **Key architecture:**
 
 - **Vault:** Standard Yearn V3 vault (v3.0.4) accepting WBTC deposits, issuing yvWBTC-1 shares. Deployed as an immutable Vyper minimal proxy (EIP-1167) via the v3.0.4 Yearn V3 Vault Factory ([`0x770D0d1Fb036483Ed4AbB6d53c1C88fb277D812F`](https://etherscan.io/address/0x770D0d1Fb036483Ed4AbB6d53c1C88fb277D812F))
-- **Strategy queue:** **empty** (`get_default_queue() == []`). No strategy currently attached to the vault. Adding any new strategy requires a 7-day timelock proposal
-- **Governance:** Standard **Yearn V3 Role Manager** ([`0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41`](https://etherscan.io/address/0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41)) governed by the **Yearn 6-of-9 ySafe** with **7-day TimelockController** for strategy additions
+- **Strategy:** [MetaMorphoV1_1](https://etherscan.io/address/0x2bB005127069A0F0325Fb7370967E8A2b64FB77E) (ymv-WBTC) — a Yearn-operated Morpho MetaMorpho lending vault deploying WBTC into Morpho Blue markets. **Owner:** Yearn Security 4-of-7. **Guardian:** ySafe 6-of-9. **Curator:** 2-of-3 Gnosis Safe. The MetaMorpho contract itself is **immutable** (no EIP-1967 proxy).
+- **Underlying protocol:** [Morpho Blue](https://etherscan.io/address/0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb) (immutable, v1) — a permissionless lending primitive. The deployed portion (~18% of TVL) is supplied to the WBTC/LBTC market.
+- **Governance:** Standard **Yearn V3 Role Manager** ([`0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41`](https://etherscan.io/address/0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41)) governed by the **Yearn 6-of-9 ySafe** with **7-day TimelockController** for strategy additions. The MetaMorpho strategy itself adds a 3-day curator timelock for market cap changes.
 
-**Key metrics (May 11, 2026, snapshot at block 25073237, timestamp 1778519075 = 17:04:35 UTC):**
+**Key metrics (July 12, 2026, snapshot at block 25519096):**
 
-- **TVL:** 47.50511676 WBTC (~$3.87M, Chainlink BTC/USD = $81,614.41, WBTC/BTC = 0.9972)
-- **Total Supply:** 47.50336273 yvWBTC-1
-- **Price Per Share:** 1.000037 WBTC/yvWBTC-1 (essentially unchanged over ~11.9 months — the vault has been mostly undeployed)
-- **Total Debt:** 0 (on-chain)
-- **Total Idle:** 47.50511676 WBTC (100% of TVL)
-- **Deposit Limit:** **100,000 WBTC** (≈ $8.1B at snapshot — materially oversized, see Reassessment Triggers)
+- **TVL:** 47.50988862 WBTC (~$3.05M, Chainlink WBTC/USD = $64,168.64)
+- **Total Supply:** 47.49541057 yvWBTC-1
+- **Price Per Share:** 1.000305 WBTC/yvWBTC-1 (accumulated yield since strategy activation May 24, 2026)
+- **Total Debt:** 47.50988862 WBTC (100% deployed)
+- **Total Idle:** 0 WBTC (vault level; within strategy 82% is in Morpho idle market)
+- **Deposit Limit:** **100,000 WBTC** (~$6.4B at snapshot — materially oversized, see Reassessment Triggers)
+- **Strategy maxDebt:** 1,000 WBTC (~$64M)
 - **Profit Max Unlock Time:** 5 days
-- **Fees:** 0% management fee, 10% performance fee
+- **Fees:** 0% management fee, 10% performance fee (vault); 0% MetaMorpho fee
 
-**Important note:** because the vault is 100% idle **and has no strategy attached at all**, depositors today earn 0% APR and there is no protocol-dependency surface beyond WBTC itself. The dependency, liquidity, and complexity assessments below reflect this state. If Yearn proposes a new strategy under the 7-day timelock, the dependency assessment should be re-run against the actual chosen strategy. Captured under Reassessment Triggers.
+**Strategy allocation:**
+
+| Venue | WBTC | % of TVL | Notes |
+|-------|------|----------|-------|
+| MetaMorpho idle (Morpho Blue idle market) | 38.96 | 82.0% | Fully liquid, no yield |
+| Morpho Blue WBTC/LBTC market | 8.55 | 18.0% | 94.5% LLTV, 79.4% utilization, strategy is 95.2% of supply |
+| Morpho Blue WBTC/cbBTC market | 0 | 0% | Cap 500 WBTC, enabled but no position |
+
+**Important note about rsETH / deallocation context:** The vault was 100% idle from April 27–May 11, 2026 after the Aave V3 WBTC Lender was revoked, per the Yearn team in response to the April 18, 2026 rsETH bridge exploit ([hgETH report](./kerneldao-hgeth.md)). The current MetaMorpho strategy was activated May 24, 2026, restoring yield generation through a different, non-Aave, non-rsETH-exposed route.
 
 **Links:**
 
 - [Yearn V3 Documentation](https://docs.yearn.fi/getting-started/products/yvaults/v3)
 - [Yearn V3 Vault Management](https://docs.yearn.fi/developers/v3/vault_management)
 - [Yearn Security](https://github.com/yearn/yearn-security/blob/master/SECURITY.md)
+- [Morpho Blue Documentation](https://docs.morpho.org/)
 - [DeFiLlama: Yearn Finance](https://defillama.com/protocol/yearn-finance)
 - [Yearn Multisig Info](https://docs.yearn.fi/developers/security/multisig)
 - [hgETH reassessment (rsETH bridge exploit context)](./kerneldao-hgeth.md)
@@ -72,17 +83,32 @@ yvWBTC-1 is also the **newest and least mature vault** in the mainnet risk-1 set
 | Vault Factory (v3.0.4) | [`0x770D0d1Fb036483Ed4AbB6d53c1C88fb277D812F`](https://etherscan.io/address/0x770D0d1Fb036483Ed4AbB6d53c1C88fb277D812F) |
 | Vault Original (v3.0.4) | [`0xd8063123BBA3B480569244AE66BFE72B6c84b00d`](https://etherscan.io/address/0xd8063123BBA3B480569244AE66BFE72B6c84b00d) |
 
-### Strategies (0 in default queue, 0 with debt)
+### Strategies (1 active in default queue, 100% deployed)
 
-`get_default_queue()` returns `[]` at block 25073237. The previously-attached **Aave V3 WBTC Lender** ([`0x0B9Ae07457BAED5536B1f3e78C9649E980fB4EDc`](https://etherscan.io/address/0x0B9Ae07457BAED5536B1f3e78C9649E980fB4EDc)) was revoked from the vault — `vault.strategies(0x0B9A…)` returns `(activation=0, last_report=0, current_debt=0, max_debt=0)`, indicating the strategy is no longer attached.
+`get_default_queue()` returns `[0x2bB005127069A0F0325Fb7370967E8A2b64FB77E]` at block 25519096. The single attached strategy is a **MetaMorpho V1_1 vault** ("ymv-WBTC") deployed specifically for yvWBTC-1:
 
-Adding any new strategy now requires a fresh `addNewStrategy()` proposal through the Strategy Manager TimelockController (7-day delay). Until that happens, yvWBTC-1 has **no protocol dependency surface beyond WBTC itself**.
+| Contract | Address | Type |
+|----------|---------|------|
+| ymv-WBTC (MetaMorphoV1_1) | [`0x2bB005127069A0F0325Fb7370967E8A2b64FB77E`](https://etherscan.io/address/0x2bB005127069A0F0325Fb7370967E8A2b64FB77E) | Morpho MetaMorpho ERC-4626 vault, immutable |
 
-**Important:** with no strategy attached, yvWBTC-1 is unambiguously **not part of the Sky concentration risk** that affects yvUSDC-1 / yvUSDS-1 / yvDAI-1. If a new strategy is proposed with Sky/USDS routing or rsETH-collateral exposure, the dependency assessment should be re-run.
+Vault `strategies(0x2bB0…)` returns `(activation=1779638639 [May 24, 2026], last_report=1783571039 [Jul 9, 2026], current_debt=47.5099 WBTC, max_debt=1000 WBTC)`. The strategy was activated 13 days after the May 11, 2026 snapshot, following a 7-day TimelockController proposal.
 
 ### Strategy Protocol Dependencies
 
-**None active or queued at the snapshot.** The vault holds WBTC directly and does not currently interact with any external protocol other than the WBTC token itself.
+The MetaMorpho strategy allocates capital to **Morpho Blue** lending markets:
+
+| Contract | Address | Type |
+|----------|---------|------|
+| Morpho Blue | [`0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb`](https://etherscan.io/address/0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb) | Immutable lending primitive (v1) |
+| WBTC/LBTC Market (94.5% LLTV) | `0xf6a056627a51e511ec7f48332421432ea6971fc148d8f3c451e14ea108026549` | Active: 18.0% of TVL |
+| WBTC/cbBTC Market (94.5% LLTV) | `0x39d6cc9211d023cc16708a2378d821d394d8cfaa3640e3a4d4638d292e10035d` | In queue, cap 500 WBTC, no position |
+| LBTC (Lombard BTC) | [`0x8236a87084f8B84306f72007F36F2618A5634494`](https://etherscan.io/address/0x8236a87084f8B84306f72007F36F2618A5634494) | Collateral token in active market |
+| cbBTC (Coinbase BTC) | [`0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf`](https://etherscan.io/address/0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf) | Collateral token in queued market |
+| MorphoChainlinkOracleV2 (LBTC) | [`0xa98105B8227E0f2157816Feb7A331364A9B74F80`](https://etherscan.io/address/0xa98105B8227E0f2157816Feb7A331364A9B74F80) | Chainlink LBTC/USD oracle |
+| MorphoChainlinkOracleV2 (cbBTC) | [`0x3eF1F71723d633deE9834c5a7577c39B13C17aeb`](https://etherscan.io/address/0x3eF1F71723d633deE9834c5a7577c39B13C17aeb) | Chainlink cbBTC/USD oracle |
+| AdaptiveCurveIrm | [`0x870aC11D48B15DB9a138Cf899d20F13F79Ba00BC`](https://etherscan.io/address/0x870aC11D48B15DB9a138Cf899d20F13F79Ba00BC) | Interest rate model (shared by both markets) |
+
+**Note:** yvWBTC-1 remains **outside the Sky/USDS concentration** affecting yvUSDC-1 / yvUSDS-1 / yvDAI-1. The strategy routes exclusively through WBTC-native Morpho Blue markets with BTC-collateral pairs.
 
 ## Audits and Due Diligence Disclosures
 
@@ -96,9 +122,17 @@ Adding any new strategy now requires a fresh `addNewStrategy()` proposal through
 
 The **v3.0.4 patch release** (used by yvWBTC-1) was reviewed **internally** by the Yearn team rather than re-engaging external auditors. The diff from v3.0.2 is a minor patch-level change; the external audits cover the core architecture. Source: [yearn-vaults-v3 GitHub releases](https://github.com/yearn/yearn-vaults-v3/releases).
 
-### Underlying Protocol Audits
+### Underlying Protocol Audits: Morpho Blue & MetaMorpho
 
-No active underlying protocol dependency at the May 11, 2026 snapshot — the only previously-attached strategy (Aave V3 WBTC Lender) was revoked between the April 27 and May 5 snapshots and there are no strategies currently in the queue. Underlying-protocol audits will become applicable when a new strategy is added; this section will be reassessed at that point. The historical Aave V3 attachment is documented in the Historical Track Record below.
+| Auditor | Date | Scope | Report |
+|---------|------|-------|--------|
+| [ChainSecurity](https://github.com/morpho-org/morpho-blue/blob/main/audits/2024-01-05-chainsecurity.pdf) | Jan 5, 2024 | Morpho Blue | PDF |
+| [Spearbit](https://github.com/morpho-org/morpho-blue/blob/main/audits/2024-01-08-spearbit.pdf) | Jan 8, 2024 | Morpho Blue | PDF |
+| [Cantina](https://github.com/morpho-org/morpho-blue/blob/main/audits/2024-02-02-cantina.pdf) | Feb 2, 2024 | Morpho Blue | PDF |
+| [Cantina](https://cantina.xyz/competitions/47418e9c-6540-47bd-a205-7f410b6bea43) | May 2024 | MetaMorpho | Competition |
+| [OpenZeppelin](https://github.com/morpho-org/morpho-blue/blob/main/audits/2024-09-17-openzeppelin-timelock.pdf) | Sep 17, 2024 | Timelock | PDF |
+
+Morpho Blue core contracts are **immutable** (no proxy, no upgrade mechanism). MetaMorpho V1_1 is also immutable. The historical Aave V3 attachment (which was revoked) is documented in the Historical Track Record below.
 
 ### Strategy Review Process
 
@@ -108,76 +142,124 @@ All strategies pass through Yearn's **12-metric risk-scoring framework** ([RISK_
 
 - **Yearn (Immunefi):** active, **$200,000** max payout (Critical). https://immunefi.com/bounty/yearnfinance/
 - **Yearn (Sherlock):** also listed at https://audits.sherlock.xyz/bug-bounties/30
-- **Underlying-protocol bug bounties:** N/A at this snapshot — no underlying protocol is integrated. When a strategy is added, the underlying protocol's bounty coverage will be evaluated at that point
+- **Underlying-protocol bug bounties:** [Morpho (Immunefi)](https://immunefi.com/bounty/morpho/) — **$2,500,000** max payout (Critical)
 - **Safe Harbor (SEAL):** Yearn is **not** listed on the SEAL Safe Harbor registry
 
 ### On-Chain Complexity
 
-**Trivially low** — the vault holds WBTC directly with no strategy attached. There are no conversion hops, no leverage, no looping, no cross-chain. Standard ERC-4626 throughout. The vault contract itself is immutable.
-
-If a new strategy is later attached, complexity will depend on the chosen integration; the previously-queued Aave V3 WBTC Lender would have been a simple single-hop lend.
+**Low** — single strategy, single underlying lending protocol. The flow is:
+```
+yvWBTC-1 (ERC-4626) → MetaMorpho (ERC-4626) → Morpho Blue idle market + WBTC/LBTC lending market
+```
+Two ERC-4626 layers (vault + MetaMorpho) with Morpho Blue as the underlying lending primitive. No leverage, no looping, no cross-chain. Morpho Blue uses MorphoChainlinkOracleV2 for pricing (standard Chainlink feeds). Both the yvWBTC-1 vault and MetaMorpho strategy contract are immutable.
 
 ## Historical Track Record
 
-- **Vault deployed:** May 13, 2025 (deployment [tx](https://etherscan.io/tx/0x8cac67b54afe9af0cc072a2e63852c787343ae514638a54d9644894f6b2a3984)) — **~11.9 months** in production. **Newest of the six mainnet risk-1 vaults.**
-- **TVL:** 47.5051 WBTC (~$3.87M) — well within the 100,000 WBTC deposit limit (the cap itself is materially oversized — see Reassessment Triggers)
-- **PPS trend:** 1.000000 → 1.000037 (essentially flat, ~0% annualized — the vault has been mostly undeployed over its short life)
-- **Security incidents:** None known for this vault or for the Yearn V3 framework
-- **Strategy changes:** the Aave V3 WBTC Lender (only strategy ever attached) was added 2025-05-18 and **revoked at some point between the April 27 and May 5 snapshots** — at the May 11 snapshot the vault still has no attached strategy
-- **Yearn V3 track record:** V3 framework live since May 2024 (~24 months). No V3 vault exploits
+- **Vault deployed:** May 13, 2025 (deployment [tx](https://etherscan.io/tx/0x8cac67b54afe9af0cc072a2e63852c787343ae514638a54d9644894f6b2a3984)) — **~14 months** in production
+- **TVL:** 47.5099 WBTC (~$3.05M). WBTC TVL essentially flat year-over-year; USD TVL declined ~21% since May 2026 due to BTC price drop ($81,600 → $64,200)
+- **PPS trend:** 1.000000 (deployment) → 1.000037 (May 11, 2026, mostly undeployed) → **1.000305** (July 12, 2026, ~49 days of yield since MetaMorpho strategy activated May 24, 2026)
+- **Security incidents:** None known for this vault, Yearn V3, Morpho Blue, or MetaMorpho
+- **Strategy history:**
+  - May 18, 2025: Aave V3 WBTC Lender attached
+  - Apr 27–May 5, 2026: Aave V3 WBTC Lender **revoked** (precautionary response to April 18 rsETH bridge exploit per Yearn team; causal attribution unverified)
+  - May 11, 2026: Vault idle, default queue empty (last snapshot of previous report)
+  - **May 24, 2026: MetaMorpho V1_1 (ymv-WBTC) activated** after 7-day TimelockController proposal. Funds deployed immediately
+- **Yearn V3 track record:** V3 framework live since May 2024 (~26 months). No V3 vault exploits
+- **Morpho Blue track record:** Live since Jan 2024 (~30 months). No exploits. ~$1B+ active markets
 
-**Yearn protocol TVL:** ~$197.5M total across all chains ([DeFiLlama](https://defillama.com/protocol/yearn), April 2026).
+**Yearn protocol TVL:** ~$147M total across all chains ([DeFiLlama](https://defillama.com/protocol/yearn), July 2026, down from ~$197.5M in April 2026).
 
 ## Funds Management
 
-yvWBTC-1 currently holds 100% WBTC idle. There are **no attached strategies** to characterize.
+yvWBTC-1 deploys all WBTC through a single MetaMorpho V1_1 strategy (ymv-WBTC). Within the strategy, ~82% of TVL is idle on Morpho Blue's idle market and ~18% is supplied as lending liquidity to the WBTC/LBTC Morpho Blue market.
 
 ### Current State (snapshot)
 
-- **Total Assets:** 47.50511676 WBTC
-- **Total Debt:** 0
-- **Total Idle:** 47.50511676 WBTC (100%)
-- **Capital utilization:** 0% deployed
-- **Default queue length:** 0
+- **Total Assets:** 47.50988862 WBTC
+- **Total Debt:** 47.50988862 WBTC (100% deployed to strategy)
+- **Total Idle:** 0 WBTC (at vault level)
+- **Capital utilization:** 100% deployed (at vault level); 18.0% actually earning yield (at strategy level)
+- **Default queue length:** 1 (MetaMorpho ymv-WBTC)
 
-WBTC is held directly at the vault contract. ERC-4626 redemptions settle atomically against this idle balance with no slippage.
+### Strategy Breakdown
 
-### Strategies
+**ymv-WBTC (MetaMorphoV1_1)** — [`0x2bB005127069A0F0325Fb7370967E8A2b64FB77E`](https://etherscan.io/address/0x2bB005127069A0F0325Fb7370967E8A2b64FB77E)
 
-**None attached at the snapshot.** The vault has no protocol-dependency surface beyond WBTC itself. Adding any new strategy requires a 7-day TimelockController proposal.
+| Metric | Value |
+|--------|-------|
+| Strategy totalAssets | 47.5105 WBTC |
+| Yearn V3 maxDebt | 1,000 WBTC (~$64M) |
+| Yearn V3 currentDebt | 47.5099 WBTC |
+| Activation | May 24, 2026 (unix 1779638639) |
+| Last report | Jul 9, 2026 (unix 1783571039) |
+| MetaMorpho fee | 0% |
+| MetaMorpho timelock (curator cap changes) | 3 days |
+
+**Within the MetaMorpho strategy:**
+
+| Venue | WBTC | % of TVL | Utilization | Strategy share of market |
+|-------|------|----------|-------------|--------------------------|
+| Morpho Blue idle market | 38.96 | 82.0% | N/A (always liquid) | N/A (shared idle pool) |
+| Morpho Blue WBTC/LBTC (94.5% LLTV) | 8.55 | 18.0% | 79.4% | 95.2% |
+| Morpho Blue WBTC/cbBTC (94.5% LLTV) | 0 | 0% | ~0% | N/A |
+
+**LBTC market context:** The active WBTC/LBTC market has 8.98 WBTC total supply with 7.13 WBTC borrowed (79.4% utilization). The yvWBTC-1 strategy provides 95.2% of all supply — it is the dominant (and essentially sole) liquidity provider. At 79.4% utilization, ~1.85 WBTC of available liquidity remains; large withdrawals from this market would require borrower repayments or new depositor inflows. However, 82% of TVL is in the idle market (immediately redeemable), so redemptions up to ~82% of TVL can be serviced without touching the LBTC market.
+
+**Morpho market parameters:**
+
+| Parameter | WBTC/LBTC Market | WBTC/cbBTC Market |
+|-----------|------------------|--------------------|
+| Market ID | `0xf6a056…` | `0x39d6cc…` |
+| Loan token | WBTC | WBTC |
+| Collateral token | LBTC (Lombard BTC) | cbBTC (Coinbase BTC) |
+| Oracle | MorphoChainlinkOracleV2 (LBTC/USD) | MorphoChainlinkOracleV2 (cbBTC/USD) |
+| IRM | AdaptiveCurveIrm | AdaptiveCurveIrm |
+| LLTV | 94.5% | 94.5% |
+| MetaMorpho supply cap | 250 WBTC | 500 WBTC |
+| Strategy position | 8.55 WBTC | 0 WBTC |
 
 ### Accessibility
 
-- **Deposits:** Permissionless ERC-4626. Subject to 100,000 WBTC deposit limit (cap is oversized — see Reassessment Triggers)
-- **Withdrawals:** ERC-4626. Atomic against idle balance — no strategy unwind needed
+- **Deposits:** Permissionless ERC-4626. Subject to 100,000 WBTC deposit limit (cap remains oversized — see Reassessment Triggers)
+- **Withdrawals:** ERC-4626 `withdraw` → MetaMorpho `redeem` → Morpho Blue idle market withdrawal + LBTC market withdrawal. The 82% idle buffer enables large redemptions without touching the LBTC market
 - **No cooldown or lock period**
-- **Fees:** 0% management, 10% performance
+- **Fees:** 0% management, 10% performance (vault); 0% MetaMorpho fee; Morpho Blue has no protocol fee
 - **Profit unlock:** 5 days
 
 ### Collateralization
 
-- **100% on-chain WBTC backing** — all of TVL is held directly at the vault contract
-- **Collateral quality:** WBTC is a wrapped representation of BTC, custodied offchain by BitGo. Quality is tied to BitGo's custody integrity and historical proof-of-reserves cadence
-- **No leverage**
-- **Fully redeemable** — atomic redemption from the idle balance
+- **100% on-chain WBTC backing** — all TVL is deployed to the MetaMorpho strategy, which holds WBTC either as idle (82%) or as Morpho Blue supply positions (18%)
+- **Collateral quality:** The underlying asset is WBTC (BitGo-custodied wrapped BTC). The LBTC exposure is through **over-collateralized lending at 94.5% LLTV** — the strategy lends WBTC and receives LBTC as collateral from borrowers
+- **Collateral token risk (LBTC):** Lombard BTC is a liquid staking derivative for Bitcoin (similar to Lido's stETH for ETH). Newer than cbBTC or WBTC but used with tight LLTV. Limited track record relative to more established wrapped-BTC products
+- **Collateral token risk (cbBTC):** Coinbase Wrapped BTC — well-established with strong institutional custody. Currently zero exposure
+- **No leverage** at the vault level — the strategy operates as a pure lender, not a borrower
+- **Oracle risk:** Both markets use MorphoChainlinkOracleV2 with Chainlink price feeds. Chainlink is the most battle-tested oracle infrastructure in DeFi. However, oracle manipulation of LBTC/USD (a newer feed) could trigger incorrect liquidations of borrowers, temporarily reducing available liquidity
 
 ### Provability
 
-- **PPS:** ERC-4626, fully algorithmic
-- **Strategy `totalAssets()`:** n/a — no strategy attached
-- **Profit / loss reporting:** n/a today (no strategy reports flow); when a strategy is later attached, profits would unlock over 5 days
+- **PPS:** ERC-4626, fully algorithmic. Vault PPS = convertToAssets(1e18) / 1e18. On-chain at block 25519096: 1.000305
+- **Strategy totalAssets():** MetaMorpho ERC-4626 → Morpho Blue share math + idle balance. Fully on-chain and verifiable
+- **Profit / loss reporting:** Automated via keeper → StrategyReported events on the vault. Profits unlock over 5 days. Last report: Jul 9, 2026
+- **Morpho Blue position:** `Morpho.position(marketId, strategy)` → `(supplyShares, borrowShares, collateral)` — all on-chain
 
 ## Liquidity Risk
 
-Trivially atomic. `totalAssets()` = `totalIdle()` = 47.5051 WBTC, so any user redemption settles against the vault's WBTC balance with no slippage, no strategy unwind, and no dependency on any underlying lending market's utilization.
+**Favorable** — 82% idle buffer within the MetaMorpho strategy provides strong redemption capacity. The deployed 18% faces a concentrated, high-utilization Morpho Blue market.
 
-- **Exit pipeline:** ERC-4626 `withdraw` against the vault's idle WBTC balance — single transaction, no external protocol calls
-- **Same-asset:** WBTC-denominated share token — no price-divergence risk inside the vault (BTC custody risk is upstream of the vault)
-- **No DEX liquidity needed**
+- **Exit pipeline:** ERC-4626 `withdraw` → MetaMorpho `redeem` → Morpho Blue idle market withdrawal (82% of TVL, instant) + LBTC market withdrawal (18% of TVL, constrained). The idle portion redeems atomically; LBTC market withdrawal requires available liquidity or borrower repayments
+- **Idle liquidity:** 38.96 WBTC (82% of TVL) held in Morpho Blue's idle market — effectively cash-equivalent, redeemable on demand
+- **LBTC market liquidity:** 8.55 WBTC supplied to the WBTC/LBTC market at 79.4% utilization. Available liquidity: ~1.85 WBTC. The strategy is 95.2% of market supply, meaning a large withdrawal from this market would exceed available liquidity and require borrowers to repay. In Morpho Blue, borrowers can be liquidated if collateral value drops, restoring liquidity
+- **Same-asset:** WBTC-denominated throughout — no price-divergence risk inside the vault (WBTC/BTC peg risk is upstream at BitGo)
+- **No DEX liquidity needed** — exit is through lending-market unwind, not AMM swap
 - **No withdrawal queue or cooldown**
-- **Deposit limit:** 100,000 WBTC cap vs 47.5051 WBTC TVL — materially oversized; not a liquidity issue today, but should be tightened before any future strategy attachment
+- **Deposit limit:** 100,000 WBTC cap vs 47.5 WBTC TVL — materially oversized; not a liquidity issue today, but should be tightened
+- **MetaMorpho timelock:** 3-day delay on market cap changes by the curator — prevents sudden allocation shifts
 
-If a new strategy is attached later, the liquidity profile will become a function of that strategy's underlying market — captured under Reassessment Triggers.
+**Liquidity stress scenario:** A redemption exceeding ~39 WBTC (the idle buffer) would partially draw from the LBTC market. Given the market's 79.4% utilization and the strategy's 95.2% supply dominance, the strategy may not be able to exit the full position immediately. However, in practice:
+1. The idle buffer covers ~82% of TVL, accommodating most conceivable redemptions
+2. LBTC borrowers may repay to avoid liquidation if interest rates rise
+3. Liquidations would bring in new WBTC supply to the market
+4. The curator can rebalance the supply queue (subject to 3-day timelock)
 
 ## Centralization & Control Risks
 
@@ -212,14 +294,26 @@ ySafe 6-of-9 signers include publicly known DeFi contributors — see [Yearn Mul
 
 ### External Dependencies
 
-**Today:** none directly funded. The only critical dependency is the underlying WBTC token itself (and its BitGo-custodied BTC backing).
-
-**If a new strategy is later attached:** dependency profile becomes a function of the chosen strategy. The previously-attached Aave V3 WBTC Lender is the natural candidate; if re-attached, dependency would be:
+The strategy introduces a structured dependency chain. The complete external dependency surface:
 
 | Dependency | Criticality | Notes |
 |-----------|-------------|-------|
-| **WBTC (BitGo)** | Critical (underlying asset) | Wrapped BTC; relies on BitGo's custody integrity and proof-of-reserves practice |
-| **Aave V3** | High (if/when funded) | Blue-chip, $30B+ TVL |
+| **WBTC (BitGo)** | Critical (underlying asset) | Wrapped BTC; relies on BitGo's custody integrity and proof-of-reserves practice. All vault value ultimately depends on WBTC's peg to BTC |
+| **Morpho Blue** | Critical (for deployed portion) | Immutable lending primitive, ~30 months production, $1B+ markets, 3 top-tier audits. Currently holds 100% of TVL (82% idle + 18% active) |
+| **MetaMorpho V1_1** | High (strategy layer) | Immutable ERC-4626 wrapper. Audited by Cantina, Spearbit, OpenZeppelin. Yearn-governed (Security as owner, ySafe as guardian) |
+| **Chainlink (LBTC/USD oracle)** | High (liquidation pricing) | MorphoChainlinkOracleV2 wrapping Chainlink LBTC/USD feed. Oracle failure → incorrect liquidations → temporary illiquidity for LBTC market positions |
+| **Chainlink (cbBTC/USD oracle)** | Low (no current exposure) | Identical architecture to LBTC oracle. Currently unused |
+| **LBTC (Lombard BTC)** | Moderate (collateral) | Bitcoin liquid staking derivative. Newer than cbBTC/wBTC. Used as collateral at 94.5% LLTV. If LBTC depegs or has custody issues, borrowers face liquidation, which would release WBTC back to the market (beneficial for lenders) unless the oracle lags |
+| **cbBTC (Coinbase BTC)** | Low (no current exposure) | Coinbase wrapped Bitcoin. Well-established, strong custody. In supply queue but no position |
+| **AdaptiveCurveIrm** | Low (interest rate model) | Morpho's standard adaptive IRM. Battle-tested, no known issues |
+
+**Concentration note:** The strategy is currently single-market for its deployed portion (100% of deployed capital → one WBTC/LBTC market). While only 18% of TVL is deployed, this is a single-point dependency within the deployed segment. The available-but-unused cbBTC market provides a diversification path that the curator can activate.
+
+**Oracle dependency depth:** Both markets use a two-layer oracle stack:
+1. MorphoChainlinkOracleV2 — adapter contract (immutable, Morpho-maintained)
+2. Chainlink AggregatorV3 — the underlying price feed
+
+Chainlink oracle failure is a systemic risk shared by most DeFi lending protocols. For the LBTC/USD feed specifically, it has less historical data than BTC/USD or ETH/USD, but the feed architecture is identical.
 
 ## Operational Risk
 
@@ -230,9 +324,9 @@ ySafe 6-of-9 signers include publicly known DeFi contributors — see [Yearn Mul
 - **Incident response:** 4 historical V1 events handled. V3 framework not yet stress-tested by an exploit
 - **V3 immutability:** vault cannot be upgraded
 - **Operational anomalies:**
-  - Current 100%-idle posture **and zero attached strategies** is itself an operational signal — Brain / Daddy have actively pulled all debt and revoked the only attached strategy between the April 27 and May 5 snapshots, and the empty-queue state has persisted through the May 11 snapshot. The broader risk-1 vault deallocation in late April was attributed by the Yearn team to a precautionary response following the rsETH bridge exploit (unverified attribution); the strategy revocation here is more permanent than a deallocation and the rationale has not been independently verified
-  - **Oversized deposit cap (100,000 WBTC ≈ $8.1B)** vs current 47.5 WBTC TVL — not a safety risk while the vault is undeployed, but should be tightened or its rationale documented before any future strategy attachment. Action item under Reassessment Triggers
-  - **Not yet in `alert_large_flows.py` monitoring list** — likely an oversight given how recently the vault was deployed and that it currently holds no debt. Recommend Yearn adds it before any meaningful TVL
+  - **Oversized deposit cap (100,000 WBTC ≈ $6.4B)** vs current 47.5 WBTC TVL — not a safety risk while TVL remains low, but should be tightened or its rationale documented. Action item under Reassessment Triggers
+  - **Not yet in `alert_large_flows.py` monitoring list** — the vault has been live ~14 months with rising TVL. Recommend Yearn adds it before any material TVL increase
+  - **Strategy-level idle ratio:** 82% idle within MetaMorpho is operationally conservative — the curator (2-of-3 Safe) has not raised the LBTC market cap beyond 250 WBTC despite the available 250 WBTC headroom, indicating conservative risk management
 
 ## Monitoring
 
@@ -249,21 +343,31 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 
 | Contract | Address | Monitor |
 |----------|---------|---------|
-| yvWBTC-1 Vault | [`0x751F0cC6115410A3eE9eC92d08f46Ff6Da98b708`](https://etherscan.io/address/0x751F0cC6115410A3eE9eC92d08f46Ff6Da98b708) | PPS (`convertToAssets(1e8)`), `totalAssets()`, `totalDebt()`, `totalIdle()`, Deposit / Withdraw events, `StrategyChanged` |
-| Strategy Manager (Timelock) | [`0x88Ba032be87d5EF1fbE87336b7090767F367BF73`](https://etherscan.io/address/0x88Ba032be87d5EF1fbE87336b7090767F367BF73) | New `addStrategy()` proposals (7-day delay) |
+| yvWBTC-1 Vault | [`0x751F0cC6115410A3eE9eC92d08f46Ff6Da98b708`](https://etherscan.io/address/0x751F0cC6115410A3eE9eC92d08f46Ff6Da98b708) | PPS (`convertToAssets(1e8)`), `totalAssets()`, `totalDebt()`, `totalIdle()`, Deposit / Withdraw events, `StrategyChanged`, `DebtUpdated` |
+| ymv-WBTC (MetaMorpho) | [`0x2bB005127069A0F0325Fb7370967E8A2b64FB77E`](https://etherscan.io/address/0x2bB005127069A0F0325Fb7370967E8A2b64FB77E) | `totalAssets()`, `totalSupply()`, `convertToAssets(1e8)`, supply cap changes (`setSupplyQueue`, `submitCap`), timelock operations |
+| Morpho Blue | [`0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb`](https://etherscan.io/address/0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb) | Market state for `0xf6a056…` and `0x39d6cc…` (totalSupplyAssets, totalBorrowAssets, utilization, fee) |
+| Strategy Manager (Timelock) | [`0x88Ba032be87d5EF1fbE87336b7090767F367BF73`](https://etherscan.io/address/0x88Ba032be87d5EF1fbE87336b7090767F367BF73) | New `addStrategy()` / `revokeStrategy()` proposals (7-day delay) |
 | ySafe (Daddy) | [`0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52`](https://etherscan.io/address/0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52) | Signer / threshold changes |
+| Security multisig | [`0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0`](https://etherscan.io/address/0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0) | MetaMorpho owner: signer / threshold changes |
+| Curator multisig | [`0x90D0f26025571295D18a6c041E47450B81886B51`](https://etherscan.io/address/0x90D0f26025571295D18a6c041E47450B81886B51) | Market cap changes, supply queue modifications (3-day timelock) |
 | Accountant | [`0x5A74Cb32D36f2f517DB6f7b0A0591e09b22cDE69`](https://etherscan.io/address/0x5A74Cb32D36f2f517DB6f7b0A0591e09b22cDE69) | Fee changes |
+| LBTC / cbBTC Chainlink feeds | [LBTC/USD](https://data.chain.link/feeds/ethereum/mainnet/lbtc-usd), [cbBTC/USD](https://data.chain.link/feeds/ethereum/mainnet/cbbtc-usd) | Oracle deviation, heartbeat, circuit-breaker triggers |
 
 ### Critical Events to Monitor
 
-- **New strategy attachment** — `StrategyChanged(strategy, ChangeType.ADDED)` would indicate the timelock has executed an `addNewStrategy()` proposal; trigger reassessment to evaluate the new dependency
-- **Idle ratio change** — currently 100%; a drop after a strategy is attached indicates re-deployment
-- **Strategy `current_debt` changes** — `DebtUpdated` events on the vault (n/a until a strategy is attached)
-- **Emergency actions** (`Shutdown`)
-- **ySafe / Brain / Security signer or threshold changes**
+- **Strategy queue changes** — additions/removals from `get_default_queue()`
+- **Strategy debt changes** — `DebtUpdated` events; watch for debt shifts between idle and LBTC market
+- **MetaMorpho supply cap changes** — `submitCap` / `acceptCap` events on the MetaMorpho contract (3-day timelock)
+- **MetaMorpho supply queue changes** — `setSupplyQueue` by curator
+- **LBTC market utilization spikes** — currently 79.4%; approaching 90%+ significantly degrades withdrawal capacity
+- **Morpho Blue market parameter changes** — LLTV or oracle changes on the active markets (requires new Morpho Blue market creation since core is immutable)
+- **Emergency actions** — vault `Shutdown` or Morpho Blue market pause (guardian can pause)
+- **ySafe / Brain / Security / Curator signer or threshold changes**
 - **PPS decrease** — should only increase outside of explicit loss events
 - **Deposit-limit changes** — particularly relevant given the current oversized cap
 - **WBTC-specific:** BitGo custody / proof-of-reserves issues, WBTC-BTC peg deviation, blacklisting events
+- **LBTC-specific:** Lombard custody issues, LBTC-BTC peg deviation, oracle deviation
+- **Chainlink oracle incidents** affecting LBTC/USD or cbBTC/USD feeds
 
 ### Monitoring Functions
 
@@ -271,34 +375,42 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 |----------|----------|---------|-----------|
 | `convertToAssets(1e8)` | Vault | PPS tracking | Every 6 hours |
 | `totalAssets()` | Vault | Total TVL | Daily |
-| `totalDebt()` / `totalIdle()` | Vault | Capital deployment ratio — **key early signal that a strategy has been attached and funded** | Daily |
-| `get_default_queue()` | Vault | Queue composition — **currently empty; non-empty indicates a new strategy attachment** | Daily |
-| `deposit_limit()` | Vault | Cap monitoring (currently oversized) | Daily |
-| `getThreshold()` / `getOwners()` | ySafe | Governance integrity | Weekly |
-| `getMinDelay()` | ySafe | Delay change detection | Weekly |
+| `totalDebt()` / `totalIdle()` | Vault | Capital deployment ratio | Daily |
+| `get_default_queue()` | Vault | Queue composition | Daily |
+| `deposit_limit()` | Vault | Cap monitoring (oversized) | Daily |
+| `convertToAssets(1e8)` | MetaMorpho | Strategy PPS tracking | Every 6 hours |
+| `totalAssets()` | MetaMorpho | Strategy TVL | Daily |
+| Morpho `market(id)` | Morpho Blue | LBTC + cbBTC market state (supply, borrow, utilization) | Daily |
+| Morpho `position(id, strategy)` | Morpho Blue | Strategy supply shares per market | Daily |
+| `getThreshold()` / `getOwners()` | ySafe, Security, Curator | Governance integrity | Weekly |
+| `getMinDelay()` | TimelockController | Delay change detection | Weekly |
+| Chainlink LBTC/USD latestAnswer | Oracle | Oracle deviation monitoring | Every 6 hours |
 
 ## Risk Summary
 
 ### Key Strengths
 
-- **Battle-tested Yearn V3 infrastructure:** 3 audits by top firms, ~24 months of clean V3 production. Immutable vault contract eliminates proxy upgrade risk
+- **Battle-tested Yearn V3 infrastructure:** 3 audits by top firms, ~26 months of clean V3 production. Immutable vault contract eliminates proxy upgrade risk
 - **Standard Yearn governance:** Yearn V3 Role Manager + 6-of-9 ySafe (named DeFi signers) + 7-day self-governed timelock
-- **No Sky / USDS exposure:** yvWBTC-1 is WBTC-native with no strategy attached and never routed through the Sky / USDS stack — this vault is excluded from the Sky concentration risk affecting the other stable risk-1 vaults
-- **Trivially liquid today** — 100% idle, atomic redemption with no slippage
-- **No leverage. No cross-chain. No conversion hops** — the vault holds WBTC directly with no strategy attached
-- **7-day timelock guard on any future strategy:** any new strategy attachment must clear the Strategy Manager TimelockController before it can take debt — preserving a reassessment window
+- **Morpho Blue is immutable and heavily audited:** 3 top-tier audits, ~30 months of production, $1B+ markets, no exploits
+- **Conservative allocation:** 82% idle within MetaMorpho provides substantial redemption buffer. Only 18% deployed to a single Morpho Blue market
+- **No Sky / USDS exposure:** Pure WBTC → Morpho Blue → WBTC lending markets. No routing through the Sky/USDS stack that creates concentration risk in yvUSDC-1 / yvUSDS-1 / yvDAI-1
+- **No leverage. No cross-chain. No conversion hops** — WBTC-native throughout
+- **7-day Yearn timelock + 3-day MetaMorpho timelock** — dual-delay guard on strategy changes and market cap adjustments
+- **Good yield resumption:** PPS moved from 1.000037 to 1.000305 in ~49 days since strategy activation
 
 ### Key Risks
 
-- **Idle posture (100% un-deployed) and empty queue persisting to May 11:** per the Yearn team the April deallocation was precautionary following the April 18, 2026 rsETH bridge exploit (see [hgETH report](./kerneldao-hgeth.md) for verified facts about the event). The team's specific causal attribution has not been independently verified. **Between the April 27 and May 5 snapshots the only attached strategy (Aave V3 WBTC Lender) was revoked entirely** — this is a step beyond a temporary pull, and the rationale has not been independently confirmed. As of the May 11 snapshot no replacement strategy has been queued; any future deployment will require a new 7-day timelock proposal
-- **Newest and least mature vault** of the six mainnet risk-1 vaults (~11.9 months only). PPS appreciation is essentially zero (1.000037) reflecting the mostly-undeployed history
-- **No yield while idle** — depositors today earn 0% APR on the idle balance (PPS is essentially flat)
-- **No diversification cushion if a new single-venue strategy is later attached:** WBTC market liquidity is historically narrower than USD-stablecoin markets, so a future single-strategy attachment would carry venue-concentration risk
-- **Re-deployment risk:** when any new strategy is later proposed and funded, dependency, liquidity, and complexity scores need to be re-evaluated against the actual chosen mix
+- **LBTC collateral risk:** The deployed 18% of TVL is in a market where collateral is LBTC (Lombard BTC), a relatively newer Bitcoin liquid staking derivative. While the 94.5% LLTV provides conservative over-collateralization, LBTC has a shorter track record than cbBTC or WBTC
+- **Single-market deployment concentration:** 100% of deployed capital is in one Morpho Blue market. The idle buffer mitigates this (82% idle), but redeployment to a second market (cbBTC) would improve diversification
+- **Market dominance:** The strategy is 95.2% of the LBTC market supply — large withdrawals from the deployed portion would face significant friction at the current 79.4% utilization
+- **Vault immaturity:** ~14 months old, with only ~49 days of yield-bearing history. The vault itself is still the youngest in the mainnet risk-1 set
+- **Oversized deposit cap:** 100,000 WBTC cap vs 47.5 WBTC TVL remains a governance hygiene concern
+- **Missing monitoring:** yvWBTC-1 is still not in `alert_large_flows.py`
 
 ### Critical Risks
 
-- None identified. All gates pass. The current idle posture and oversized deposit cap are temporary / cosmetic concerns rather than fundamental risks to the vault.
+- None identified. All gates pass. The current posture — 82% idle, 18% in over-collateralized lending at a blue-chip protocol (Morpho Blue) with conservative LLTV and dual-timelock governance — presents a well-structured risk profile.
 
 ---
 
@@ -309,13 +421,13 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 - Use decimals when a subcategory falls between scores
 - Prioritize on-chain evidence over documentation claims
 - **Rounding rule:** the weighted sum is rounded to one decimal place using standard nearest-0.1 rounding; when the value is exactly halfway between two 0.1 marks (X.X50), round UP to the higher (riskier) score per the conservative principle
-- **Score reflects current snapshot state (100% idle).** Reassess when funds re-deploy.
+- **Score reflects current snapshot state (July 12, 2026):** 100% deployed through MetaMorpho → Morpho Blue, with 82% idle and 18% in WBTC/LBTC lending market.
 
 ### Critical Risk Gates
 
-- [x] **No audit** — Yearn V3 core audited by 3 top firms. Aave V3 extensively audited. ✅ PASS
-- [x] **Unverifiable reserves** — ERC-4626 + 100% idle WBTC verifiable on-chain. ✅ PASS
-- [x] **Total centralization** — 6-of-9 multisig with publicly named signers. ✅ PASS
+- [x] **No audit** — Yearn V3 core audited by 3 top firms. Morpho Blue audited by ChainSecurity, Spearbit, Cantina. MetaMorpho audited by Cantina, OpenZeppelin. ✅ PASS
+- [x] **Unverifiable reserves** — ERC-4626 + Morpho Blue share math, fully on-chain verifiable. ✅ PASS
+- [x] **Total centralization** — 6-of-9 multisig with publicly named signers + 7-day timelock. ✅ PASS
 
 **All gates pass.** Proceed to category scoring.
 
@@ -325,14 +437,14 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 
 | Factor | Assessment |
 |--------|-----------|
-| Audits | V3 framework: 3 audits by top firms. v3.0.4 patch reviewed internally. No active strategies to assess at the snapshot |
-| Bug bounty | $200K (Yearn Immunefi) |
-| Production history | **~11.9 months** (May 13, 2025) — youngest of the six mainnet risk-1 vaults. V3 framework: ~24 months |
-| TVL | **47.5051 WBTC** (~$3.87M). Deposit limit: 100,000 WBTC (oversized) |
-| Security incidents | None on V3 |
-| Strategy review | Rigorous 12-metric framework with ySec security review (n/a today — no strategy attached) |
+| Audits | V3 framework: 3 audits. Morpho Blue: 3 audits. MetaMorpho: multiple audits. Strategy reviewed via Yearn's 12-metric framework |
+| Bug bounty | $200K (Yearn Immunefi) + $2.5M (Morpho Immunefi) |
+| Production history | Vault: **~14 months** (mostly undeployed until May 24, 2026). Strategy: **~49 days** (activated May 24). V3 framework: ~26 months. Morpho Blue: ~30 months |
+| TVL | **47.5099 WBTC** (~$3.05M). Deposit limit: 100,000 WBTC (oversized). Strategy maxDebt: 1,000 WBTC |
+| Security incidents | None on any component |
+| Strategy review | Yearn 12-metric framework + ySec review |
 
-**Score: 1.5 / 5** — strong audit coverage, no incidents. The vault is the **youngest in the set** (~11.9 months) and has been **mostly undeployed** — the track record gap reflects shorter time-in-production, not shorter time-at-risk-for-depositors (with no strategy funded, deposited WBTC has never been exposed to a counterparty).
+**Score: 1.5 / 5** — strong audit coverage across all layers, no incidents. The strategy is only ~49 days old (short track record for this specific MetaMorpho instance), but the underlying Morpho Blue protocol has ~30 months of clean production. The vault spent most of its life idle, so yield-bearing track record is limited but risk-bearing history is not misleading.
 
 #### Category 2: Centralization & Control Risks (Weight: 30%)
 
@@ -340,39 +452,40 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 
 | Factor | Assessment |
 |--------|-----------|
-| Upgradeability | V3 vault is **immutable** |
-| Multisig | 6-of-9 ySafe with **publicly named, prominent DeFi signers** |
-| Timelock | 7-day delay on `ADD_STRATEGY` and `ACCOUNTANT`. Self-governed |
-| Privileged roles | Well-distributed; no role concentration |
+| Upgradeability | V3 vault is **immutable**. MetaMorpho is **immutable**. Morpho Blue is **immutable** |
+| Multisig | 6-of-9 ySafe with **publicly named, prominent DeFi signers**. MetaMorpho owner: Security 4-of-7. Curator: 2-of-3 Safe |
+| Timelock | 7-day Yearn TimelockController + 3-day MetaMorpho curator timelock |
+| Privileged roles | Well-distributed; no role concentration. Dual timelock layers for strategy and market-cap changes |
 | EOA risk | None |
 
-**Governance Score: 1.0 / 5** — textbook score-1 governance.
+**Governance Score: 1.0 / 5** — textbook score-1 governance. Multiple immutable contracts, distributed roles, named signers, dual-timelock architecture.
 
 **Subcategory B: Programmability**
 
 | Factor | Assessment |
 |--------|-----------|
-| PPS | On-chain ERC-4626, fully algorithmic |
+| PPS | Fully on-chain: vault ERC-4626 → MetaMorpho ERC-4626 → Morpho Blue share math |
 | Vault operations | Permissionless deposits / withdrawals |
-| Strategy reporting | Programmatic via keeper (idle today) |
-| Debt allocation | Automated (Debt Allocator) + manual (Brain) |
+| Strategy reporting | Automated via keeper → StrategyReported events. Last report: Jul 9, 2026 |
+| Debt allocation | Automated (Debt Allocator) + manual (Brain) + MetaMorpho curator (supply caps) |
+| Oracle dependency | MorphoChainlinkOracleV2 (LBTC/USD, cbBTC/USD). Chainlink is the most battle-tested oracle infrastructure |
 
-**Programmability Score: 1.0 / 5** — fully programmatic.
+**Programmability Score: 1.0 / 5** — fully programmatic with battle-tested oracle infrastructure.
 
 **Subcategory C: External Dependencies**
 
 | Factor | Assessment |
 |--------|-----------|
-| Protocol count (today) | 0 funded strategies, 0 queued strategies (`get_default_queue() == []`) |
-| Criticality | Only the WBTC token itself (BitGo custody) |
-| Quality | WBTC is the most-liquid wrapped-BTC representation in DeFi |
-| Forward-looking | Any new strategy must clear a 7-day TimelockController proposal before it can hold debt — preserving a re-review window |
+| Protocol count (today) | 1 active strategy → Morpho Blue (2 markets: 1 active, 1 queued). Collateral tokens: LBTC (active), cbBTC (queued). Oracles: 2 Chainlink feeds. Total: ~7 distinct dependencies |
+| Criticality | WBTC (critical, underlying). Morpho Blue (critical, holds all funds). Chainlink LBTC/USD oracle (high, liquidation pricing). LBTC (moderate, collateral) |
+| Quality | Morpho Blue: top-tier, immutable, $1B+ TVL. Chainlink: battle-tested. LBTC: newer but serious (Lombard). cbBTC: Coinbase-backed, well-established |
+| Single-point concentration | 100% of deployed capital (18% of TVL) in one Morpho Blue market. 82% idle buffer mitigates but diversification to cbBTC market would improve resilience |
 
-**Dependencies Score: 1.0 / 5** — at the snapshot the only material dependency is WBTC itself. With **no strategy attached and no funded protocol dependency**, depositors' WBTC sits at the immutable vault contract with zero counterparty surface. Any future strategy attachment must clear a 7-day TimelockController proposal — preserving a re-review window. Re-evaluate upward against the actual mix once a strategy is attached.
+**Dependencies Score: 2.0 / 5** — the dependency surface expanded from 1 (WBTC alone) to ~7 distinct components. The protocols themselves are high-quality (Morpho Blue, Chainlink), but the number of dependencies is material and the deployed portion is single-market concentrated. LBTC as a newer collateral token at 94.5% LLTV adds moderate risk. The 82% idle buffer provides substantial mitigation.
 
-**Centralization Score = (1.0 + 1.0 + 1.0) / 3 = 1.0**
+**Centralization Score = (1.0 + 1.0 + 2.0) / 3 = 1.33**
 
-**Score: 1.0 / 5**
+**Score: 1.3 / 5**
 
 #### Category 3: Funds Management (Weight: 30%)
 
@@ -380,23 +493,23 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 
 | Factor | Assessment |
 |--------|-----------|
-| Backing | 100% on-chain WBTC (today, all idle at vault contract) |
-| Collateral quality | WBTC is custodied by BitGo. Quality depends on BitGo's custody integrity and proof-of-reserves cadence |
-| Leverage | None |
-| Verifiability | WBTC ERC-20 balance fully on-chain; the BTC backing is off-chain (BitGo custody) |
+| Backing | 100% on-chain WBTC deployed through MetaMorpho → Morpho Blue (82% idle, 18% active lending). The WBTC balance is directly verifiable on-chain through Morpho share math |
+| Collateral quality | Underlying asset: WBTC (BitGo custody). Lending exposure: over-collateralized at 94.5% LLTV against LBTC. The strategy is a pure lender, not a borrower |
+| Leverage | None at vault or strategy level |
+| Verifiability | Fully on-chain: vault ERC-4626 → MetaMorpho ERC-4626 → Morpho Blue supply positions |
 
-**Score: 1.5 / 5** — top-tier on-chain backing of WBTC, but WBTC's wrapped-asset structure (off-chain custody) is a half-step risk above pure on-chain assets like USDC/USDT/DAI/USDS, all of which also have off-chain backing but with different custody models. Conservative half-step bump.
+**Score: 1.5 / 5** — top-tier on-chain backing with over-collateralized lending. WBTC's off-chain custody (BitGo) and LBTC's newer status keep this at 1.5 rather than 1.0. No leverage, pure lender position.
 
 **Subcategory B: Provability**
 
 | Factor | Assessment |
 |--------|-----------|
-| Reserve transparency | Fully on-chain at the vault — anyone can verify yvWBTC-1's WBTC balance |
-| Exchange rate | ERC-4626, programmatic, real-time |
-| Reporting | Automated via keepers (idle today) with 5-day profit unlock |
-| Third-party verification | Underlying WBTC balance trivially on-chain; BitGo's proof-of-reserves is published off-chain |
+| Reserve transparency | Fully on-chain across the full dependency chain — vault, MetaMorpho, Morpho Blue supply positions |
+| Exchange rate | Two-layer ERC-4626 (vault + MetaMorpho), fully algorithmic |
+| Reporting | Automated via keepers with 5-day profit unlock. Last report: Jul 9, 2026 |
+| Third-party verification | All positions verifiable via Etherscan + `cast`. Chainlink oracle feeds are publicly accessible |
 
-**Score: 1.0 / 5** — excellent on-chain provability for the vault layer.
+**Score: 1.0 / 5** — excellent on-chain provability for the entire dependency chain.
 
 **Funds Management Score = (1.5 + 1.0) / 2 = 1.25**
 
@@ -406,25 +519,25 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 
 | Factor | Assessment |
 |--------|-----------|
-| Exit mechanism | 100% idle today — atomic, no slippage, no strategy unwind |
-| Liquidity depth | Trivially excellent today (idle balance covers any redemption up to TVL) |
-| Large holder impact | None today — full balance redeemable |
-| Same-value asset | WBTC-denominated |
-| Withdrawal restrictions | None |
+| Exit mechanism | 82% idle (instant redemption through Morpho idle market). 18% in WBTC/LBTC lending market at 79.4% utilization — withdrawal constrained by available liquidity (~1.85 WBTC) |
+| Liquidity depth | Excellent for idle portion (covers any redemption up to 82% of TVL). Constrained for deployed portion — strategy is 95.2% of market supply |
+| Large holder impact | Redemptions >82% of TVL would need LBTC market unwind; above available liquidity would require borrower repayments or liquidations |
+| Same-value asset | WBTC-denominated throughout |
+| Withdrawal restrictions | None. No cooldown, no lock period. MetaMorpho redeem → Morpho withdraw is instant |
 
-**Score: 1.0 / 5** — trivially liquid today. **When a future strategy is attached and funded**, the liquidity score may need to step up — WBTC lending-market liquidity is historically narrower than USD stablecoin markets, and a single-strategy attachment would carry venue-concentration risk. Captured under Reassessment Triggers.
+**Score: 1.5 / 5** — the 82% idle buffer provides strong redemption capacity for typical usage. The deployed portion's constrained liquidity (single-market, high utilization, strategy dominance) prevents a score of 1.0, but the idle buffer prevents a score of 2.0 or higher. The Morpho Blue liquidation mechanism provides a backstop for deployed liquidity recovery.
 
 #### Category 5: Operational Risk (Weight: 5%)
 
 | Factor | Assessment |
 |--------|-----------|
-| Team | Yearn — established 2020, public, named multisig signers |
-| Vault management | Standard pattern across 37+ vaults |
-| Documentation | Comprehensive, code verified on Etherscan |
-| Legal | BORG (Cayman foundation) |
-| Incident response | 4 historical V1 events, $200K Immunefi. **Demonstrated again here** — Brain / Debt Allocator pulled all debt and the only attached strategy was subsequently revoked, following the rsETH bridge exploit (per Yearn team, unverified attribution) |
-| Monitoring | Active alerts, but **yvWBTC-1 is NOT yet in `alert_large_flows.py`** — should be added before any meaningful TVL |
-| Deposit cap hygiene | **100,000 WBTC cap (≈ $8.1B) vs 47.5 WBTC TVL** is materially oversized. Not a safety risk while undeployed but should be tightened |
+| Team | Yearn — established 2020, public, named multisig signers. Morpho — established 2022, respected |
+| Vault management | Standard pattern across 37+ vaults. MetaMorpho adds curator layer (2-of-3 Safe) for supply cap management |
+| Documentation | Comprehensive. Strategy code verified on Etherscan. Morpho Blue docs extensive |
+| Legal | Yearn BORG (Cayman foundation). Morpho: Swiss association |
+| Incident response | Demonstrated: Yearn pulled all debt during April 2026 rsETH incident, revoked Aave strategy, re-deployed via MetaMorpho within weeks. Morpho has not had an exploit incident |
+| Monitoring | Active Yearn alerts, but **yvWBTC-1 is NOT yet in `alert_large_flows.py`**. MetaMorpho/Morpho monitoring coverage needs confirmation |
+| Deposit cap hygiene | **100,000 WBTC cap (~$6.4B) vs 47.5 WBTC TVL** remains materially oversized |
 
 **Score: 1.5 / 5** — top-tier operational maturity at the framework level, half-step bump for the missing monitoring entry and the oversized deposit cap on this specific vault.
 
@@ -433,13 +546,13 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 | Category | Score | Weight | Weighted |
 |----------|------:|-------:|---------:|
 | Audits & Historical | 1.5 | 20% | 0.300 |
-| Centralization & Control | 1.0 | 30% | 0.300 |
+| Centralization & Control | 1.3 | 30% | 0.390 |
 | Funds Management | 1.25 | 30% | 0.375 |
-| Liquidity Risk | 1.0 | 15% | 0.150 |
+| Liquidity Risk | 1.5 | 15% | 0.225 |
 | Operational Risk | 1.5 | 5% | 0.075 |
-| **Final Score** | | | **1.200 → 1.2 / 5.0** |
+| **Final Score** | | | **1.365 → 1.4 / 5.0** |
 
-1.200 rounds to 1.2 under the standard nearest-0.1 rule. This is the **lowest risk surface of the six mainnet risk-1 vaults**: with no strategy attached, depositors' WBTC has zero counterparty exposure beyond the immutable vault contract and the WBTC token itself. The youngest-vault status, oversized deposit cap, and missing monitoring entry are operational-hygiene issues but do not put deposited funds at risk.
+1.365 rounds to 1.4 under the standard nearest-0.1 rule. This is up from the previous 1.2, reflecting the newly-attached strategy and expanded dependency surface. However, 1.4 remains well within the **Minimal Risk** tier. The primary drivers of the +0.2 increase are: (a) Dependencies expanded from WBTC-only (1.0) to 7-component dependency chain including newer LBTC collateral (2.0); (b) Liquidity moved from trivially atomic (1.0) to mostly-idle with constrained deployed portion (1.5).
 
 ### Risk Tier
 
@@ -451,30 +564,45 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 | 3.5–4.5 | Elevated Risk | Limited approval, strict limits |
 | 4.5–5.0 | High Risk | Not recommended |
 
-**Final Risk Tier: Minimal Risk (1.2 / 5.0) — Approved, high confidence**
+**Final Risk Tier: Minimal Risk (1.4 / 5.0) — Approved, high confidence**
 
 ---
 
 ## Reassessment Triggers
 
-- **Time-based:** Reassess in 6 months (October 2026) or annually
-- **TVL-based:** Reassess if TVL exceeds 200 WBTC (~$15M) or changes by ±50%
-- **rsETH-related deallocation and strategy revocation:**
-  - **rerun this assessment once Yearn attaches and funds any new strategy on yvWBTC-1.** The current 100%-idle / empty-queue posture has persisted from the May 5 to May 11 snapshots; the dependency profile and liquidity score all need re-evaluation against any future chosen strategy
-  - if any new strategy is added that takes direct or indirect rsETH exposure, full re-review of the dependency subscore
+- **Time-based:** Reassess in 6 months (January 2027) or annually
+- **TVL-based:** Reassess if TVL exceeds 200 WBTC (~$12.8M at current prices) or changes by ±50%
 - **Strategy posture:**
-  - **any `addStrategy()` proposal at the Strategy Manager TimelockController** ([`0x88Ba032be87d5EF1fbE87336b7090767F367BF73`](https://etherscan.io/address/0x88Ba032be87d5EF1fbE87336b7090767F367BF73)) targeting yvWBTC-1 — review during the 7-day delay window before the strategy can be funded
-  - **if a USDS-denominated or Sky-routed strategy is later attached** to yvWBTC-1, the "no Sky concentration" exclusion no longer holds — re-evaluate dependency and concentration scores against the broader risk-1 stable stack
-  - if more than one strategy is attached, re-evaluate the dependency subscore for diversification
-- **Underlying-protocol incidents:** any major incident affecting WBTC (or the protocol of any future attached strategy) — full re-review
+  - **any `addStrategy()` or `revokeStrategy()` proposal at the Strategy Manager TimelockController** ([`0x88Ba032be87d5EF1fbE87336b7090767F367BF73`](https://etherscan.io/address/0x88Ba032be87d5EF1fbE87336b7090767F367BF73)) targeting yvWBTC-1 — review during the 7-day delay window
+  - **if a USDS-denominated or Sky-routed strategy is later attached** — re-evaluate dependency and concentration scores
+  - if additional strategies are attached, re-evaluate the dependency subscore for diversification
+- **MetaMorpho / Morpho Blue:**
+  - Any supply cap changes on active markets (3-day curator timelock provides advance notice)
+  - Addition or removal of Morpho Blue markets from the MetaMorpho supply queue
+  - Any Morpho Blue market parameter change (requires new market creation since core is immutable)
+  - Chainlink oracle changes for LBTC/USD or cbBTC/USD feeds
+- **Allocation shifts:**
+  - If deployed portion exceeds 50% of TVL (currently 18%)
+  - If idle ratio drops below 20% (currently 82%)
+  - If a second Morpho market receives a material allocation — re-evaluate diversification
+- **Underlying-protocol incidents:**
+  - Any major incident affecting Morpho Blue, MetaMorpho, or WBTC
+  - LBTC depeg event, Lombard custody issues, or significant LBTC/USD oracle deviation
+  - Chainlink oracle failure or manipulation affecting LBTC or cbBTC feeds
 - **Action items (operational hygiene):**
-  - **Tighten the deposit cap** — current `deposit_limit = 100,000 WBTC` (≈ $8.1B at snapshot) is materially above any plausible near-term TVL. Either tighten the cap (e.g. to a multiple of intended TVL) or document the rationale with the Yearn team and revisit this report before re-deployment
-  - **Add yvWBTC-1 to `alert_large_flows.py`** monitored vault list before any meaningful TVL
-- **WBTC-specific:**
-  - BitGo proof-of-reserves issues
-  - sustained WBTC-BTC peg deviation
-  - significant blacklisting / freezing events affecting WBTC
-- **Governance-based:** ySafe / Brain / Security signer or threshold changes; any change to the timelock delay (would itself require 7 days)
+  - **Tighten the deposit cap** — current `deposit_limit = 100,000 WBTC` (~$6.4B at snapshot) is materially above any plausible near-term TVL
+  - **Add yvWBTC-1 to `alert_large_flows.py`** monitored vault list
+- **WBTC-specific:** BitGo proof-of-reserves issues, sustained WBTC-BTC peg deviation, significant blacklisting / freezing events
+- **Governance-based:** ySafe / Brain / Security / Curator signer or threshold changes; any change to the timelock delays
+
+---
+
+## Assessment History
+
+| Date | Score | Notes |
+|------|-------|-------|
+| May 11, 2026 | 1.2 | Initial assessment: 100% idle, empty strategy queue, no protocol dependencies beyond WBTC |
+| July 12, 2026 | 1.4 | Reassessment: MetaMorpho V1_1 strategy activated May 24, 2026 deploying 18% to WBTC/LBTC Morpho Blue market (82% idle). Dependency surface expanded to Morpho Blue + Chainlink + LBTC. Score +0.2 on dependencies (+1.0) and liquidity (+0.5), offset by continued excellent governance and collateralization. Still Minimal Risk tier |
 
 ---
 
@@ -490,25 +618,47 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 │  │  0x751F…b708          │                                          │
 │  │                       │                                          │
 │  │  47.5 WBTC TVL        │                                          │
-│  │  (~$3.87M)            │                                          │
-│  │  100% idle            │  ← all WBTC held at vault contract       │
-│  │  totalDebt = 0        │                                          │
-│  │  default queue = []   │  ← no strategy attached                  │
+│  │  ~$3.05M              │                                          │
+│  │  totalDebt = 100% TVL │  ← fully deployed to strategy            │
 │  │  deposit_limit=100k   │  ← oversized vs TVL                      │
-│  └───────────────────────┘                                          │
+│  └──────────┬────────────┘                                          │
+│             │ 100% (47.5 WBTC)                                      │
+│             ▼                                                       │
+│  ┌───────────────────────┐                                          │
+│  │  MetaMorphoV1_1       │  ← Yearn-governed ERC-4626               │
+│  │  "ymv-WBTC", immut.   │    Owner: Security 4-of-7                │
+│  │  0x2bB0…77E           │    Guardian: ySafe 6-of-9                │
+│  │                       │    Curator: 2-of-3 Safe                  │
+│  │  totalAssets: 47.51   │    Fee: 0% | Timelock: 3 days            │
+│  └────┬────────────┬─────┘                                          │
+│       │ 82% idle   │ 18% active                                     │
+│       ▼            ▼                                                │
+│  ┌─────────┐  ┌──────────────────────┐                              │
+│  │ Morpho  │  │ Morpho Blue          │                              │
+│  │ Blue    │  │ WBTC/LBTC Market     │                              │
+│  │ idle    │  │ (94.5% LLTV)         │                              │
+│  │ market  │  │ Oracle: Chainlink     │                              │
+│  │         │  │   LBTC/USD           │                              │
+│  │ 38.96   │  │ IRM: AdaptiveCurve   │                              │
+│  │ WBTC    │  │                       │                              │
+│  │         │  │ Strategy: 8.55 WBTC   │                              │
+│  └─────────┘  │ Market: 8.98 WBTC    │                              │
+│               │ Util: 79.4%           │                              │
+│               └──────────────────────┘                              │
 │                                                                      │
-│  Strategies in queue: NONE (`get_default_queue() == []`)            │
-│   - Previously-attached Aave V3 WBTC Lender revoked between Apr 27  │
-│     and May 5 snapshots (`activation = 0` at 0x0B9A…4EDc)           │
-└──────────────────────────────────────────────────────────────────────┘
+│  Available but unused:                                               │
+│  ┌──────────────────────┐                                           │
+│  │ Morpho Blue          │  ← queued, cap 500 WBTC, no position      │
+│  │ WBTC/cbBTC Market    │                                           │
+│  │ (94.5% LLTV)         │                                           │
+│  └──────────────────────┘                                           │
+└─────────────────────────────────────────────────────────────────────┘
 
-At the snapshot the vault holds WBTC directly with no strategy attached
-and no protocol dependency surface beyond WBTC itself. Any new strategy
-must clear a 7-day TimelockController proposal before it can hold debt.
-Whether the empty-queue posture is permanent deprecation or a precursor
-to re-onboarding under the timelock is not on-chain verifiable today.
-The vault remains fully outside the Sky / USDS concentration that
-affects yvUSDC-1 / yvUSDS-1 / yvDAI-1.
+Dependency chain: WBTC (BitGo) → yvWBTC-1 → MetaMorpho → Morpho Blue
+→ Chainlink (LBTC/USD) + LBTC (Lombard).
+
+All three core contracts (yvWBTC-1, MetaMorpho, Morpho Blue) are immutable.
+The vault remains fully outside the Sky / USDS concentration.
 ```
 
 ## Appendix: TimelockController Role Structure

--- a/reports/report/yearn-yvwbtc.md
+++ b/reports/report/yearn-yvwbtc.md
@@ -142,7 +142,7 @@ All strategies pass through Yearn's **12-metric risk-scoring framework** ([RISK_
 
 - **Yearn (Immunefi):** active, **$200,000** max payout (Critical). https://immunefi.com/bounty/yearnfinance/
 - **Yearn (Sherlock):** also listed at https://audits.sherlock.xyz/bug-bounties/30
-- **Underlying-protocol bug bounties:** [Morpho (Immunefi)](https://immunefi.com/bounty/morpho/) — **$2,500,000** max payout (Critical)
+- **Underlying-protocol bug bounties:** [Morpho (Cantina)](https://cantina.xyz/bounties/35a5f0a1-2ffd-432c-8f3b-77d169add8c3) — **$2,500,000** max payout (Critical)
 - **Safe Harbor (SEAL):** Yearn is **not** listed on the SEAL Safe Harbor registry
 
 ### On-Chain Complexity
@@ -438,7 +438,7 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 | Factor | Assessment |
 |--------|-----------|
 | Audits | V3 framework: 3 audits. Morpho Blue: 3 audits. MetaMorpho: multiple audits. Strategy reviewed via Yearn's 12-metric framework |
-| Bug bounty | $200K (Yearn Immunefi) + $2.5M (Morpho Immunefi) |
+| Bug bounty | $200K (Yearn Immunefi) + $2.5M (Morpho Cantina) |
 | Production history | Vault: **~14 months** (mostly undeployed until May 24, 2026). Strategy: **~49 days** (activated May 24). V3 framework: ~26 months. Morpho Blue: ~30 months |
 | TVL | **47.5099 WBTC** (~$3.05M). Deposit limit: 100,000 WBTC (oversized). Strategy maxDebt: 1,000 WBTC |
 | Security incidents | None on any component |

--- a/reports/report/yearn-yvwbtc.md
+++ b/reports/report/yearn-yvwbtc.md
@@ -289,7 +289,7 @@ ySafe 6-of-9 signers include publicly known DeFi contributors — see [Yearn Mul
 - **PPS:** ERC-4626, fully algorithmic
 - **Vault operations:** permissionless deposit / withdraw on-chain
 - **Strategy reporting:** automated via keeper (when strategy is funded)
-- **Debt allocation:** Debt Allocator (automated) + Brain (manual) — currently 0 deployed
+- **Debt allocation:** Debt Allocator (automated) + Brain (manual) — fully deployed to MetaMorpho strategy via the vault queue
 - **Off-chain inputs:** none
 
 ### External Dependencies
@@ -361,7 +361,7 @@ Other monitoring that does cover yvWBTC-1 implicitly via the broader Yearn V3 se
 - **MetaMorpho supply queue changes** — `setSupplyQueue` by curator
 - **LBTC market utilization spikes** — currently 79.4%; approaching 90%+ significantly degrades withdrawal capacity
 - **Morpho Blue market parameter changes** — LLTV or oracle changes on the active markets (requires new Morpho Blue market creation since core is immutable)
-- **Emergency actions** — vault `Shutdown` or Morpho Blue market pause (guardian can pause)
+- **Emergency actions** — vault `Shutdown`; MetaMorpho guardian (ySafe 6-of-9) can revoke markets from the supply queue and set caps to zero. Morpho Blue core is immutable with no pause mechanism
 - **ySafe / Brain / Security / Curator signer or threshold changes**
 - **PPS decrease** — should only increase outside of explicit loss events
 - **Deposit-limit changes** — particularly relevant given the current oversized cap

--- a/reports/report/yearn-yvwbtc.md
+++ b/reports/report/yearn-yvwbtc.md
@@ -115,15 +115,6 @@ The MetaMorpho strategy allocates capital to **Morpho Blue** lending markets:
 
 The **v3.0.4 patch release** (used by yvWBTC-1) was reviewed **internally** by the Yearn team rather than re-engaging external auditors. The diff from v3.0.2 is a minor patch-level change; the external audits cover the core architecture. Source: [yearn-vaults-v3 GitHub releases](https://github.com/yearn/yearn-vaults-v3/releases).
 
-### Underlying Protocol Audits: Morpho Blue & MetaMorpho
-
-| Auditor | Date | Scope | Report |
-|---------|------|-------|--------|
-| [ChainSecurity](https://github.com/morpho-org/morpho-blue/blob/main/audits/2024-01-05-chainsecurity.pdf) | Jan 5, 2024 | Morpho Blue | PDF |
-| [Spearbit](https://github.com/morpho-org/morpho-blue/blob/main/audits/2024-01-08-spearbit.pdf) | Jan 8, 2024 | Morpho Blue | PDF |
-| [Cantina](https://github.com/morpho-org/morpho-blue/blob/main/audits/2024-02-02-cantina.pdf) | Feb 2, 2024 | Morpho Blue | PDF |
-| [Cantina](https://cantina.xyz/competitions/47418e9c-6540-47bd-a205-7f410b6bea43) | May 2024 | MetaMorpho | Competition |
-| [OpenZeppelin](https://github.com/morpho-org/morpho-blue/blob/main/audits/2024-09-17-openzeppelin-timelock.pdf) | Sep 17, 2024 | Timelock | PDF |
 
 Morpho Blue core contracts are **immutable** (no proxy, no upgrade mechanism). MetaMorpho V1_1 is also immutable. The historical Aave V3 attachment (which was revoked) is documented in the Historical Track Record below.
 


### PR DESCRIPTION
## Reassessment: yvWBTC-1 (July 12, 2026)

**Issue:** #309  
**Files changed:** `reports/report/yearn-yvwbtc.md`, `reports/graph/yearn-yvwbtc.yaml`

### Summary

The yvWBTC-1 vault was reassessed 61 days after the May 11, 2026 snapshot. A new MetaMorpho V1_1 strategy was activated on May 24, 2026, materially changing the vault's posture.

### Changed facts

| Fact | Previous (May 11) | Current (Jul 12) |
|------|------------------|-------------------|
| Strategy | Empty queue (idle) | MetaMorpho V1_1 (ymv-WBTC) at `0x2bB0…77E` |
| Total Debt | 0 (0% deployed) | 47.51 WBTC (100% deployed) |
| Total Idle | 47.51 WBTC (100%) | 0 (at vault level; 82% idle within strategy) |
| TVL | 47.5051 WBTC (~$3.87M) | 47.5099 WBTC (~$3.05M, BTC price down 21%) |
| PPS | 1.000037 | 1.000305 |
| Strategy maxDebt | N/A | 1,000 WBTC |
| Dependencies | WBTC only | +Morpho Blue, MetaMorpho, LBTC, cbBTC, 2× Chainlink oracles |
| Score | 1.2 | 1.4 (+0.2) |

### Score changes

- **Dependencies**: 1.0 → 2.0 (WTC-only → 7-component chain)
- **Liquidity**: 1.0 → 1.5 (atomic idle → 82% idle + 18% constrained lending market)
- **Governance**: unchanged at 1.0
- **Collateralization**: unchanged at 1.5
- **Provaability**: unchanged at 1.0
- **Final**: 1.2 → 1.4 (still Minimal Risk)

### Allocation

- Morpho Blue idle market: 38.96 WBTC (82.0%)
- Morpho Blue WBTC/LBTC market: 8.55 WBTC (18.0%, 79.4% util, strat is 95.2% of supply)
- Morpho Blue WBTC/cbBTC market: 0 WBTC (queued, cap 500 WBTC)

### Unchanged critical controls

- ySafe 6-of-9, Brain 3-of-8, Security 4-of-7 — all verified on-chain
- 7-day TimelockController delay — verified at 604800 seconds
- Vault immutable (Vyper minimal proxy)
- Deposit limit: 100,000 WBTC (still oversized)
- No Sky/USDS exposure

### Graph

Updated with: strategy node (ymv-wbtc), Morpho Blue, LBTC/cbBTC dependencies, curator governance node. Build passes.

### Verification

All values verified on-chain via `cast` at block 25519096. Governance thresholds from Safe `getThreshold()`/`getOwners()` calls.