### PR TITLE
fix(kinetiq-khype): correct risk tier label (2.3 is Low, not Medium)

### DIFF
--- a/reports/report/kinetiq-khype.md
+++ b/reports/report/kinetiq-khype.md
@@ -482,7 +482,7 @@ Funds management score = (2.0 + 1.5) / 2 = **1.75**
 
 ## Overall Risk Score: **2.3 / 5.0**
 
-### Risk Tier: **MEDIUM RISK**
+### Risk Tier: **LOW RISK**
 
 Rationale:
 - kHYPE is a well-audited LST with significant TVL ($932M, up ~36% over the last quarter) and deep DeFi integration.


### PR DESCRIPTION
## Problem

`reports/report/kinetiq-khype.md` concludes with:

```
## Overall Risk Score: **2.3 / 5.0**
### Risk Tier: **MEDIUM RISK**
```

But the house tier bands used across this repo (e.g. `maple-syrupusdc.md`, `kerneldao-hgeth.md`) put **1.5-2.5 in Low Risk** and 2.5-3.5 in Medium. A score of 2.3 is Low Risk — the label contradicts the band.

## Fix

Relabel the tier to **LOW RISK**. Verified no other text in the report depends on the tier label (no band table, no "enhanced monitoring" recommendation tied to Medium).