### PR TITLE
Shared contracts: cross-assessment exposure and coverage gaps

### DIFF
--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -234,6 +234,130 @@ export interface GraphSummary {
   referencedBy: string[];
 }
 
+/** A contract that appears in more than one assessment's graph. */
+export interface SharedContract {
+  /** `<chain>:<address-lowercased>` — the identity used for matching. */
+  key: string;
+  address: string;
+  chain: string;
+  /** The most common label across the graphs that name it. */
+  label: string;
+  /** Every distinct label used, when graphs disagree on naming. */
+  aliases: string[];
+  /** Categories the contract is filed under, across graphs. */
+  categories: string[];
+  /** Assessments that include it, with the local node label. */
+  occurrences: { slug: string; nodeId: string; label: string; category: string }[];
+  /**
+   * The slug that *owns* this contract, when one of the graphs anchors it as a
+   * vault. Null means no assessment covers it in its own right.
+   */
+  assessedBy: string | null;
+  /**
+   * A graph that lists this contract as one of its *own* (any category other
+   * than `dependency`) and has a report behind it. Weaker than `assessedBy`:
+   * the assessment covers the contract, but not as its cross-link anchor, so
+   * dependency cards pointing here get no drill-down. Usually means the
+   * referencing graph should point at that graph's vault address instead.
+   */
+  ownedBy: string | null;
+  /**
+   * How to read the sharing. A contract filed as an external `dependency` by
+   * any graph is third-party surface several assessments sit on; anything else
+   * shared (multisigs, timelocks, keepers, accountants) is one protocol's own
+   * machinery reused across its vaults. Both matter, but they are different
+   * findings: the first is a coverage gap, the second is concentration.
+   */
+  kind: "external" | "internal";
+}
+
+let sharedCache: SharedContract[] | undefined;
+
+/**
+ * Contracts appearing in more than one graph.
+ *
+ * Cross-linking only fires when a dependency has its *own* report, which hides
+ * the plainest form of shared exposure: seven vault graphs all pointing at the
+ * same Morpho Blue deployment, or the same 6-of-9 multisig holding roles across
+ * seven vaults. Neither is visible when the graphs are read one at a time.
+ *
+ * Sorted by breadth (how many assessments touch the contract) so the systemic
+ * ones surface first.
+ */
+export function getSharedContracts(): SharedContract[] {
+  if (sharedCache) return sharedCache;
+  const index = getGraphIndex();
+  const byKey = new Map<string, SharedContract>();
+
+  for (const slug of getGraphSlugs()) {
+    const g = getGraphBySlug(slug);
+    if (!g) continue;
+    for (const n of g.nodes) {
+      if (!n.address) continue;
+      const chain = (n.chain ?? g.chain).toLowerCase();
+      const key = `${chain}:${n.address.toLowerCase()}`;
+      let entry = byKey.get(key);
+      if (!entry) {
+        entry = {
+          key,
+          address: n.address,
+          chain,
+          label: n.label,
+          aliases: [],
+          categories: [],
+          occurrences: [],
+          assessedBy: index.get(key)?.slug ?? null,
+          ownedBy: null,
+          kind: "internal",
+        };
+        byKey.set(key, entry);
+      }
+      entry.occurrences.push({
+        slug,
+        nodeId: n.id,
+        label: n.label,
+        category: n.category,
+      });
+      if (!entry.aliases.includes(n.label)) entry.aliases.push(n.label);
+      if (!entry.categories.includes(n.category)) entry.categories.push(n.category);
+    }
+  }
+
+  const shared = [...byKey.values()].filter((c) => {
+    const slugs = new Set(c.occurrences.map((o) => o.slug));
+    return slugs.size > 1;
+  });
+
+  for (const c of shared) {
+    c.kind = c.categories.includes("dependency") ? "external" : "internal";
+    c.ownedBy =
+      c.assessedBy ??
+      c.occurrences.find((o) => o.category !== "dependency" && getReportBySlug(o.slug))?.slug ??
+      null;
+    // Prefer the label the owning assessment uses; otherwise the most common
+    // one, so a contract named six ways still reads sensibly.
+    const owned = c.assessedBy && c.occurrences.find((o) => o.slug === c.assessedBy);
+    if (owned) {
+      c.label = owned.label;
+    } else {
+      const counts = new Map<string, number>();
+      for (const o of c.occurrences) counts.set(o.label, (counts.get(o.label) ?? 0) + 1);
+      c.label = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0][0];
+    }
+    c.occurrences.sort((a, b) => a.slug.localeCompare(b.slug));
+    c.aliases.sort();
+  }
+
+  shared.sort((a, b) => {
+    const an = new Set(a.occurrences.map((o) => o.slug)).size;
+    const bn = new Set(b.occurrences.map((o) => o.slug)).size;
+    return bn - an || a.label.localeCompare(b.label);
+  });
+
+  sharedCache = shared;
+  return shared;
+}
+
 export function getGraphSummaries(): GraphSummary[] {
   const forward = getGraphIndex();
   const reverse = getReverseGraphIndex();

--- a/src/pages/graph/index.astro
+++ b/src/pages/graph/index.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import { getGraphSummaries } from "../../lib/graph";
+import { getGraphSummaries, getSharedContracts } from "../../lib/graph";
 import { getReportBySlug } from "../../lib/reports";
 import { scoreColor, scoreTier, scoreTextColor } from "../../lib/colors";
 import { chainLabel } from "../../lib/graphStyle";
@@ -28,6 +28,14 @@ const totalNodes = summaries.reduce((n, s) => n + s.nodeCount, 0);
 const totalEdges = summaries.reduce((n, s) => n + s.edgeCount, 0);
 const linked = summaries.filter((s) => s.dependsOn.length > 0).length;
 const mostReferenced = rows[0];
+
+const sharedContracts = getSharedContracts();
+// The headline is the widest *external* dependency with no report — a coverage
+// gap. Shared internal machinery is a separate finding, covered on that page.
+const widestGap = sharedContracts.find((c) => c.kind === "external" && !c.assessedBy);
+const widestGapReach = widestGap
+  ? new Set(widestGap.occurrences.map((o) => o.slug)).size
+  : 0;
 ---
 
 <BaseLayout
@@ -56,6 +64,20 @@ const mostReferenced = rows[0];
       </div>
     )}
   </div>
