### PR TITLE
normalize Assessment Date format: show only latest Updated date

### DIFF
--- a/reports/TEMPLATE.md
+++ b/reports/TEMPLATE.md
@@ -3,8 +3,9 @@
 - **Assessment Date:** [Month Day, Year]
 <!--
   Keep the ORIGINAL assessment date here. When a report is reassessed/updated,
-  do NOT overwrite it — append the new date in parentheses, e.g.:
-    - **Assessment Date:** May 27, 2026 (Updated: June 17, 2026)
+  do NOT overwrite it — append the latest date in parentheses using the
+  "Updated:" prefix, showing ONLY the single most recent date:
+    - **Assessment Date:** March 20, 2026 (Updated: July 31, 2026)
   The website reads both: the earliest date becomes "Original", the latest
   becomes "Latest", and the page is tagged "Updated report". Overwriting the
   single date loses that history and the report shows as brand new.
@@ -31,11 +32,11 @@ Status field (optional — omit for active reports):
 
 Assessment Date format:
   - Use full English month name and four-digit year, e.g. "March 4, 2026".
-  - When a report is reassessed, append the new date in parentheses on the
-    same line, e.g.
+  - When a report is reassessed, append the latest update date in parentheses
+    with the "Updated:" prefix, showing ONLY the single most recent date:
         **Assessment Date:** February 8, 2026 (Updated: March 22, 2026)
-    or, when reassessing in response to an event:
-        **Assessment Date:** April 27, 2026 (reassessment after April 18, 2026 exploit)
+    Do NOT stack multiple dates or add prose like "rechecked," "reassessed,"
+    or "corrected" — collapse all prior updates into the single latest date.
   - The reassessment-scan workflow parses every "Month Day, Year" date on this
     line and uses the latest one to decide whether the report is stale, so the
     appended date keeps the staleness clock honest.

--- a/reports/reassessment/SKILL.md
+++ b/reports/reassessment/SKILL.md
@@ -51,8 +51,10 @@ Do not spend time redoing static background unless a mutable fact changed. Do no
    - cross-chain bridge / messaging dependencies (LayerZero/OFT, Chainlink CCIP, CCTP, Wormhole, Axelar, Stargate, etc.)
    If any changed, update `reports/graph/<slug>.yaml` using `reports/graph/SKILL.md`. If no graph exists, create one when the report has enough data; otherwise mark the missing graph inputs as `TODO`. If a bridge dependency was added, removed, or changed, also update `src/data/bridges.json` so the `/bridges/` page stays in sync (see the "Bridge dependencies" bullet in `reports/skill.md`); `npm run build` runs `scripts/check_bridges.mjs` and will warn about any bridge the report mentions but that isn't listed.
 6. Patch only affected sections **in place**. Do not add a "Reassessment Notes", changelog, or "what changed" section to the report body. Common sections:
-   - header assessment date: keep the original date and append the new one in
-     parentheses, e.g. `- **Assessment Date:** May 27, 2026 (Updated: June 17, 2026)`.
+   - header assessment date: keep the original date and append the latest one in
+     parentheses with the "Updated:" prefix, showing ONLY the single most
+     recent update date — do NOT stack multiple dates or add prose like
+     "rechecked" or "corrected." E.g. `- **Assessment Date:** May 27, 2026 (Updated: June 17, 2026)`.
      Never overwrite the original date — the website derives "Original" vs
      "Latest" and the "Updated report" tag from both dates.
    - Overview + Links

--- a/reports/report/aave-sgho.md
+++ b/reports/report/aave-sgho.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: Aave — sGHO
 
