### PR TITLE
reassess(yearn-yvusdt): refresh TVL, strategy allocations, and dependency graph (July 2026)

### DIFF
--- a/reports/graph/yearn-yvusdt.yaml
+++ b/reports/graph/yearn-yvusdt.yaml
@@ -67,31 +67,24 @@ nodes:
 
   # Strategies
   - id: spark-usdt-lender
-    label: Spark USDT Lender (45.58%)
-    address: "0xED48069a2b9982B4eec646CBfA7b81d181f9400B"
+    label: Spark USDT Lender (56.06%)
+    address: "0x176Caf15f1793fc16898458E0ba295ec6523E9E2"
     category: strategy
-  - id: morpho-gauntlet-usdt
-    label: Morpho Gauntlet USDT Prime (54.42%)
-    address: "0x6D2981FF9b8d7edbb7604de7A65BAC8694ac849F"
-    category: strategy
-  - id: morpho-steakhouse-usdt
-    label: Morpho Steakhouse USDT (queued, 0%)
-    address: "0x0a4ea2bDe8496a878a7ca2772056a8e6fe3245c5"
+  - id: metamorpo-usdt
+    label: MetaMorpho Vault (ymv-USDT) (43.94%)
+    address: "0x0963232eB842BAF53E8e517691f81745C1F228a0"
     category: strategy
 
   # External dependencies
   - id: spark-lend-usdt
     label: Spark Lend USDT Market
+    address: "0xC13e21B648A5Ee794902342038FF3aDAB66BE987"
     category: dependency
     note: Sky sub-DAO; admin keys live under Sky governance
-  - id: morpho-gauntlet-vault
-    label: Morpho Gauntlet USDT Prime Vault
+  - id: morpho
+    label: Morpho Protocol
+    address: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
     category: dependency
-    note: Gauntlet-curated Morpho MetaMorpho vault
-  - id: morpho-steakhouse-vault
-    label: Morpho Steakhouse USDT Vault
-    category: dependency
-    note: Steakhouse-curated Morpho MetaMorpho vault
 
 edges:
   # Deployment / vault infrastructure
@@ -110,15 +103,11 @@ edges:
   - from: yvUSDT
     to: spark-usdt-lender
     kind: allocates-to
-    label: "45.58%"
+    label: "56.06%"
   - from: yvUSDT
-    to: morpho-gauntlet-usdt
+    to: metamorpo-usdt
     kind: allocates-to
-    label: "54.42%"
-  - from: yvUSDT
-    to: morpho-steakhouse-usdt
-    kind: allocates-to
-    label: "queued"
+    label: "43.94%"
 
   # Governance roles on vault
   - from: daddy
@@ -146,6 +135,12 @@ edges:
     kind: holds-role
     label: "REPORTING + DEBT_MANAGER"
 
+  # MetaMorpho vault ownership — Security is the owner
+  - from: security
+    to: metamorpo-usdt
+    kind: controls
+    label: "MetaMorpho owner"
+
   # Role manager wiring
   - from: daddy
     to: role-manager
@@ -172,11 +167,7 @@ edges:
     to: spark-lend-usdt
     kind: deposits-into
     label: "USDT supply"
-  - from: morpho-gauntlet-usdt
-    to: morpho-gauntlet-vault
+  - from: metamorpo-usdt
+    to: morpho
     kind: deposits-into
     label: "USDT deposit"
-  - from: morpho-steakhouse-usdt
-    to: morpho-steakhouse-vault
-    kind: deposits-into
-    label: "USDT deposit (queued)"

--- a/reports/report/yearn-yvusdt.md
+++ b/reports/report/yearn-yvusdt.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: Yearn — yvUSDT-1
 
