### PR TITLE
fix(saturn-usdat): correct final score arithmetic (2.825, not 2.875)

### DIFF
--- a/reports/report/saturn-usdat.md
+++ b/reports/report/saturn-usdat.md
@@ -4,7 +4,7 @@
 - **Token:** USDat (Saturn USD)
 - **Chain:** Ethereum
 - **Token Address:** [`0x23238f20b894f29041f48D88eE91131C395Aaa71`](https://etherscan.io/address/0x23238f20b894f29041f48D88eE91131C395Aaa71)
-- **Final Score: 2.875/5.0**
+- **Final Score: 2.825/5.0**
 
 > Assessment requested in [yearn/risk-score#135](https://github.com/yearn/risk-score/issues/135) — *"USDat as collateral"*. This report assesses **USDat**, the non-yielding stablecoin. The staked, yield-bearing **sUSDat** ([`0xD166337499E176bbC38a1FBd113Ab144e5bd2Df7`](https://etherscan.io/address/0xD166337499E176bbC38a1FBd113Ab144e5bd2Df7)) carries materially different (STRC credit) risk and is discussed only as context.
 
@@ -331,7 +331,7 @@ YIELD LAYER (context only — not USDat backing)
 | Funds Management | 2.5 | 30% | 0.75 |
 | Liquidity Risk | 3.0 | 15% | 0.45 |
 | Operational Risk | 2.5 | 5% | 0.125 |
-| **Final Score** | | | **2.875 ≈ 2.9 / 5.0** |
+| **Final Score** | | | **2.825 ≈ 2.8 / 5.0** |
 
 **Optional Modifiers:** none apply (protocol <2 years, TVL history <1 year).
 
@@ -345,7 +345,7 @@ YIELD LAYER (context only — not USDat backing)
 | 3.5-4.5 | Elevated Risk | Limited approval, strict limits |
 | 4.5-5.0 | High Risk | Not recommended |
 
-**Final Risk Tier: MEDIUM RISK (2.9/5.0) — Approved with enhanced monitoring**
+**Final Risk Tier: MEDIUM RISK (2.8/5.0) — Approved with enhanced monitoring**
 
 ---
 


### PR DESCRIPTION
## Problem

The final score in `reports/report/saturn-usdat.md` is arithmetically wrong. The weighted rows in the final table sum to **2.825**:

| Category | Weighted |
|---|---|
| Audits & Historical (3.25 × 20%) | 0.65 |
| Centralization & Control (2.83 × 30%) | 0.85 |
| Funds Management (2.5 × 30%) | 0.75 |
| Liquidity Risk (3.0 × 15%) | 0.45 |
| Operational Risk (2.5 × 5%) | 0.125 |
| **Sum** | **2.825** |

The body also scores Centralization at 2.8/2.83 (L300-302), so 2.825 is the internally consistent total. But the final table (L334), the header (L7), and the tier line (L348) all stated **2.875 ≈ 2.9**.

## Fix

Correct all three occurrences to **2.825 ≈ 2.8**. The risk tier is unchanged — 2.8 remains in the 2.5-3.5 Medium band.