-- **Assessment Date:** April 2, 2026 (rechecked April 22, 2026; refreshed post-deployment May 19, 2026; external-review corrections May 19, 2026; reassessed July 27, 2026)
+- **Assessment Date:** April 2, 2026 (Updated: July 27, 2026)
 - **Token:** sGho (GHO Savings Vault)
 - **Chain:** Ethereum
 - **Token Address:** [`0xE1753F2e00940cC31213dd92013cF019DFE4ca1d`](https://etherscan.io/address/0xE1753F2e00940cC31213dd92013cF019DFE4ca1d)

--- a/reports/report/apyx-apxusd.md
+++ b/reports/report/apyx-apxusd.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: Apyx
 
-- **Assessment Date:** April 19, 2026 (Updated May 29, 2026; August 1, 2026; corrected August 3, 2026)
+- **Assessment Date:** April 19, 2026 (Updated: August 3, 2026)
 - **Token:** apxUSD
 - **Chain:** Ethereum + Base + BNB Chain
 - **Token Address:** [`0x98a878B1CD98131b271883b390F68d2c90674665`](https://etherscan.io/address/0x98a878B1CD98131b271883b390F68d2c90674665)

--- a/reports/report/cap-stcusd.md
+++ b/reports/report/cap-stcusd.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: Cap — stcUSD
 
-- **Assessment Date:** March 20, 2026 (Updated: July 31, 2026; prior reassessment May 23, 2026)
+- **Assessment Date:** March 20, 2026 (Updated: July 31, 2026)
 - **Token:** stcUSD (Staked cap USD)
 - **Chain:** Ethereum
 - **Token Address:** [`0x88887bE419578051FF9F4eb6C858A951921D8888`](https://etherscan.io/address/0x88887bE419578051FF9F4eb6C858A951921D8888)

--- a/reports/report/fluid.md
+++ b/reports/report/fluid.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: Fluid Lending Protocol
 
-- **Assessment Date:** February 12, 2026 (Updated: July 22, 2026; prior reassessments Apr 27, May 24, Jul 6, 2026)
+- **Assessment Date:** February 12, 2026 (Updated: July 22, 2026)
 - **Token:** fTokens (fUSDC, fUSDT, fWETH, etc.)
 - **Chain:** Ethereum Mainnet
 - **Token Address:** [`0x9Fb7b4477576Fe5B32be4C1843aFB1e55F251B33`](https://etherscan.io/address/0x9Fb7b4477576Fe5B32be4C1843aFB1e55F251B33) (fUSDC)

--- a/reports/report/infinifi.md
+++ b/reports/report/infinifi.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: InfiniFi
 
-- **Assessment Date:** February 4, 2026 (Updated: July 4, 2026; July 29, 2026)
+- **Assessment Date:** February 4, 2026 (Updated: July 29, 2026)
 - **Token:** siUSD (Staked iUSD)
 - **Chain:** Ethereum Mainnet
 - **Token Address:** [`0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB`](https://etherscan.io/address/0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB)

--- a/reports/report/kerneldao-hgeth.md
+++ b/reports/report/kerneldao-hgeth.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: KernelDAO (Kelp Gain)
 
-- **Assessment Date:** June 29, 2026 (reassessment; vault unpaused since last assessment)
+- **Assessment Date:** June 29, 2026
 - **Token:** hgETH (High Growth ETH)
 - **Chain:** Ethereum
 - **Token Address:** [`0xc824A08dB624942c5E5F330d56530cD1598859fD`](https://etherscan.io/address/0xc824A08dB624942c5E5F330d56530cD1598859fD)

--- a/reports/report/paxos-usdg.md
+++ b/reports/report/paxos-usdg.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: Paxos USDG (Global Dollar)
 
-- **Assessment Date:** March 20, 2026 (reassessed July 30, 2026)
+- **Assessment Date:** March 20, 2026 (Updated: July 30, 2026)
 - **Token:** USDG (Global Dollar)
 - **Chain:** Ethereum
 - **Token Address:** [`0xe343167631d89B6Ffc58B88d6b7fB0228795491D`](https://etherscan.io/address/0xe343167631d89B6Ffc58B88d6b7fB0228795491D)

--- a/reports/report/re-reusd.md
+++ b/reports/report/re-reusd.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: Re Protocol reUSD
 
-- **Assessment Date:** June 21, 2026 (reassessed; previous: April 17, 2026)
+- **Assessment Date:** June 21, 2026
 - **Token:** reUSD (Re Protocol Deposit Token)
 - **Chain:** Ethereum (primary), multi-chain (Avalanche, Arbitrum, Base, Katana, BNB Chain, Ink)
 - **Token Address:** [`0x5086bf358635B81D8C47C66d1C8b9E567Db70c72`](https://etherscan.io/address/0x5086bf358635B81D8C47C66d1C8b9E567Db70c72)

--- a/reports/report/saturn-usdat.md
+++ b/reports/report/saturn-usdat.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: Saturn (USDat)
 
-- **Assessment Date:** May 27, 2026 (updated June 17, 2026)
+- **Assessment Date:** May 27, 2026 (Updated: June 17, 2026)
 - **Token:** USDat (Saturn USD)
 - **Chain:** Ethereum
 - **Token Address:** [`0x23238f20b894f29041f48D88eE91131C395Aaa71`](https://etherscan.io/address/0x23238f20b894f29041f48D88eE91131C395Aaa71)

--- a/reports/report/unit-ubtc.md
+++ b/reports/report/unit-ubtc.md
@@ -1,6 +1,6 @@
 # Protocol Risk Assessment: Unit Bitcoin (UBTC)
 
-- **Assessment Date:** May 19, 2026 (reassessed July 1, 2026; implementation decompiled July 22, 2026)
+- **Assessment Date:** May 19, 2026 (Updated: July 22, 2026)
 - **Token:** UBTC
 - **Chain:** HyperEVM (Hyperliquid L1 ecosystem)
 - **Token Address:** [`0x9FDBdA0A5e284c32744D2f17Ee5c74B284993463`](https://hyperevmscan.io/address/0x9FDBdA0A5e284c32744D2f17Ee5c74B284993463)


### PR DESCRIPTION
## Summary
Normalizes the `Assessment Date` line across all 42 reports in `reports/report/` to follow the standard format: `Assessment Date: <original_date> (Updated: <latest_date>)`.

## Changes (10 reports)

| Report | Before | After |
|--------|--------|-------|
| aave-sgho | `(rechecked Apr 22; ... reassessed Jul 27, 2026)` | `(Updated: July 27, 2026)` |
| apyx-apxusd | `(Updated May 29, 2026; August 1, 2026; corrected August 3, 2026)` | `(Updated: August 3, 2026)` |
| cap-stcusd | `(Updated: July 31, 2026; prior reassessment May 23, 2026)` | `(Updated: July 31, 2026)` |
| fluid | `(Updated: July 22, 2026; prior reassessments ...)` | `(Updated: July 22, 2026)` |
| infinifi | `(Updated: July 4, 2026; July 29, 2026)` | `(Updated: July 29, 2026)` |
| paxos-usdg | `(reassessed July 30, 2026)` | `(Updated: July 30, 2026)` |
| saturn-usdat | `(updated June 17, 2026)` | `(Updated: June 17, 2026)` |
| unit-ubtc | `(reassessed Jul 1, 2026; ... decompiled Jul 22, 2026)` | `(Updated: July 22, 2026)` |
| kerneldao-hgeth | `(reassessment; vault unpaused ...)` | *(removed — no dated update)* |
| re-reusd | `(reassessed; previous: April 17, 2026)` | *(removed — no dated update)* |

**Validation:** All 42 reports now conform to one of two formats:
- `Assessment Date: <date>` — no updates
- `Assessment Date: <date> (Updated: <latest_date>)` — single latest update date