+
+  {sharedContracts.length > 0 && (
+    <a class="gi-banner" href="/graph/shared/">
+      <span class="gi-banner-title">Shared contracts &rarr;</span>
+      <span class="gi-banner-body">
+        {sharedContracts.length} contracts appear in more than one assessment
+        {widestGap && widestGapReach > 1 && (
+          <>
+            {" — "}<b>{widestGap.label}</b> underlies {widestGapReach} assessments with no report of its own
+          </>
+        )}.
+      </span>
+    </a>
+  )}
 
   <div class="gi-tools">
     <input type="text" id="gi-search" placeholder="Filter by protocol or slug…" autocomplete="off" />
@@ -145,6 +167,30 @@ const mostReferenced = rows[0];
     font-size: 0.72rem;
     color: var(--text-secondary);
   }
+  .gi-banner {
+    display: block;
+    margin-top: 1rem;
+    padding: 0.7rem 0.9rem;
+    border: 1px solid rgba(110, 167, 255, 0.35);
+    border-radius: 8px;
+    text-decoration: none;
+  }
+  .gi-banner:hover {
+    border-color: rgba(110, 167, 255, 0.7);
+  }
+  .gi-banner-title {
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .gi-banner-body {
+    display: block;
+    margin-top: 0.15rem;
+    font-size: 0.76rem;
+    color: var(--text-secondary);
+  }
+
   .gi-tools {
     padding: 1rem 0 0.6rem;
   }

--- a/src/pages/graph/shared.astro
+++ b/src/pages/graph/shared.astro
@@ -1,0 +1,440 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getSharedContracts, explorerUrl, type SharedContract } from "../../lib/graph";
+import { getReportBySlug } from "../../lib/reports";
+import { scoreColor, scoreTier, scoreTextColor } from "../../lib/colors";
+import { chainLabel } from "../../lib/graphStyle";
+
+const shared = getSharedContracts();
+
+const breadth = (c: SharedContract) => new Set(c.occurrences.map((o) => o.slug)).size;
+
+const rows = shared.map((c) => ({
+  ...c,
+  breadth: breadth(c),
+  slugs: [...new Set(c.occurrences.map((o) => o.slug))].sort(),
+  report: c.assessedBy ? getReportBySlug(c.assessedBy) : undefined,
+}));
+
+// Two different findings live in this dataset. An external dependency shared
+// by several assessments and carrying no report of its own is a coverage gap.
+// Shared internal machinery — one multisig holding roles across seven vaults —
+// is concentration, and expecting it to have its own report would be wrong.
+const gaps = rows.filter((r) => r.kind === "external" && !r.ownedBy);
+const control = rows.filter((r) => r.kind === "internal");
+// External, already covered by some assessment, but not at that assessment's
+// anchor address — so the cross-link silently doesn't fire.
+const partial = rows.filter((r) => r.kind === "external" && !r.assessedBy && r.ownedBy);
+const widestGap = gaps[0];
+const widestControl = control[0];
+
+const CATEGORY_LABELS: Record<string, string> = {
+  vault: "Vault",
+  strategy: "Strategy",
+  governance: "Governance",
+  infra: "Infra",
+  dependency: "Dependency",
+};
+---
+
+<BaseLayout
+  title="Shared Contracts — Yearn Curation"
+  description="Contracts that appear in more than one risk assessment: shared dependencies, shared governance, and coverage gaps."
+  ogUrl="/graph/shared/"
+  ogImage="/og/default.png"
+>
+  <section class="sc-hero">
+    <h1>Shared Contracts</h1>
+    <p class="sc-sub">
+      Contracts that appear in more than one assessment's dependency graph. Reading
+      graphs one at a time hides this: the same lending market or the same multisig
+      can sit under a large share of the book without any single report saying so.
+      Derived at build time from the <a href="/graph/">graph corpus</a> by address.
+    </p>
+  </section>
+
+  <div class="sc-stats">
+    <div class="sc-stat"><b>{rows.length}</b><span>contracts in 2+ assessments</span></div>
+    <div class="sc-stat"><b>{gaps.length}</b><span>external dependencies with no report</span></div>
+    {widestGap && (
+      <div class="sc-stat sc-stat-wide">
+        <b>{widestGap.breadth}&times;</b><span>{widestGap.label} — widest coverage gap</span>
+      </div>
+    )}
+    {widestControl && (
+      <div class="sc-stat sc-stat-wide">
+        <b>{widestControl.breadth}&times;</b><span>{widestControl.label} — widest shared control</span>
+      </div>
+    )}
+  </div>
+
+  <div class="sc-tools">
+    <input type="text" id="sc-search" placeholder="Filter by contract, address or assessment…" autocomplete="off" />
+    <div class="sc-seg" role="group" aria-label="Filter by kind">
+      <button type="button" class="sc-seg-btn is-on" data-filter="all" aria-pressed="true">All</button>
+      <button type="button" class="sc-seg-btn" data-filter="gap" aria-pressed="false"
+        >Coverage gaps <span class="sc-seg-n">{gaps.length}</span></button
+      >
+      <button type="button" class="sc-seg-btn" data-filter="control" aria-pressed="false"
+        >Shared control <span class="sc-seg-n">{control.length}</span></button
+      >
+      {partial.length > 0 && (
+        <button type="button" class="sc-seg-btn" data-filter="partial" aria-pressed="false"
+          >Missed links <span class="sc-seg-n">{partial.length}</span></button
+        >
+      )}
+    </div>
+  </div>
+
+  <p class="sc-note" id="sc-note" data-mode="all">
+    Everything shared across assessments, widest reach first.
+  </p>
+
+  <ul class="sc-list" id="sc-list">
+    {rows.map((r) => (
+      <li
+        class="sc-row"
+        data-search={`${r.label} ${r.aliases.join(" ")} ${r.address} ${r.slugs.join(" ")}`.toLowerCase()}
+        data-kind={
+          r.kind === "internal"
+            ? "control"
+            : r.assessedBy
+              ? "assessed"
+              : r.ownedBy
+                ? "partial"
+                : "gap"
+        }
+      >
+        <div class="sc-head">
+          <span class="sc-count" title={`Appears in ${r.breadth} assessments`}>{r.breadth}&times;</span>
+          <div class="sc-id">
+            <span class="sc-label">{r.label}</span>
+            <span class="sc-meta">
+              <a href={explorerUrl(r.address, r.chain)} target="_blank" rel="noopener noreferrer"
+                >{r.address.slice(0, 10)}…{r.address.slice(-6)} &#8599;</a
+              >
+              <span class="sc-chain">{chainLabel(r.chain)}</span>
+              {r.categories.map((c) => (
+                <span class={`sc-cat cat-${c}`}>{CATEGORY_LABELS[c] ?? c}</span>
+              ))}
+            </span>
+          </div>
+          {r.assessedBy && r.report?.finalScore != null ? (
+            <a
+              class="sc-assessed"
+              href={`/graph/${r.assessedBy}/`}
+              style={`--c:${scoreColor(r.report.finalScore)}`}
+            >
+              <span
+                class="sc-score"
+                style={`background:${scoreColor(r.report.finalScore)};color:${scoreTextColor(r.report.finalScore)}`}
+                >{r.report.finalScore.toFixed(1)}</span
+              >
+              <span>{scoreTier(r.report.finalScore)}</span>
+            </a>
+          ) : r.kind === "internal" ? (
+            <span class="sc-internal" title="One protocol's own machinery, reused across its vaults — shared control rather than a coverage gap">
+              Shared control
+            </span>
+          ) : r.ownedBy ? (
+            <a
+              class="sc-partial"
+              href={`/graph/${r.ownedBy}/`}
+              title="Covered by this assessment, but not as its cross-link anchor — dependency cards pointing here get no drill-down"
+              >Covered by {r.ownedBy}</a
+            >
+          ) : (
+            <span class="sc-gap" title="An external dependency several assessments rely on, with no risk report of its own">
+              No report of its own
+            </span>
+          )}
+        </div>
+        <div class="sc-in">
+          <span class="sc-in-label">In</span>
+          {r.slugs.map((s, i) => (
+            <>
+              {i > 0 && <span class="sc-sep">·</span>}
+              <a href={`/graph/${s}/`}>{s}</a>
+            </>
+          ))}
+        </div>
+        {r.aliases.length > 1 && (
+          <div class="sc-aliases">
+            <span class="sc-in-label">Named</span>{r.aliases.join(" · ")}
+          </div>
+        )}
+      </li>
+    ))}
+  </ul>
+  <p class="sc-empty" id="sc-empty" hidden>No contracts match that filter.</p>
+
+  <script>
+    const search = document.getElementById("sc-search") as HTMLInputElement | null;
+    const list = document.getElementById("sc-list");
+    const empty = document.getElementById("sc-empty");
+    const note = document.getElementById("sc-note");
+    let mode = "all";
+
+    const NOTES: Record<string, string> = {
+      all: "Everything shared across assessments, widest reach first.",
+      partial: "Contracts an assessment already covers, but not at its anchor address, so dependency cards pointing here get no drill-down. Usually the referencing graph should point at the covering graph's vault address instead.",
+      gap: "External dependencies several assessments rely on that carry no risk report of their own. Each one is exposure the book takes without a dedicated assessment behind it.",
+      control:
+        "One protocol's own machinery — multisigs, timelocks, keepers, accountants — reused across its vaults. Not a coverage gap: a concentration signal, since a single key holder reaches every assessment listed.",
+    };
+
+    function apply() {
+      const q = (search?.value ?? "").trim().toLowerCase();
+      let shown = 0;
+      list?.querySelectorAll<HTMLElement>(".sc-row").forEach((row) => {
+        const matchesText = !q || (row.dataset.search ?? "").includes(q);
+        const matchesMode = mode === "all" || row.dataset.kind === mode;
+        const hit = matchesText && matchesMode;
+        row.hidden = !hit;
+        if (hit) shown++;
+      });
+      if (empty) empty.hidden = shown > 0;
+      if (note) note.textContent = NOTES[mode] ?? NOTES.all;
+    }
+
+    search?.addEventListener("input", apply);
+    document.querySelectorAll<HTMLElement>(".sc-seg-btn").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        mode = btn.dataset.filter ?? "all";
+        document.querySelectorAll<HTMLElement>(".sc-seg-btn").forEach((b) => {
+          const on = b === btn;
+          b.classList.toggle("is-on", on);
+          b.setAttribute("aria-pressed", String(on));
+        });
+        apply();
+      });
+    });
+  </script>
+</BaseLayout>
+
+<style>
+  .sc-hero {
+    padding: 2rem 0 0.5rem;
+  }
+  .sc-hero h1 {
+    margin: 0 0 0.4rem;
+  }
+  .sc-sub {
+    color: var(--text-secondary);
+    max-width: 68ch;
+    margin: 0;
+  }
+  .sc-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    padding: 1.2rem 0 0.6rem;
+    border-bottom: 1px solid var(--border-color, rgba(127, 127, 127, 0.2));
+  }
+  .sc-stat {
+    display: flex;
+    flex-direction: column;
+  }
+  .sc-stat b {
+    font-size: 1.35rem;
+    line-height: 1.1;
+  }
+  .sc-stat span {
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+  }
+  .sc-stat-wide span {
+    max-width: 30ch;
+  }
+  .sc-tools {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    padding: 1rem 0 0.6rem;
+  }
+  .sc-tools input[type="text"] {
+    flex: 1 1 320px;
+    max-width: 420px;
+    padding: 0.5rem 0.7rem;
+    font-size: 0.85rem;
+    color: var(--text-primary);
+    background: transparent;
+    border: 1px solid var(--border-color, rgba(127, 127, 127, 0.25));
+    border-radius: 7px;
+  }
+  .sc-seg {
+    display: inline-flex;
+    gap: 0.3rem;
+  }
+  .sc-seg-btn {
+    padding: 0.35rem 0.7rem;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    background: transparent;
+    border: 1px solid var(--border-color, rgba(127, 127, 127, 0.25));
+    border-radius: 999px;
+    cursor: pointer;
+  }
+  .sc-seg-btn.is-on {
+    color: var(--text-primary);
+    border-color: rgba(110, 167, 255, 0.6);
+  }
+  .sc-seg-n {
+    opacity: 0.65;
+    font-variant-numeric: tabular-nums;
+  }
+  .sc-note {
+    margin: 0 0 0.6rem;
+    font-size: 0.76rem;
+    line-height: 1.5;
+    color: var(--text-secondary);
+    max-width: 76ch;
+  }
+  .sc-partial {
+    flex-shrink: 0;
+    font-size: 0.7rem;
+    padding: 2px 8px;
+    border-radius: 999px;
+    color: #6ea7ff;
+    border: 1px solid rgba(110, 167, 255, 0.45);
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  .sc-partial:hover {
+    border-color: rgba(110, 167, 255, 0.9);
+  }
+  .sc-internal {
+    flex-shrink: 0;
+    font-size: 0.7rem;
+    padding: 2px 8px;
+    border-radius: 999px;
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
+    cursor: help;
+    white-space: nowrap;
+  }
+  .sc-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .sc-row {
+    padding: 0.8rem 0.2rem;
+    border-bottom: 1px solid var(--border-color, rgba(127, 127, 127, 0.14));
+  }
+  .sc-row[hidden] {
+    display: none;
+  }
+  .sc-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.8rem;
+  }
+  .sc-count {
+    flex-shrink: 0;
+    min-width: 2.4rem;
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    padding-top: 0.05rem;
+  }
+  .sc-id {
+    flex: 1;
+    min-width: 0;
+  }
+  .sc-label {
+    display: block;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .sc-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+    margin-top: 0.12rem;
+  }
+  .sc-meta a {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .sc-cat {
+    padding: 1px 6px;
+    border-radius: 3px;
+    border: 1px solid currentColor;
+    font-size: 0.64rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    opacity: 0.85;
+  }
+  .cat-vault { color: #6ea7ff; }
+  .cat-strategy { color: #fbbf24; }
+  .cat-governance { color: #f87171; }
+  .cat-infra { color: #94a3b8; }
+  .cat-dependency { color: #c4b5fd; }
+
+  .sc-assessed {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-shrink: 0;
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+    text-decoration: none;
+  }
+  .sc-assessed:hover {
+    color: var(--text-primary);
+  }
+  .sc-score {
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 2px 7px;
+    border-radius: 4px;
+  }
+  .sc-gap {
+    flex-shrink: 0;
+    font-size: 0.7rem;
+    padding: 2px 8px;
+    border-radius: 999px;
+    color: #fbbf24;
+    border: 1px solid rgba(251, 191, 36, 0.45);
+    cursor: help;
+    white-space: nowrap;
+  }
+  .sc-in,
+  .sc-aliases {
+    margin-top: 0.35rem;
+    padding-left: 3.2rem;
+    font-size: 0.73rem;
+    color: var(--text-secondary);
+    display: flex;
+    align-items: baseline;
+    gap: 0.3rem;
+    flex-wrap: wrap;
+  }
+  .sc-in-label {
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.6rem;
+    opacity: 0.75;
+  }
+  .sc-sep {
+    opacity: 0.5;
+  }
+  .sc-empty {
+    color: var(--text-secondary);
+    padding: 1rem 0;
+  }
+
+  @media (max-width: 620px) {
+    .sc-head {
+      flex-wrap: wrap;
+    }
+    .sc-in,
+    .sc-aliases {
+      padding-left: 0;
+    }
+  }
+</style>

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro";
 import { getAllReports } from "../lib/reports";
-import { getGraphSummaries } from "../lib/graph";
+import { getGraphSummaries, getSharedContracts } from "../lib/graph";
 import { scoreTier } from "../lib/colors";
 
 // llms.txt — a markdown briefing for LLMs and AI search engines, served at the
@@ -89,11 +89,32 @@ export const GET: APIRoute = async () => {
     }
   }
 
+  // Contracts several assessments share. The unassessed ones are the useful
+  // signal: a contract many graphs depend on that no report covers directly.
+  const shared = getSharedContracts();
+  const gaps = shared.filter((c) => c.kind === "external" && !c.assessedBy).slice(0, 15);
+  if (gaps.length > 0) {
+    lines.push(
+      "",
+      "## Shared external dependencies without their own assessment",
+      "",
+      `${shared.length} contracts appear in more than one dependency graph. The external dependencies below carry no risk report of their own, so the exposure is only visible in aggregate. Shared internal machinery (multisigs, keepers, accountants reused across one protocol's vaults) is listed separately. Full list: ${SITE}/graph/shared/`,
+      "",
+    );
+    for (const c of gaps) {
+      const slugs = [...new Set(c.occurrences.map((o) => o.slug))].sort();
+      lines.push(
+        `- ${c.label} (${c.address} on ${c.chain}): in ${slugs.length} assessments — ${slugs.join(", ")}`,
+      );
+    }
+  }
+
   lines.push(
     "",
     "## Other resources",
     "",
     `- [Dependency graphs](${SITE}/graph/): contract-level maps and cross-protocol exposure`,
+    `- [Shared contracts](${SITE}/graph/shared/): contracts appearing in more than one assessment`,
     `- [Token exposures](${SITE}/tokens/): shared-asset overlap across curated protocols`,
     `- [Bridge dependencies](${SITE}/bridges/): cross-chain bridge risk`,
     `- [Live monitoring](${SITE}/monitoring/): real-time protocol alerts (governance, oracle, owner changes)`,


### PR DESCRIPTION
> **Stacked on #399** — base is `graph-page-readability-panel`, since this reuses the graph-index machinery added there. Retarget to `master` once #399 merges.

## Why

Cross-linking between graphs only fires when a dependency has its **own** risk report. That hides the plainest form of shared exposure: **61 addresses appear in more than one dependency graph**, and reading the graphs one at a time makes none of it visible.

## What it finds

New `/graph/shared/` derives them at build time by address, split three ways because they call for different responses:

### Coverage gaps — 3
External dependencies several assessments rely on, with no report of their own.

| Contract | Reach |
|---|---|
| **Morpho Blue** `0xBBBBBbbB…EEFFCb` | **7** — `sky-stusds`, `yearn-yvdai`, `yearn-yvusd`, `yearn-yvusdc`, `yearn-yvusdt`, `yearn-yvwbtc`, `yearn-yvweth` |

Morpho Blue sits under seven assessments and has never been assessed directly.

### Missed links — 7
External contracts an assessment **already covers**, but not at its anchor address, so the cross-link silently doesn't fire. `DAI-USDC LitePSM` is covered by `sky-usds` yet renders as a plain dependency card in `yearn-yvdai` and `yearn-yvusdc`. These are YAML fixes, not research — the referencing graph should point at the covering graph's vault address.

### Shared control — 43
One protocol's own machinery reused across its vaults. **Not** a coverage gap — expecting a multisig to have its own risk report would be wrong. It's a concentration signal, and it's stark: the Yearn **6-of-9 ySafe**, the **3-of-8 Brain**, the **4-of-7 Security** multisig, the **7-day Strategy Manager timelock**, the **Role Manager**, the **Debt Allocator** and the **yHaaS keeper** each reach all 7 Yearn vault assessments.

An earlier revision lumped all of these together as "no report of its own", which produced a misleading headline (a Yearn multisig topping a list of "coverage gaps"). The three-way split is what makes the page honest.

## Also surfaced

Each row lists the assessments involved, the categories it's filed under, and — when graphs disagree — every name used for it. That last one is a finding by itself: Morpho Blue is variously **"Morpho Blue"**, **"Morpho Lending Markets"**, **"Morpho Protocol"** and **"Morpho Protocol (lending base)"** across four graphs.

The page is reachable from a banner on `/graph/` and from `llms.txt`, so the coverage gaps are legible to an agent reading the site as well as to a person.

## Validation

`astro build` (110 pages), `npm test` (19/19), `check_graphs` clean of errors. Browser-verified: all four filter modes with correct counts and labels (3 / 7 / 43 / 61), text filter, the assessed-row drill-down (`stcUSD` → `/graph/cap-stcusd/`), no console errors, and no horizontal overflow at 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