-- **Assessment Date:** May 11, 2026
+- **Assessment Date:** May 11, 2026 (Updated: July 13, 2026)
 - **Token:** yvUSDT-1 (USDT-1 yVault)
 - **Chain:** Ethereum
 - **Token Address:** [`0x310B7Ea7475A0B449Cfd73bE81522F1B88eFAFaa`](https://etherscan.io/address/0x310B7Ea7475A0B449Cfd73bE81522F1B88eFAFaa)
@@ -8,37 +8,35 @@
 
 ## Overview + Links
 
-yvUSDT-1 is a **USDT-denominated Yearn V3 vault** (ERC-4626) on Ethereum mainnet. The vault holds **~$7.30M USDT** and is **100% deployed** at the snapshot — `totalIdle = 0`, `totalDebt = totalAssets`. The queue holds **three strategies** (Spark USDT, Morpho Gauntlet USDT Prime, Morpho Steakhouse USDT). Two previously-queued strategies — **USDT Fluid Lender and Aave V3 USDT Lender** — were revoked between the April 27 and May 5 snapshots (`activation = 0` on both) and remain revoked at this snapshot.
+yvUSDT-1 is a **USDT-denominated Yearn V3 vault** (ERC-4626) on Ethereum mainnet. The vault holds **~$7.23M USDT** and is **100% deployed** at the snapshot — `totalIdle = 0`, `totalDebt = totalAssets`. The queue holds **two strategies** — a **Yearn-deployed MetaMorpho vault (ymv-USDT)** and a **Spark USDT Lender**. All five previously-queued strategies — Spark USDT Lender, Morpho Gauntlet USDT Prime, Morpho Steakhouse USDT, USDT Fluid Lender, and Aave V3 USDT Lender — are now revoked (`activation = 0`).
 
-Per the Yearn team, the late-April 100%-idle posture was a **precautionary deallocation following the April 18, 2026 rsETH (KelpDAO) bridge exploit** on the LayerZero OFT bridge layer (the rsETH event itself is documented in the [hgETH reassessment report](./kerneldao-hgeth.md)). The team's specific causal attribution has not been independently verified, but the rsETH event itself is well documented. **Funds have since been re-deployed** — the deallocation reversed, but the redeployment landed in a narrower set of venues (3 instead of 5) and did not return to Fluid or Aave V3 USDT.
+Since the May 2026 assessment, the strategy queue was fully replaced: the prior Spark USDT Lender and Morpho Gauntlet/Steakhouse strategies were revoked, and two new strategies were added — the MetaMorpho vault (activated May 10, 2026) and a new Spark USDT Lender instance (activated June 29, 2026). The Morpho exposure is now through a **Yearn-operated MetaMorpho vault** (governed by Yearn Security with a 3-day timelock and a 2-of-3 curator multisig) rather than through third-party curated Morpho vaults (Gauntlet, Steakhouse).
 
-The PPS is 1.080708 (~8.07% cumulative since deployment, ~4.5% annualized). The current report captures the May 11 state — debt has rebalanced from the May 5 ~50/50 split to ~45.58% Spark / ~54.42% Morpho Gauntlet, with Spark's share trimmed by ~$233K and Morpho Gauntlet's increased by ~$409K (net TVL +$176K).
+The PPS is **1.086177** (~8.62% cumulative since deployment, ~4.4% annualized over ~23.6 months).
 
 **Key architecture:**
 
 - **Vault:** Standard Yearn V3 vault (v3.0.2) accepting USDT deposits, issuing yvUSDT-1 shares. Deployed as an immutable Vyper minimal proxy (EIP-1167) via the v3.0.2 Yearn V3 Vault Factory ([`0x444045c5C13C246e117eD36437303cac8E250aB0`](https://etherscan.io/address/0x444045c5C13C246e117eD36437303cac8E250aB0))
-- **Strategy queue (3 strategies, all USDT-native):**
-  - Spark USDT Lender ([`0xED48069a2b9982B4eec646CBfA7b81d181f9400B`](https://etherscan.io/address/0xED48069a2b9982B4eec646CBfA7b81d181f9400B)) — 45.58% of debt
-  - Morpho Gauntlet USDT Prime Compounder ([`0x6D2981FF9b8d7edbb7604de7A65BAC8694ac849F`](https://etherscan.io/address/0x6D2981FF9b8d7edbb7604de7A65BAC8694ac849F)) — 54.42% of debt
-  - Morpho Steakhouse USDT Compounder ([`0x0a4ea2bDe8496a878a7ca2772056a8e6fe3245c5`](https://etherscan.io/address/0x0a4ea2bDe8496a878a7ca2772056a8e6fe3245c5)) — queued, 0 debt
+- **Strategy queue (2 strategies, both USDT-native):**
+  - MetaMorpho Vault (ymv-USDT) ([`0x0963232eB842BAF53E8e517691f81745C1F228a0`](https://etherscan.io/address/0x0963232eB842BAF53E8e517691f81745C1F228a0)) — 43.94% of debt, Morpho MetaMorpho vault
+  - Spark USDT Lender ([`0x176Caf15f1793fc16898458E0ba295ec6523E9E2`](https://etherscan.io/address/0x176Caf15f1793fc16898458E0ba295ec6523E9E2)) — 56.06% of debt, Spark Lend
 - **Governance:** Standard **Yearn V3 Role Manager** ([`0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41`](https://etherscan.io/address/0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41)) governed by the **Yearn 6-of-9 ySafe** with **7-day TimelockController** for strategy additions
 
-**Key metrics (May 11, 2026, snapshot at block 25073237, timestamp 1778519075 = 17:04:35 UTC):**
+**Key metrics (July 13, 2026, snapshot at block 25521239):**
 
-- **TVL:** 7,297,009.96 USDT (100% deployed)
-- **Total Supply:** 6,752,058.44 yvUSDT-1
-- **Price Per Share:** 1.080708 USDT/yvUSDT-1 (~8.07% cumulative appreciation over ~21.6 months, ~4.5% annualized)
-- **Total Debt:** 7,297,009.96 USDT (100% of TVL)
+- **TVL:** 7,229,374.54 USDT (100% deployed)
+- **Total Supply:** 6,655,795.03 yvUSDT-1
+- **Price Per Share:** 1.086177 USDT/yvUSDT-1 (~8.62% cumulative appreciation over ~23.6 months, ~4.4% annualized)
+- **Total Debt:** 7,228,870.58 USDT (~99.99% of TVL; ~$503 unallocated due to floating P&L / pending profit unlock)
 - **Total Idle:** 0
 - **Debt distribution:**
-  - Spark USDT Lender: 3,325,977.14 USDT (45.58%)
-  - Morpho Gauntlet USDT Prime Compounder: 3,971,032.82 USDT (54.42%)
-  - Morpho Steakhouse USDT Compounder: 0 (queued, unfunded)
+  - MetaMorpho Vault (ymv-USDT): 3,176,868.08 USDT (43.94%)
+  - Spark USDT Lender: 4,052,002.50 USDT (56.06%)
 - **Deposit Limit:** 50,000,000 USDT
 - **Profit Max Unlock Time:** 10 days
-- **Fees:** 0% management fee, 10% performance fee
+- **Fees:** 0% management fee, 10% performance fee (unchanged)
 
-**Sky exposure note:** Spark Lend is a **Sky sub-DAO** (governed by Sky), so the ~45.58% allocation to Spark USDT Lender carries a **Sky-governance dependency** on the Spark admin keys, even though USDT itself has no USDS / Sky peg dependency. This is materially less Sky-coupled than yvUSDC-1 / yvUSDS-1 / yvDAI-1 (which have direct USDS exposure), but yvUSDT-1 is **not fully Sky-independent** — the prior framing of the queue as having "no Sky routing" was incorrect and has been revised here.
+**Sky exposure note:** Spark Lend is a **Sky sub-DAO** (governed by Sky), so the ~56% allocation to Spark USDT Lender carries a **Sky-governance dependency** on the Spark admin keys, even though USDT itself has no USDS / Sky peg dependency. This is materially less Sky-coupled than yvUSDC-1 / yvUSDS-1 / yvDAI-1 (which have direct USDS exposure), but yvUSDT-1 is **not fully Sky-independent**. The Sky-governance share has increased from ~46% to ~56% since the May 2026 strategy replacement.
 
 **Links:**
 
@@ -79,30 +77,31 @@ The PPS is 1.080708 (~8.07% cumulative since deployment, ~4.5% annualized). The 
 | Vault Factory (v3.0.2) | [`0x444045c5C13C246e117eD36437303cac8E250aB0`](https://etherscan.io/address/0x444045c5C13C246e117eD36437303cac8E250aB0) |
 | Vault Original (v3.0.2) | [`0x1ab62413e0cf2eBEb73da7D40C70E7202ae14467`](https://etherscan.io/address/0x1ab62413e0cf2eBEb73da7D40C70E7202ae14467) |
 
-### Strategies (3 in default queue, 2 with debt)
+### Strategies (2 in default queue, both with debt)
 
 | # | Strategy | Name | Current Debt (USDT) | Allocation |
 |---|----------|------|--------------------:|-----------:|
-| 1 | [`0xED48069a2b9982B4eec646CBfA7b81d181f9400B`](https://etherscan.io/address/0xED48069a2b9982B4eec646CBfA7b81d181f9400B) | Spark USDT Lender | 3,325,977.14 | 45.58% |
-| 2 | [`0x6D2981FF9b8d7edbb7604de7A65BAC8694ac849F`](https://etherscan.io/address/0x6D2981FF9b8d7edbb7604de7A65BAC8694ac849F) | Morpho Gauntlet USDT Prime Compounder | 3,971,032.82 | 54.42% |
-| 3 | [`0x0a4ea2bDe8496a878a7ca2772056a8e6fe3245c5`](https://etherscan.io/address/0x0a4ea2bDe8496a878a7ca2772056a8e6fe3245c5) | Morpho Steakhouse USDT Compounder | 0 | 0% |
+| 1 | [`0x0963232eB842BAF53E8e517691f81745C1F228a0`](https://etherscan.io/address/0x0963232eB842BAF53E8e517691f81745C1F228a0) | MetaMorpho Vault (ymv-USDT) | 3,176,868.08 | 43.94% |
+| 2 | [`0x176Caf15f1793fc16898458E0ba295ec6523E9E2`](https://etherscan.io/address/0x176Caf15f1793fc16898458E0ba295ec6523E9E2) | Spark USDT Lender | 4,052,002.50 | 56.06% |
 
-**Previously queued, now revoked (`activation = 0` at block 25073237):**
+**Previously queued, now revoked (`activation = 0` at block 25521239):**
 
+- Spark USDT Lender (old) ([`0xED48069a2b9982B4eec646CBfA7b81d181f9400B`](https://etherscan.io/address/0xED48069a2b9982B4eec646CBfA7b81d181f9400B))
+- Morpho Gauntlet USDT Prime Compounder ([`0x6D2981FF9b8d7edbb7604de7A65BAC8694ac849F`](https://etherscan.io/address/0x6D2981FF9b8d7edbb7604de7A65BAC8694ac849F))
+- Morpho Steakhouse USDT Compounder ([`0x0a4ea2bDe8496a878a7ca2772056a8e6fe3245c5`](https://etherscan.io/address/0x0a4ea2bDe8496a878a7ca2772056a8e6fe3245c5))
 - USDT Fluid Lender ([`0x4Bd05E6ff75b633F504F0fC501c1e257578C8A72`](https://etherscan.io/address/0x4Bd05E6ff75b633F504F0fC501c1e257578C8A72))
 - Aave V3 USDT Lender ([`0x27998440eC85F0DF11DED26e6aB27c8D2a9d8Cb2`](https://etherscan.io/address/0x27998440eC85F0DF11DED26e6aB27c8D2a9d8Cb2))
 
-**Sky-governance exposure note:** Spark Lend is a Sky sub-DAO. Roughly 45.58% of yvUSDT-1's debt sits in Spark USDT Lender, which is administered through Sky / Spark governance. This is a **Sky-governance dependency** but not a USDS-peg or USDS-collateral dependency — yvUSDT-1 is materially less Sky-coupled than yvUSDC-1 / yvUSDS-1 / yvDAI-1, but **not fully Sky-independent**. Captured in the dependency subscore.
+**Sky-governance exposure note:** Spark Lend is a Sky sub-DAO. Roughly 56% of yvUSDT-1's debt sits in Spark USDT Lender, which is administered through Sky / Spark governance. This is a **Sky-governance dependency** but not a USDS-peg or USDS-collateral dependency — yvUSDT-1 is materially less Sky-coupled than yvUSDC-1 / yvUSDS-1 / yvDAI-1, but **not fully Sky-independent**.
 
 ### Strategy Protocol Dependencies (current allocation)
 
 | Protocol | Strategy | Allocation | Notes |
 |----------|----------|-----------:|-------|
-| **Spark** | Spark USDT Lender | 45.58% | Sky sub-DAO; audited stack (ChainSecurity, Cantina) |
-| **Morpho (Gauntlet)** | Morpho Gauntlet USDT Prime Compounder | 54.42% | Curated by Gauntlet, $6.6B+ Morpho TVL, 25+ audits, Certora formal verification |
-| **Morpho (Steakhouse)** | Morpho Steakhouse USDT Compounder | 0% (queued) | Curated by Steakhouse |
+| **Morpho** | MetaMorpho Vault (ymv-USDT) | 43.94% | Yearn-operated MetaMorpho vault; governed by Yearn Security (4-of-7) with 3-day timelock; curator is a 2-of-3 Safe overlapping Brain/Security signers; guardian is Daddy (6-of-9) |
+| **Spark** | Spark USDT Lender | 56.06% | Sky sub-DAO; audited stack (ChainSecurity, Cantina); new strategy instance activated June 29, 2026 |
 
-The current debt is **split ~46/54 across two ecosystems** (Spark, Morpho). Both have multi-year USDT track records with no significant principal-loss events. The mix is less diversified than the prior 5-strategy queue but more concentrated than ideal — particularly the ~46% allocation to a single Sky-governed venue. Allocation has drifted slightly toward Morpho between May 5 and May 11 (Spark −$233K, Morpho Gauntlet +$409K).
+The current debt is **split ~44/56 across two ecosystems** (Morpho, Spark). Both have multi-year USDT track records with no significant principal-loss events. The mix is two-venue concentrated — ~56% allocation to a single Sky-governed venue is higher than the ~46% in the May 2026 snapshot and warrants continued monitoring. The Morpho leg is now through a Yearn-operated MetaMorpho vault rather than a third-party curator.
 
 ## Audits and Due Diligence Disclosures
 
@@ -118,8 +117,8 @@ The current debt is **split ~46/54 across two ecosystems** (Spark, Morpho). Both
 
 | Underlying | Audits | Notes |
 |------------|--------|-------|
-| **Spark (USDT lender)** | ChainSecurity, Cantina (Spark Lend / SparkDAO) | Sub-DAO of Sky |
-| **Morpho (Gauntlet + Steakhouse USDT)** | 25+ audits across Trail of Bits, Spearbit, OpenZeppelin, ChainSecurity, Certora; formal verification | Blue-chip, $6.6B+ TVL |
+| **Morpho** | 25+ audits across Trail of Bits, Spearbit, OpenZeppelin, ChainSecurity, Certora; formal verification | Blue-chip, $6.6B+ TVL; MetaMorpho vault source verified on Etherscan |
+| **Spark (USDT lender)** | ChainSecurity, Cantina (Spark Lend / SparkDAO) | Sub-DAO of Sky; new SparkLender strategy source verified on Etherscan |
 
 ### Strategy Review Process
 
@@ -136,47 +135,46 @@ All strategies pass through Yearn's **12-metric risk-scoring framework** ([RISK_
 
 **Low.** All funded strategies are **direct USDT lend / compound** with no conversion hops:
 
+- MetaMorpho Vault → direct USDT deposit to a Yearn-operated Morpho MetaMorpho vault
 - Spark USDT Lender → direct supply to Spark Lend USDT market
-- Morpho Gauntlet USDT Prime Compounder → direct USDT deposit to a Morpho Gauntlet vault
 - No leverage, no looping, no cross-chain
 - Standard ERC-4626 throughout
 - Vault is immutable
 
 ## Historical Track Record
 
-- **Vault deployed:** July 23, 2024 (deployment [tx](https://etherscan.io/tx/0x05681fd5be0e925bb720450418d20eda99bb22adc72be3d702de70368d7cd3ea)) — **~21.6 months** in production
-- **TVL:** 7,297,009.96 USDT (~$7.30M) — well within the $50M deposit limit
-- **PPS trend:** 1.000000 → 1.080708 (~8.07% cumulative return, ~4.5% annualized)
+- **Vault deployed:** July 23, 2024 (deployment [tx](https://etherscan.io/tx/0x05681fd5be0e925bb720450418d20eda99bb22adc72be3d702de70368d7cd3ea)) — **~23.6 months** in production
+- **TVL:** 7,229,374.54 USDT (~$7.23M) — well within the $50M deposit limit
+- **PPS trend:** 1.000000 → 1.086177 (~8.62% cumulative return, ~4.4% annualized)
 - **Security incidents:** None known for this vault or for the Yearn V3 framework
-- **Strategy changes:** active management — five strategies have been queued historically. Between April 27 and May 5, **Fluid USDT and Aave V3 USDT were revoked** (`activation = 0`); funds were also re-deployed from the brief 100%-idle state into the remaining Spark + Morpho Gauntlet venues
-- **Yearn V3 track record:** V3 framework live since May 2024 (~24 months). No V3 vault exploits
+- **Strategy history:** seven strategies have been queued historically. Five have been revoked. Between May and July 2026, all three strategies active in the May report (Spark USDT Lender, Morpho Gauntlet USDT Prime, Morpho Steakhouse USDT) were revoked and replaced by two new strategies: a Yearn-operated MetaMorpho vault (ymv-USDT, activated May 10, 2026) and a new Spark USDT Lender instance (activated June 29, 2026)
+- **Yearn V3 track record:** V3 framework live since May 2024 (~26 months). No V3 vault exploits
 
-**Yearn protocol TVL:** ~$197.5M total across all chains ([DeFiLlama](https://defillama.com/protocol/yearn), April 2026).
+**Yearn protocol TVL:** ~$147M total across all chains ([DeFiLlama](https://defillama.com/protocol/yearn), July 2026).
 
 **Underlying USDT lending market track records:** Spark Lend and Morpho both have multi-year track records on USDT markets with no significant principal-loss events.
 
 ## Funds Management
 
-yvUSDT-1 is **100% deployed** at the snapshot, split ~46/54 between Spark USDT Lender and Morpho Gauntlet USDT Prime Compounder. Morpho Steakhouse USDT remains queued but unfunded.
+yvUSDT-1 is **100% deployed** at the snapshot, split ~44/56 between a Yearn-operated MetaMorpho vault (ymv-USDT) and a Spark USDT Lender.
 
 ### Current State (snapshot)
 
-- **Total Assets:** 7,297,009.96 USDT
-- **Total Debt:** 7,297,009.96 USDT (100% deployed)
+- **Total Assets:** 7,229,374.54 USDT
+- **Total Debt:** 7,228,870.58 USDT (~99.99% deployed; ~$503 floating P&L)
 - **Total Idle:** 0
-- **Capital utilization:** 100%
+- **Capital utilization:** ~99.99%
 
-ERC-4626 redemptions now settle by unwinding strategy positions in queue order — atomic from the user's perspective as long as the underlying lending markets have available liquidity (Spark Lend and Morpho USDT markets are both deep multi-million-USDT venues).
+ERC-4626 redemptions settle by unwinding strategy positions in queue order — atomic from the user's perspective as long as the underlying lending markets have available liquidity (Spark Lend and Morpho USDT markets are both deep multi-million-USDT venues).
 
 ### Active Strategies
 
 | Strategy | Allocation | Mechanic | Risk profile |
 |----------|-----------:|----------|-------------|
-| **Spark USDT Lender** | 45.58% | Direct supply to Spark Lend USDT market | Sky sub-DAO, ChainSecurity / Cantina audits |
-| **Morpho Gauntlet USDT Prime Compounder** | 54.42% | Direct USDT deposit to Morpho Gauntlet vault | Curated by Gauntlet, blue-chip lending markets |
-| **Morpho Steakhouse USDT Compounder** | 0% (queued) | Direct USDT deposit to Morpho Steakhouse vault | Curated by Steakhouse, blue-chip lending markets |
+| **MetaMorpho Vault (ymv-USDT)** | 43.94% | USDT deposit to Yearn-operated MetaMorpho vault on Morpho | Governed by Yearn Security (4-of-7), 3-day timelock, 2-of-3 curator Safe |
+| **Spark USDT Lender** | 56.06% | Direct supply to Spark Lend USDT market | Sky sub-DAO, ChainSecurity / Cantina audits; new instance June 2026 |
 
-All are simple lend / compound patterns with no leverage, no conversion hops, and no cross-chain.
+Both strategies are simple lend / compound patterns with no leverage, no conversion hops, and no cross-chain. The MetaMorpho vault introduces an additional governance layer (owner, curator, guardian, timelock) that is absent from the prior third-party curated Morpho vaults.
 
 ### Accessibility
 
@@ -188,12 +186,12 @@ All are simple lend / compound patterns with no leverage, no conversion hops, an
 
 ### Collateralization
 
-- **100% USDT backing** — held in Spark and Morpho USDT lending positions
+- **~99.99% USDT backing** — held through MetaMorpho vault on Morpho and Spark Lend USDT market positions
 - **Collateral quality:** USDT is the largest stablecoin by market cap. Centrally-issued by Tether
 - **No leverage**
-- **Redemption:** atomic for normal sizes; very large redemptions depend on Spark / Morpho market utilization at the moment of withdrawal
+- **Redemption:** atomic for normal sizes; very large redemptions depend on MetaMorpho vault liquidity and Spark market utilization at the moment of withdrawal
 
-The collateral quality is the union of Spark Lend USDT and Morpho USDT market quality — both are blue-chip USDT venues with multi-year clean track records.
+The collateral quality is the union of the Yearn-operated MetaMorpho vault and Spark Lend USDT market quality — both are blue-chip USDT venues with multi-year clean track records.
 
 ### Provability
 
@@ -203,15 +201,15 @@ The collateral quality is the union of Spark Lend USDT and Morpho USDT market qu
 
 ## Liquidity Risk
 
-**Exit pipeline:** ERC-4626 `withdraw` → strategy `withdraw` → underlying lending market withdrawal (Spark Lend USDT or Morpho Gauntlet USDT vault).
+**Exit pipeline:** ERC-4626 `withdraw` → strategy `withdraw` → underlying lending market withdrawal (MetaMorpho vault on Morpho or Spark Lend USDT market).
 
-- **Underlying liquidity:** Spark Lend USDT and Morpho Gauntlet USDT are both multi-million-dollar venues with healthy utilization headroom; ~$3.3M (Spark) and ~$4.0M (Morpho) here are small fractions of either market's free liquidity
+- **Underlying liquidity:** Spark Lend USDT and Morpho MetaMorpho vault are both multi-million-dollar venues with healthy utilization headroom; ~$4.1M (Spark) and ~$3.2M (Morpho) here are small fractions of either venue's free liquidity
 - **Same-asset:** USDT-denominated share token — no price-divergence risk
 - **No DEX liquidity needed** — exits via the lending protocol's own redemption mechanics
-- **No withdrawal queue or cooldown** — atomic redemption for normal sizes
-- **Deposit limit:** 50M USDT cap vs $7.30M TVL (room for +585%)
+- **No withdrawal queue or cooldown** — atomic redemption for normal sizes (MetaMorpho vault has a 3-day timelock on parameter changes but redemptions are atomic)
+- **Deposit limit:** 50M USDT cap vs $7.23M TVL (room for +591%)
 
-The two-ecosystem split (~46% Spark / ~54% Morpho) means a liquidity squeeze in one venue can be partially absorbed by the other (subject to queue order and the user's withdraw size).
+The two-ecosystem split (~44% Morpho / ~56% Spark) means a liquidity squeeze in one venue can be partially absorbed by the other (subject to queue order and the user's withdraw size).
 
 ## Centralization & Control Risks
 
@@ -249,11 +247,12 @@ ySafe 6-of-9 signers include publicly known DeFi contributors — see [Yearn Mul
 | Dependency | Criticality | Notes |
 |-----------|-------------|-------|
 | **USDT (Tether)** | Critical (underlying asset) | Centrally issued; relies on Tether's operational and reserve integrity |
-| **Spark Lend** | High (~46% of debt) | Sky sub-DAO; Spark admin keys live under Sky governance |
-| **Morpho (Gauntlet curator)** | High (~54% of debt) | Morpho protocol $6.6B+ TVL; Gauntlet curator selects underlying markets |
+| **Spark Lend** | High (~56% of debt) | Sky sub-DAO; Spark admin keys live under Sky governance |
+| **Morpho** | High (~44% of debt) | Morpho protocol $6.6B+ TVL; MetaMorpho vault governed by Yearn Security with 3-day timelock + 2-of-3 curator Safe |
 | **Sky governance** | Indirect via Spark | Spark Lend admin sits under Sky; not an independent venue |
+| **MetaMorpho curator** | Indirect, internal | 2-of-3 Safe with overlapping Brain/Security signers; can adjust vault parameters within timelock constraints |
 
-**Dependency quality:** the deployed mix is **two blue-chip ecosystems split ~46/54** (Spark + Morpho/Gauntlet). Less diversified than the prior 5-strategy queue, and ~46% of debt sits behind Sky-governed infrastructure. Materially less Sky-coupled than yvUSDC-1 / yvUSDS-1 / yvDAI-1 (which carry direct USDS exposure) but **not fully Sky-independent** as the original report claimed.
+**Dependency quality:** the deployed mix is **two blue-chip ecosystems split ~44/56** (Morpho + Spark). ~56% of debt sits behind Sky-governed infrastructure — an increase from ~46% in the May 2026 snapshot. Materially less Sky-coupled than yvUSDC-1 / yvUSDS-1 / yvDAI-1 (which carry direct USDS exposure) but **not fully Sky-independent**. The Morpho leg is now through a Yearn-operated MetaMorpho vault rather than third-party curated vaults, which internalizes curator risk but adds the vault's own governance surface (owner, curator, guardian, timelock).
 
 ## Operational Risk
 
@@ -263,9 +262,11 @@ ySafe 6-of-9 signers include publicly known DeFi contributors — see [Yearn Mul
 - **Legal:** Yearn BORG via [YIP-87](https://gov.yearn.fi/t/yip-87-convert-ychad-eth-into-a-borg/14540)
 - **Incident response:** 4 historical V1 events handled. V3 framework not yet stress-tested by an exploit
 - **V3 immutability:** vault cannot be upgraded
-- **Operational anomalies:**
-  - The brief late-April 100%-idle posture (followed by full redeployment by May 5) showed Brain / Debt Allocator can rapidly pull and re-route debt. Per the Yearn team the deallocation was precautionary following the rsETH bridge exploit (unverified attribution)
-  - **Two strategies revoked** between April 27 and May 5 — USDT Fluid Lender and Aave V3 USDT Lender now have `activation = 0`. The redeployment landed in a narrower set of venues (Spark + Morpho only). The rationale for revoking those two specifically has not been independently verified
+- **Operational history:**
+  - Late April 2026: 100%-idle posture, precautionary deallocation following the rsETH bridge exploit (per Yearn team, unverified attribution)
+  - May 2026: Redeployment into Spark + Morpho Gauntlet (~46/54 split); Fluid and Aave V3 strategies revoked
+  - May–July 2026: Full strategy-queue replacement — all three remaining strategies revoked, replaced by a Yearn-operated MetaMorpho vault (activated May 10, 2026) and a new Spark USDT Lender (activated June 29, 2026). Rationale for the full replacement rather than incremental changes has not been independently verified
+  - The sequence demonstrates active debt management capability: the operations multisigs can pull, revoke, and redeploy across entirely new strategy sets
 
 ## Monitoring
 
@@ -282,19 +283,21 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 | Contract | Address | Monitor |
 |----------|---------|---------|
 | yvUSDT-1 Vault | [`0x310B7Ea7475A0B449Cfd73bE81522F1B88eFAFaa`](https://etherscan.io/address/0x310B7Ea7475A0B449Cfd73bE81522F1B88eFAFaa) | PPS (`convertToAssets(1e6)`), `totalAssets()`, `totalDebt()`, `totalIdle()`, Deposit / Withdraw events |
-| Each active USDT strategy | (3 queued addresses above) | `totalAssets()`, `current_debt`, `isShutdown()`, keeper report frequency |
+| Each active USDT strategy | (2 active addresses above) | `totalAssets()`, `current_debt`, `isShutdown()`, keeper report frequency |
+| MetaMorpho vault (ymv-USDT) | [`0x0963232eB842BAF53E8e517691f81745C1F228a0`](https://etherscan.io/address/0x0963232eB842BAF53E8e517691f81745C1F228a0) | `totalAssets()`, `owner()`, `curator()`, `guardian()`, `timelock()`, `supplyQueue()` market list |
 | ySafe (Daddy) | [`0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52`](https://etherscan.io/address/0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52) | Signer / threshold changes |
 | Accountant | [`0x5A74Cb32D36f2f517DB6f7b0A0591e09b22cDE69`](https://etherscan.io/address/0x5A74Cb32D36f2f517DB6f7b0A0591e09b22cDE69) | Fee changes |
 
 ### Critical Events to Monitor
 
-- **Allocation drift** — currently ~50/50 Spark/Morpho; a drift toward >75% in one venue should trigger reassessment of the dependency subscore
+- **Allocation drift** — currently ~44/56 Morpho/Spark; a drift toward >75% in one venue should trigger reassessment of the dependency subscore
 - **Strategy `current_debt` changes** — `DebtUpdated` events on the vault
 - **Strategy additions / removals** — `StrategyChanged` events (new strategies pass through 7-day timelock; further revocations are operational signals)
+- **MetaMorpho vault governance changes** — `owner()`, `curator()`, `guardian()`, or timelock changes on the ymv-USDT vault
 - **Emergency actions** (`Shutdown`)
 - **ySafe / Brain / Security signer or threshold changes**
 - **PPS decrease** — should only increase outside of explicit loss events
-- **Sky / Spark governance events** — Spark Lend admin actions can affect ~50% of yvUSDT-1's debt
+- **Sky / Spark governance events** — Spark Lend admin actions can affect ~56% of yvUSDT-1's debt
 - **USDT-specific:** Tether-side issues (peg deviation, attestation reports, blacklisting events)
 
 ### Monitoring Functions
@@ -305,7 +308,7 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 | `totalAssets()` | Vault | Total TVL | Daily |
 | `totalDebt()` / `totalIdle()` | Vault | Capital deployment ratio — currently 100% deployed | Daily |
 | `strategies(address)` | Vault | Per-strategy debt, last report time, activation (revocations show `activation = 0`) | Daily |
-| `get_default_queue()` | Vault | Withdrawal queue composition (currently 3 strategies) | Weekly |
+| `get_default_queue()` | Vault | Withdrawal queue composition (currently 2 strategies) | Weekly |
 | `getThreshold()` / `getOwners()` | ySafe | Governance integrity | Weekly |
 | `getMinDelay()` | ySafe | Delay change detection | Weekly |
 
@@ -313,21 +316,21 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 
 ### Key Strengths
 
-- **Battle-tested Yearn V3 infrastructure:** 3 audits by top firms, ~24 months of clean V3 production. Immutable vault contract eliminates proxy upgrade risk
+- **Battle-tested Yearn V3 infrastructure:** 3 audits by top firms, ~26 months of clean V3 production. Immutable vault contract eliminates proxy upgrade risk
 - **Standard Yearn governance:** Yearn V3 Role Manager + 6-of-9 ySafe (named DeFi signers) + 7-day self-governed timelock
-- **Two-ecosystem split:** ~46/54 across Spark Lend and Morpho Gauntlet — both blue-chip USDT venues with multi-year clean track records
+- **Two-ecosystem split:** ~44/56 across Morpho and Spark Lend — both blue-chip USDT venues with multi-year clean track records
 - **No USDS-peg exposure:** yvUSDT-1 holds USDT, not USDS, so it is not exposed to USDS peg risk that affects yvUSDC-1 / yvUSDS-1 / yvDAI-1
 - **Active monitoring** via Yearn's monitoring-scripts repo
 - **No leverage. No cross-chain. No conversion hops** in the active strategies
-- **Established track record:** ~21.6 months in production, ~8.07% cumulative return, zero incidents
+- **Established track record:** ~23.6 months in production, ~8.62% cumulative return, zero incidents
 
 ### Key Risks
 
-- **Concentration in two venues only:** ~46% Spark + ~54% Morpho/Gauntlet. The pre-deallocation 5-strategy queue offered better venue diversification; the post-redeployment 3-strategy queue (with one unfunded) is materially more concentrated
-- **Sky-governance dependency on ~46% of debt:** Spark Lend is a Sky sub-DAO, so Sky governance / Spark admin keys can affect close to half of yvUSDT-1's funds. Less coupled than the USDS-denominated vaults but **not Sky-independent** as the prior report claimed
-- **Operational signal:** the late-April deallocation followed by the May 5 redeployment with two strategies revoked is a meaningful operational footprint. Per Yearn team this was rsETH-precautionary (see [hgETH report](./kerneldao-hgeth.md)) but specific attribution has not been independently verified
+- **Concentration in two venues only:** ~44% Morpho (MetaMorpho) + ~56% Spark Lender. Less diversified than the prior 5-strategy queue
+- **Sky-governance dependency on ~56% of debt:** Spark Lend is a Sky sub-DAO, so Sky governance / Spark admin keys can affect over half of yvUSDT-1's funds. This is an increase from ~46% in the May 2026 snapshot. Less coupled than the USDS-denominated vaults but **not Sky-independent**
+- **MetaMorpho governance surface:** the ymv-USDT MetaMorpho vault introduces an additional governance layer — Yearn Security (4-of-7) as owner, a 2-of-3 curator Safe (overlapping Brain/Security signers), Daddy (6-of-9) as guardian, and a 3-day timelock. While internal to Yearn, this adds parameters that can affect ~44% of funds
+- **Full strategy-queue replacement:** all five previously-queued strategies were revoked and replaced by two new ones between May and July 2026. The rationale for the full replacement rather than incremental changes has not been independently verified
 - **USDT-specific:** centrally-issued stablecoin with periodic concerns about Tether's reserve composition; this risk is inherent to the underlying asset and not specific to yvUSDT-1
-- **Strategy revocation rationale unverified:** USDT Fluid Lender and Aave V3 USDT Lender — both blue-chip — were revoked entirely. The rationale (rsETH-related vs strategy-specific issue vs APR optimization) is not independently verifiable on-chain
 
 ### Critical Risks
 
@@ -342,7 +345,7 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 - Use decimals when a subcategory falls between scores
 - Prioritize on-chain evidence over documentation claims
 - **Rounding rule:** the weighted sum is rounded to one decimal place using standard nearest-0.1 rounding; when the value is exactly halfway between two 0.1 marks (X.X50), round UP to the higher (riskier) score per the conservative principle
-- **Score reflects May 11 snapshot — 100% deployed across Spark + Morpho (~46/54).**
+- **Score reflects July 13 snapshot — 100% deployed across MetaMorpho (Morpho) + Spark (~44/56).**
 
 ### Critical Risk Gates
 
@@ -360,12 +363,12 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 |--------|-----------|
 | Audits | V3 framework: 3 audits by top firms. Active underlying protocols (Spark, Morpho): blue-chip with extensive audit coverage |
 | Bug bounty | $200K (Yearn Immunefi) |
-| Production history | **~21.6 months** (July 23, 2024). V3 framework: ~24 months |
-| TVL | **$7.30M** USDT (100% deployed). Deposit limit: 50M |
+| Production history | **~23.6 months** (July 23, 2024). V3 framework: ~26 months |
+| TVL | **$7.23M** USDT (100% deployed). Deposit limit: 50M |
 | Security incidents | None on V3, none on the active underlying protocols |
 | Strategy review | Rigorous 12-metric framework with ySec security review |
 
-**Score: 1.5 / 5** — strong audit coverage, ~21.6 months clean production, no incidents.
+**Score: 1.5 / 5** — strong audit coverage, ~23.6 months clean production, no incidents.
 
 #### Category 2: Centralization & Control Risks (Weight: 30%)
 
@@ -373,7 +376,7 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 
 | Factor | Assessment |
 |--------|-----------|
-| Upgradeability | V3 vault is **immutable** |
+| Upgradeability | V3 vault is **immutable** (EIP-1167 minimal proxy) |
 | Multisig | 6-of-9 ySafe with **publicly named, prominent DeFi signers** |
 | Timelock | 7-day delay on `ADD_STRATEGY` and `ACCOUNTANT`. Self-governed |
 | Privileged roles | Well-distributed; no role concentration |
@@ -396,12 +399,12 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 
 | Factor | Assessment |
 |--------|-----------|
-| Protocol count (active) | 2 funded ecosystems (Spark Lend, Morpho Gauntlet); 1 additional queued (Morpho Steakhouse) |
-| Criticality | USDT (Tether) + Spark Lend (~46%, Sky-governed) + Morpho/Gauntlet (~54%) |
-| Concentration | ~46% behind Sky-governed infrastructure (Spark) — meaningful Sky-governance dependency, but no USDS-peg dependency |
+| Protocol count (active) | 2 funded ecosystems (Morpho via MetaMorpho vault, Spark Lend); no queued strategies |
+| Criticality | USDT (Tether) + MetaMorpho/Morpho (~44%) + Spark Lend (~56%, Sky-governed) |
+| Concentration | ~56% behind Sky-governed infrastructure (Spark) — meaningful Sky-governance dependency, increased from ~46% in May 2026. The Morpho leg is through a Yearn-operated MetaMorpho vault with its own governance surface |
 | Quality | Top-tier on both venues; concentration is the main concern |
 
-**Dependencies Score: 2.5 / 5** — two blue-chip ecosystems (Spark Lend, Morpho/Gauntlet), but ~46% of debt sits behind Sky-governance infrastructure (Spark Lend → Sky sub-DAO → Sky governance). The rubric "1–2 blue-chip dependencies" = 2 captures the count; the +0.5 reflects that the Sky-governance share is a single-point-of-control concentration above what a pure two-blue-chip split would carry. The Morpho leg is governed by Morpho DAO + Gauntlet curator, which is independent of Sky.
+**Dependencies Score: 2.5 / 5** — two blue-chip ecosystems (Morpho, Spark Lend), but ~56% of debt sits behind Sky-governance infrastructure (Spark Lend → Sky sub-DAO → Sky governance) and the Morpho leg introduces MetaMorpho governance surface (owner, curator, guardian, timelock). The rubric "1–2 blue-chip dependencies" = 2 captures the count; the +0.5 reflects that the Sky-governance share is a single-point-of-control concentration above what a pure two-blue-chip split would carry. The Morpho leg is governed by Yearn Security + curator Safe + guardian, independent of Sky.
 
 **Centralization Score = (1.0 + 1.0 + 2.5) / 3 ≈ 1.5**
 
@@ -413,7 +416,7 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 
 | Factor | Assessment |
 |--------|-----------|
-| Backing | 100% USDT (held via Spark Lend and Morpho Gauntlet positions) |
+| Backing | 100% USDT (held via MetaMorpho vault on Morpho and Spark Lend USDT positions) |
 | Collateral quality | USDT is the largest stablecoin by market cap; centrally issued by Tether |
 | Leverage | None |
 | Verifiability | Vault and strategy positions fully on-chain |
@@ -439,13 +442,13 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 
 | Factor | Assessment |
 |--------|-----------|
-| Exit mechanism | ERC-4626 → strategy unwind through Spark and Morpho USDT markets |
-| Liquidity depth | Both venues have multi-million-USDT free liquidity; ~$3.3M (Spark) and ~$4.0M (Morpho) are small relative to either market |
-| Large holder impact | Very large redemptions depend on Spark / Morpho utilization at withdraw time |
+| Exit mechanism | ERC-4626 → strategy unwind through MetaMorpho vault and Spark USDT market |
+| Liquidity depth | Both venues have multi-million-USDT free liquidity; ~$3.2M (MetaMorpho) and ~$4.1M (Spark) are small relative to either market |
+| Large holder impact | Very large redemptions depend on MetaMorpho vault / Spark utilization at withdraw time |
 | Same-value asset | USDT-denominated |
 | Withdrawal restrictions | None |
 
-**Score: 1.0 / 5** — both active venues are deep blue-chip USDT lending markets with healthy utilization headroom. The ~46/54 split provides cross-venue resilience. Re-evaluate if either venue's utilization spikes or if allocation drifts beyond ~75% to a single venue.
+**Score: 1.0 / 5** — both active venues are deep blue-chip USDT lending markets with healthy utilization headroom. The ~44/56 split provides cross-venue resilience. Re-evaluate if either venue's utilization spikes or if allocation drifts beyond ~75% to a single venue.
 
 #### Category 5: Operational Risk (Weight: 5%)
 
@@ -455,10 +458,10 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 | Vault management | Standard pattern across 37+ vaults |
 | Documentation | Comprehensive, code verified on Etherscan |
 | Legal | BORG (Cayman foundation) |
-| Incident response | 4 historical V1 events, $200K Immunefi. **Demonstrated again here** — Brain / Debt Allocator pulled all debt and re-deployed within ~8 days, revoking Fluid USDT and Aave V3 USDT in the process (per Yearn team rsETH-precautionary, unverified attribution) |
+| Incident response | 4 historical V1 events, $200K Immunefi. Demonstrated active debt management — the Brain/Debt Allocator pulled all debt, revoked five strategies across two phases, and redeployed into a new two-strategy configuration (Yearn-operated MetaMorpho vault + new Spark USDT Lender) between April and July 2026 |
 | Monitoring | Active hourly alerts, vault in monitored list |
 
-**Score: 1.0 / 5** — top-tier operational maturity. The deallocate / redeploy / revoke sequence demonstrates incident-response capability, though the rationale for the specific revocations has not been independently verified.
+**Score: 1.0 / 5** — top-tier operational maturity. The deallocate / redeploy / full-strategy-replacement sequence demonstrates incident-response and debt-management capability.
 
 ### Final Score Calculation
 
@@ -489,14 +492,14 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 
 ## Reassessment Triggers
 
-- **Time-based:** Reassess in 6 months (November 2026) or annually
+- **Time-based:** Reassess in 6 months (January 2027) or annually
 - **TVL-based:** Reassess if TVL exceeds $25M or changes by ±50%
 - **rsETH-related context:** if any new strategy is added that takes direct or indirect rsETH exposure, full re-review of the dependency subscore
 - **Strategy posture:**
-  - **if a USDS-denominated strategy is later added** to yvUSDT-1, the partial Sky-coupling becomes a peg dependency — re-evaluate dependency and concentration scores against the broader risk-1 stable stack
+  - if a USDS-denominated strategy is later added to yvUSDT-1, the partial Sky-coupling becomes a peg dependency — re-evaluate dependency and concentration scores against the broader risk-1 stable stack
   - if either venue's allocation drifts above ~75% of deployed funds, re-evaluate the dependency / liquidity scores
-  - if Morpho Steakhouse USDT is funded (currently queued at 0), re-check the per-venue concentration
-  - if any further strategy revocations occur, investigate the rationale
+  - the MetaMorpho vault's governance parameters (owner, curator, guardian, timelock) are new; any change to these should trigger reassessment
+  - if any further strategy revocations or replacements occur, investigate the rationale
 - **Underlying-protocol incidents:** any major incident at Spark Lend or Morpho USDT markets — full re-review
 - **USDT-specific:**
   - sustained Tether peg deviation
@@ -515,32 +518,40 @@ Yearn maintains the [`monitoring`](https://github.com/yearn/monitoring) reposito
 │  ┌───────────────────────┐                                          │
 │  │  yvUSDT-1 (v3.0.2)   │                                          │
 │  │  ERC-4626, immutable  │                                          │
+│  │  EIP-1167 min proxy   │                                          │
 │  │  0x310B…FAaa          │                                          │
 │  │                       │                                          │
-│  │  $7.30M USDT TVL      │                                          │
-│  │  100% deployed        │                                          │
-│  │  totalDebt = $7.30M   │                                          │
+│  │  $7.23M USDT TVL      │                                          │
+│  │  ~99.99% deployed     │                                          │
+│  │  totalDebt = $7.23M   │                                          │
 │  │  totalIdle = 0        │                                          │
 │  └───────────┬───────────┘                                          │
 │              │                                                       │
 │      ┌───────┴────────┐                                             │
 │      ▼                ▼                                             │
-│  Spark USDT       Morpho Gauntlet                                   │
-│  3.33M (45.58%)   3.97M (54.42%)                                    │
-│  Sky sub-DAO      Morpho protocol                                   │
+│  MetaMorpho Vault  Spark USDT Lender                                │
+│  (ymv-USDT)        4.05M (56.06%)                                   │
+│  3.18M (43.94%)    Sky sub-DAO                                      │
+│  Morpho protocol                                                     │
 │                                                                      │
-│  Also queued (unfunded): Morpho Steakhouse USDT (0 debt)            │
+│  MetaMorpho governance:                                              │
+│   - Owner: Yearn Security (4-of-7)                                  │
+│   - Curator: 2-of-3 Safe                                            │
+│   - Guardian: Daddy (6-of-9)                                        │
+│   - Timelock: 3 days                                                │
 │                                                                      │
-│  Revoked between Apr 27 and May 5 (`activation = 0`):               │
+│  All previously-queued strategies revoked (activation = 0):          │
+│   - Spark USDT Lender (old, 0xED48…9400B)                           │
+│   - Morpho Gauntlet USDT Prime (0x6D29…849F)                        │
+│   - Morpho Steakhouse USDT (0x0a4e…45c5)                            │
 │   - USDT Fluid Lender (0x4Bd0…8A72)                                 │
 │   - Aave V3 USDT Lender (0x2799…8Cb2)                               │
 └──────────────────────────────────────────────────────────────────────┘
 
-The vault is now ~46/54 across two ecosystems. ~46% sits behind Sky-governed
-infrastructure (Spark Lend), so yvUSDT-1 is materially less Sky-coupled
-than the USDS-denominated risk-1 vaults but **not Sky-independent**. The
-prior 5-strategy queue offered better venue diversification. Allocation
-has drifted slightly toward Morpho between May 5 and May 11.
+The vault is now ~44/56 across two ecosystems. ~56% sits behind Sky-governed
+infrastructure (Spark Lend), up from ~46% in May 2026. The Morpho leg is through
+a Yearn-operated MetaMorpho vault with its own governance surface (owner,
+curator, guardian, timelock) rather than a third-party curated vault.
 ```
 
 ## Appendix: TimelockController Role Structure
@@ -558,3 +569,10 @@ TimelockController [`0x88Ba032be87d5EF1fbE87336b7090767F367BF73`](https://ethers
 | **CANCELLER** | Brain | 3-of-8 Safe | Cancel pending proposals |
 
 To shorten the delay, Daddy 6/9 must propose `updateDelay()`, wait 7 days during which Brain or Daddy can cancel, then execute. DEFAULT_ADMIN was never granted, so no party can self-grant PROPOSER or TIMELOCK_ADMIN to skip the flow.
+
+## Assessment History
+
+| Date | Score | Notes |
+|------|-------|-------|
+| May 11, 2026 | 1.3 | Initial assessment; ~46/54 Spark/Morpho Gauntlet split |
+| July 13, 2026 | 1.3 | Strategy-queue replacement: MetaMorpho vault + new Spark USDT Lender; ~44/56 split; Sky dependency increased to ~56% |

--- a/reports/report/yearn-yvusdt.md
+++ b/reports/report/yearn-yvusdt.md
@@ -128,7 +128,7 @@ All strategies pass through Yearn's **12-metric risk-scoring framework** ([RISK_
 
 - **Yearn (Immunefi):** active, **$200,000** max payout (Critical). https://immunefi.com/bounty/yearnfinance/
 - **Yearn (Sherlock):** also listed at https://audits.sherlock.xyz/bug-bounties/30
-- Underlying protocols (Spark, Morpho) both have active bug bounty programs
+- **Morpho (Cantina):** active, **$2,500,000** max payout (Critical). https://cantina.xyz/bounties/35a5f0a1-2ffd-432c-8f3b-77d169add8c3
 - **Safe Harbor (SEAL):** Yearn is **not** listed on the SEAL Safe Harbor registry
 
 ### On-Chain Complexity


### PR DESCRIPTION
## Reassessment: yearn-yvusdt (#308)

### Summary
Refreshed the yearn-yvusdt risk report for July 13, 2026.

### Changes
- **TVL**: $7.30M → $7.23M (DefiLlama)
- **PPS**: 1.080708 → 1.086177
- **Strategy queue**: All 5 old strategies revoked; 2 new active (MetaMorpho ymv-USDT, Spark USDT Lender)
- **Morpho exposure**: Changed from third-party curated (Gauntlet, Steakhouse) to Yearn-operated MetaMorpho vault
- **Sky-governance share**: ~46% → ~56% of debt
- **Dependency graph**: Regenerated to reflect new strategy topology

### Unchanged
- All privileged roles, proxy implementations, timelock, governance multisigs
- Score remains **1.3/5.0 (Minimal Risk)**

### Validation
- On-chain verification via `cast` with RPC from `.env`
- Etherscan for contract verification
- DefiLlama for TVL

Closes #308