### PR TITLE
fix(paxos-usdg): correct chain count and supply shares in Overview

### DIFF
--- a/reports/report/paxos-usdg.md
+++ b/reports/report/paxos-usdg.md
@@ -14,7 +14,7 @@ USDG's differentiating feature is its **distribution partner model** — ecosyst
 
 Reserves consist of **cash and cash equivalents** (primarily short-duration U.S. Treasury Bills) held in **segregated accounts** at regulated custodians, with **monthly attestation reports** from independent accounting firms published on the Paxos transparency portal.
 
-USDG is deployed on **4 chains**: Ethereum, Solana (52.3% of supply), X Layer (19.5%), and Ink (6.2%). Cross-chain bridging between Ethereum and Solana is handled via **LayerZero V2 OFT**.
+USDG is deployed on **5 chains**: X Layer (58.8% of supply), Solana (24.1%), Ethereum (15.7%), Ink (1.3%), and Hyperliquid L1 (0.1%). Cross-chain bridging between Ethereum and Solana is handled via **LayerZero V2 OFT**.
 
 **Key metrics (June 26, 2026):**
 


### PR DESCRIPTION
## Problem

The Overview of `reports/report/paxos-usdg.md` (L17) stated USDG is deployed on **4 chains** with supply shares Solana 52.3%, X Layer 19.5%, Ink 6.2% — contradicting the report's own Multi-Chain Deployments table (L73-80, June 26, 2026 DeFiLlama figures) and L132 ("across 5 chains").

The body table is internally consistent (supplies sum to the stated $2,894.2M total; shares sum to 100%):

| Chain | Supply | Share |
|---|---:|---:|
| X Layer | $1,702.3M | 58.8% |
| Solana | $697.2M | 24.1% |
| Ethereum | $455.4M | 15.7% |
| Ink | $37.7M | 1.3% |
| Hyperliquid L1 | $1.6M | 0.1% |

## Fix

Rewrite the Overview sentence to match the table: **5 chains** — X Layer 58.8%, Solana 24.1%, Ethereum 15.7%, Ink 1.3%, Hyperliquid L1 0.1%.