### PR TITLE
Generate Morpho market allocation nodes across dependency graphs

### DIFF
--- a/reports/graph/SKILL.md
+++ b/reports/graph/SKILL.md
@@ -6,6 +6,23 @@ allowed-tools: Read Write Edit Grep Glob Bash(npm:*) Bash(git:*)
 
 # Generating contract dependency graphs
 
+## Contents
+
+- [When to invoke](#when-to-invoke)
+- [Inputs](#inputs)
+- [File layout](#file-layout)
+- [Schema](#schema)
+- [Vocabulary](#vocabulary)
+- [Selection rules](#selection-rules)
+- [Authoring procedure](#authoring-procedure)
+- [Verification](#verification)
+- [Worked examples](#worked-examples)
+- [Cross-graph linking](#cross-graph-linking)
+- [Selection & chain highlight](#selection--chain-highlight)
+- [What the reader gets](#what-the-reader-gets)
+- [Morpho market expansion](#morpho-market-expansion)
+- [Common pitfalls](#common-pitfalls)
+
 Each risk report in `reports/report/` documents a protocol's contracts and their relationships in prose. A dependency-graph YAML in `reports/graph/` makes those relationships visual at `/graph/<slug>/` on the website (linked from `/report/<slug>/` automatically when a YAML exists).
 
 This skill turns a finished risk report into the corresponding YAML.

--- a/reports/graph/SKILL.md
+++ b/reports/graph/SKILL.md
@@ -58,7 +58,9 @@ The schema is enforced at build time by the validator in `src/lib/graph.ts`. Aut
 | `category` | yes | enum | One of the 5 below. |
 | `address` | no | string | EVM address. Shown in full in the details panel, drives the `↗` block-explorer link, and is what cross-graph linking matches on. |
 | `chain` | no | string | Per-node chain override; falls back to top-level `chain`. |
+| `link` | no | string | External URL for the card's `↗` affordance and the details panel. **Must use `https://`.** Prefer it to the block-explorer link for addressless nodes (e.g. Morpho market IDs, which are 32-byte identifiers — never put a market ID in `address`). |
 | `note` | no | string | Free-form context. **Rendered as prose in the details panel** when the card is clicked — write it for a human reader, not as a shorthand memo. |
+| `morphoVault` | no | enum `"v1" \| "v2"` | Tags this node as a Morpho vault whose per-market allocations are expanded by `scripts/update_morpho_graph_markets.mjs`. Records the vault contract's immutable generation. Requires `address`. **Only explicitly tagged nodes are probed** — never detected from labels, IDs, notes, or address probing. Do not tag generic Morpho protocol/market nodes, Morpho strategies that merely use flashloans, or wrapper/farm contracts that deposit into a separate vault node. |
 
 **Edge fields:**
 
@@ -291,6 +293,31 @@ Worth knowing while authoring, because it decides how much care a field deserves
 - **Metric strip** (build-time, from this YAML plus the report frontmatter): final score, graph size, largest allocation, external dependency count with the worst assessed tier, and the mint-role count. Largest allocation, external dependencies and mint authority are **clickable** — they project that set onto the canvas and fade the rest, so "4 mint roles" becomes "show me which four".
 - **Search** matches node label, address, and category label, then fits the view to the hits.
 - **Edge filters** let a reader mute whole groups (Money flow / Mint authority / Control / Governance / Wiring). This is the answer to role-spaghetti — prefer a complete YAML the reader can filter over an incomplete one.
+
+## Morpho market expansion
+
+A node tagged `morphoVault: v1` (or `v2`) is expanded by `scripts/update_morpho_graph_markets.mjs` into its current underlying market allocations. The tag records the vault contract's immutable generation, so the updater queries only the declared API collection (`vaults` for v1, `vaultV2s` for v2) rather than probing both.
+
+What the generator does:
+
+- Scans every `reports/graph/*.yaml`, finds tagged nodes, and fetches their allocations from the Morpho GraphQL API (`https://api.morpho.org/graphql`).
+- Emits a `dependency` node per non-zero market (label `cbBTC/USDC · 86% LLTV`, `link` to the Morpho market page, full 32-byte `marketId` in the `note`) and a `deposits-into` edge from the vault node to each market carrying its percentage label.
+- Represents idle assets (`collateralAsset` is null) as a synthetic `Idle <asset>` node with no Morpho link, so displayed allocations reconcile to 100%. Tiny positive shares are labelled `<0.1%`, never rounded to 0.
+- Writes into two marker-delimited sections — `# BEGIN/END GENERATED MORPHO MARKET NODES` (before `edges:`) and `# BEGIN/END GENERATED MORPHO MARKET EDGES` (inside the edge list) — preserving every byte outside those regions. V2 vaults are supported for direct `MorphoMarketV1Adapter` positions; nested/unsupported adapters fail closed.
+
+Commands:
+
+```bash
+node scripts/update_morpho_graph_markets.mjs            # check: exits 1 if any managed section is stale
+node scripts/update_morpho_graph_markets.mjs --write    # apply
+node scripts/update_morpho_graph_markets.mjs --graph <slug> --write   # one graph
+```
+
+Authoring rules:
+
+- Tag only actual Morpho vault contracts. Skip generic Morpho protocol/market nodes, strategies that only use flashloans, and wrappers/farms that deposit into a separate vault node.
+- A tag/version mismatch fails closed with an actionable error — do not guess the version; verify the contract onchain or via the API first.
+- The generated market IDs are 32-byte identifiers, not EVM addresses — they live in `link`, never in `address`.
 
 ## Common pitfalls
 

--- a/reports/graph/cap-stcusd.yaml
+++ b/reports/graph/cap-stcusd.yaml
@@ -118,42 +118,42 @@ nodes:
     label: "cbBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
-    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Steakhouse Prime USDC"
+    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"
   - id: morpho-market-34377fc4f617
     label: "weETH/USDC · 77% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x34377fc4f617c51818e92c79df31ff270c6a91bc94ad32e367fdf59b9f4ac5dd/"
-    note: "Morpho market 0x34377fc4f617c51818e92c79df31ff270c6a91bc94ad32e367fdf59b9f4ac5dd used by Steakhouse Prime USDC"
+    note: "Morpho market 0x34377fc4f617c51818e92c79df31ff270c6a91bc94ad32e367fdf59b9f4ac5dd"
   - id: morpho-market-3a85e6197511
-    label: "WBTC/USDC · 86% LLTV · 0x3a85e6197511"
+    label: "WBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49/"
-    note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49 used by Steakhouse Prime USDC"
+    note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49"
   - id: morpho-market-94b823e6bd8e
     label: "WETH/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x94b823e6bd8ea533b4e33fbc307faea0b307301bc48763acc4d4aa4def7636cd/"
-    note: "Morpho market 0x94b823e6bd8ea533b4e33fbc307faea0b307301bc48763acc4d4aa4def7636cd used by Steakhouse Prime USDC"
+    note: "Morpho market 0x94b823e6bd8ea533b4e33fbc307faea0b307301bc48763acc4d4aa4def7636cd"
   - id: morpho-market-7e585a933ffe
-    label: "wstETH/USDC · 86% LLTV · 0x7e585a933ffe"
+    label: "wstETH/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8/"
-    note: "Morpho market 0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8 used by Steakhouse Prime USDC"
+    note: "Morpho market 0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8"
   - id: morpho-market-b323495f7e41
     label: "wstETH/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc/"
-    note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc used by Steakhouse Prime USDC"
+    note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc"
   - id: morpho-market-bc99de6a8890
-    label: "cbBTC/USDC · 86% LLTV · 0xbc99de6a8890"
+    label: "cbBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe/"
-    note: "Morpho market 0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe used by Steakhouse Prime USDC"
+    note: "Morpho market 0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe"
   - id: morpho-market-09dc9e7eb5d8
     label: "WBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1/"
-    note: "Morpho market 0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1 used by Steakhouse Prime USDC"
+    note: "Morpho market 0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1"
 # END GENERATED MORPHO MARKET NODES
 
 edges:

--- a/reports/graph/cap-stcusd.yaml
+++ b/reports/graph/cap-stcusd.yaml
@@ -67,12 +67,14 @@ nodes:
     address: "0xbeef088055857739C12CD3765F20b7679Def0f51"
     category: dependency
     morphoVault: v2
+    link: "https://app.morpho.org/ethereum/vault/0xbeef088055857739C12CD3765F20b7679Def0f51/"
     note: ~$29.13M (60% of USDC FRV)
   - id: morpho-usdc-prime
     label: Morpho Gauntlet USDC Prime
     address: "0x8c106EEDAd96553e64287A5A6839c3Cc78afA3D0"
     category: dependency
     morphoVault: v2
+    link: "https://app.morpho.org/ethereum/vault/0x8c106EEDAd96553e64287A5A6839c3Cc78afA3D0/"
     note: ~$19.73M (40% of USDC FRV)
 
   # MetaMorpho Prime governance (V2)
@@ -137,16 +139,16 @@ nodes:
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8/"
     note: "Morpho market 0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8 used by Steakhouse Prime USDC"
-  - id: morpho-market-09dc9e7eb5d8
-    label: "WBTC/USDC · 86% LLTV"
-    category: dependency
-    link: "https://app.morpho.org/ethereum/market/0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1/"
-    note: "Morpho market 0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1 used by Steakhouse Prime USDC"
   - id: morpho-market-bc99de6a8890
     label: "cbBTC/USDC · 86% LLTV · 0xbc99de6a8890"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe/"
     note: "Morpho market 0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe used by Steakhouse Prime USDC"
+  - id: morpho-market-09dc9e7eb5d8
+    label: "WBTC/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1/"
+    note: "Morpho market 0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1 used by Steakhouse Prime USDC"
   - id: morpho-market-b323495f7e41
     label: "wstETH/USDC · 86% LLTV · 0xb323495f7e41"
     category: dependency
@@ -246,29 +248,29 @@ edges:
   - from: morpho-steakhouse-prime
     to: morpho-market-64d65c9a2d91
     kind: deposits-into
-    label: "91.1%"
+    label: "91.5%"
   - from: morpho-steakhouse-prime
     to: morpho-market-34377fc4f617
     kind: deposits-into
-    label: "4.0%"
+    label: "3.9%"
   - from: morpho-steakhouse-prime
     to: morpho-market-3a85e6197511
     kind: deposits-into
-    label: "2.4%"
+    label: "2.3%"
   - from: morpho-steakhouse-prime
     to: morpho-market-94b823e6bd8e
     kind: deposits-into
-    label: "1.2%"
+    label: "1.1%"
   - from: morpho-steakhouse-prime
     to: morpho-market-7e585a933ffe
     kind: deposits-into
-    label: "1.0%"
+    label: "0.9%"
   - from: morpho-steakhouse-prime
-    to: morpho-market-09dc9e7eb5d8
+    to: morpho-market-bc99de6a8890
     kind: deposits-into
     label: "<0.1%"
   - from: morpho-steakhouse-prime
-    to: morpho-market-bc99de6a8890
+    to: morpho-market-09dc9e7eb5d8
     kind: deposits-into
     label: "<0.1%"
   - from: morpho-steakhouse-prime
@@ -278,11 +280,11 @@ edges:
   - from: morpho-usdc-prime
     to: morpho-market-64d65c9a2d91
     kind: deposits-into
-    label: "47.1%"
+    label: "47.0%"
   - from: morpho-usdc-prime
     to: morpho-market-3a85e6197511
     kind: deposits-into
-    label: "45.6%"
+    label: "45.7%"
   - from: morpho-usdc-prime
     to: morpho-market-b323495f7e41
     kind: deposits-into

--- a/reports/graph/cap-stcusd.yaml
+++ b/reports/graph/cap-stcusd.yaml
@@ -125,7 +125,7 @@ nodes:
     link: "https://app.morpho.org/ethereum/market/0x34377fc4f617c51818e92c79df31ff270c6a91bc94ad32e367fdf59b9f4ac5dd/"
     note: "Morpho market 0x34377fc4f617c51818e92c79df31ff270c6a91bc94ad32e367fdf59b9f4ac5dd used by Steakhouse Prime USDC"
   - id: morpho-market-3a85e6197511
-    label: "WBTC/USDC · 86% LLTV · 0x3a85e6197511"
+    label: "WBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49/"
     note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49 used by Steakhouse Prime USDC"
@@ -140,7 +140,7 @@ nodes:
     link: "https://app.morpho.org/ethereum/market/0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8/"
     note: "Morpho market 0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8 used by Steakhouse Prime USDC"
   - id: morpho-market-bc99de6a8890
-    label: "cbBTC/USDC · 86% LLTV · 0xbc99de6a8890"
+    label: "cbBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe/"
     note: "Morpho market 0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe used by Steakhouse Prime USDC"
@@ -150,7 +150,7 @@ nodes:
     link: "https://app.morpho.org/ethereum/market/0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1/"
     note: "Morpho market 0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1 used by Steakhouse Prime USDC"
   - id: morpho-market-b323495f7e41
-    label: "wstETH/USDC · 86% LLTV · 0xb323495f7e41"
+    label: "wstETH/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc/"
     note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc used by Steakhouse Prime USDC"

--- a/reports/graph/cap-stcusd.yaml
+++ b/reports/graph/cap-stcusd.yaml
@@ -125,7 +125,7 @@ nodes:
     link: "https://app.morpho.org/ethereum/market/0x34377fc4f617c51818e92c79df31ff270c6a91bc94ad32e367fdf59b9f4ac5dd/"
     note: "Morpho market 0x34377fc4f617c51818e92c79df31ff270c6a91bc94ad32e367fdf59b9f4ac5dd used by Steakhouse Prime USDC"
   - id: morpho-market-3a85e6197511
-    label: "WBTC/USDC · 86% LLTV"
+    label: "WBTC/USDC · 86% LLTV · 0x3a85e6197511"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49/"
     note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49 used by Steakhouse Prime USDC"
@@ -135,12 +135,17 @@ nodes:
     link: "https://app.morpho.org/ethereum/market/0x94b823e6bd8ea533b4e33fbc307faea0b307301bc48763acc4d4aa4def7636cd/"
     note: "Morpho market 0x94b823e6bd8ea533b4e33fbc307faea0b307301bc48763acc4d4aa4def7636cd used by Steakhouse Prime USDC"
   - id: morpho-market-7e585a933ffe
-    label: "wstETH/USDC · 86% LLTV"
+    label: "wstETH/USDC · 86% LLTV · 0x7e585a933ffe"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8/"
     note: "Morpho market 0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8 used by Steakhouse Prime USDC"
+  - id: morpho-market-b323495f7e41
+    label: "wstETH/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc/"
+    note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc used by Steakhouse Prime USDC"
   - id: morpho-market-bc99de6a8890
-    label: "cbBTC/USDC · 86% LLTV"
+    label: "cbBTC/USDC · 86% LLTV · 0xbc99de6a8890"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe/"
     note: "Morpho market 0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe used by Steakhouse Prime USDC"
@@ -149,11 +154,6 @@ nodes:
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1/"
     note: "Morpho market 0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1 used by Steakhouse Prime USDC"
-  - id: morpho-market-b323495f7e41
-    label: "wstETH/USDC · 86% LLTV"
-    category: dependency
-    link: "https://app.morpho.org/ethereum/market/0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc/"
-    note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc used by Steakhouse Prime USDC"
 # END GENERATED MORPHO MARKET NODES
 
 edges:
@@ -248,15 +248,15 @@ edges:
   - from: morpho-steakhouse-prime
     to: morpho-market-64d65c9a2d91
     kind: deposits-into
-    label: "91.5%"
+    label: "91.9%"
   - from: morpho-steakhouse-prime
     to: morpho-market-34377fc4f617
     kind: deposits-into
-    label: "3.9%"
+    label: "3.8%"
   - from: morpho-steakhouse-prime
     to: morpho-market-3a85e6197511
     kind: deposits-into
-    label: "2.3%"
+    label: "2.0%"
   - from: morpho-steakhouse-prime
     to: morpho-market-94b823e6bd8e
     kind: deposits-into
@@ -266,15 +266,15 @@ edges:
     kind: deposits-into
     label: "0.9%"
   - from: morpho-steakhouse-prime
+    to: morpho-market-b323495f7e41
+    kind: deposits-into
+    label: "<0.1%"
+  - from: morpho-steakhouse-prime
     to: morpho-market-bc99de6a8890
     kind: deposits-into
     label: "<0.1%"
   - from: morpho-steakhouse-prime
     to: morpho-market-09dc9e7eb5d8
-    kind: deposits-into
-    label: "<0.1%"
-  - from: morpho-steakhouse-prime
-    to: morpho-market-b323495f7e41
     kind: deposits-into
     label: "<0.1%"
   - from: morpho-usdc-prime

--- a/reports/graph/cap-stcusd.yaml
+++ b/reports/graph/cap-stcusd.yaml
@@ -74,6 +74,25 @@ nodes:
     category: dependency
     morphoVault: v2
     note: ~$19.73M (40% of USDC FRV)
+
+  # MetaMorpho Prime governance (V2)
+  - id: steakhouse-prime-owner
+    label: Steakhouse Prime Owner
+    address: "0x4D7bd498Bb24098Ca281C05519629c605407f71d"
+    category: governance
+    note: Governance contract (not a Safe)
+  - id: steakhouse-prime-curator
+    label: Steakhouse Prime Curator (2-of-7)
+    address: "0x827e86072B06674a077f592A531dcE4590aDeCdB"
+    category: governance
+  - id: gauntlet-prime-owner
+    label: Gauntlet Prime Owner (4-of-7)
+    address: "0xC684c6587712e5E7BDf9fD64415F23Bd2b05fAec"
+    category: governance
+  - id: gauntlet-prime-curator
+    label: Gauntlet Prime Curator (3-of-7)
+    address: "0x9E33faAE38ff641094fa68c65c2cE600b3410585"
+    category: governance
   - id: aave-v3-usdc
     label: Aave V3 USDC Core
     category: dependency
@@ -203,6 +222,24 @@ edges:
     to: symbiotic
     kind: routes-through
     label: slashing collateral
+
+  # MetaMorpho Prime governance
+  - from: steakhouse-prime-owner
+    to: morpho-steakhouse-prime
+    kind: holds-role
+    label: "owner"
+  - from: steakhouse-prime-curator
+    to: morpho-steakhouse-prime
+    kind: holds-role
+    label: "curator"
+  - from: gauntlet-prime-owner
+    to: morpho-usdc-prime
+    kind: holds-role
+    label: "owner"
+  - from: gauntlet-prime-curator
+    to: morpho-usdc-prime
+    kind: holds-role
+    label: "curator"
 
 # BEGIN GENERATED MORPHO MARKET EDGES
 # Managed by scripts/update_morpho_graph_markets.mjs — do not edit.

--- a/reports/graph/cap-stcusd.yaml
+++ b/reports/graph/cap-stcusd.yaml
@@ -246,7 +246,7 @@ edges:
   - from: morpho-steakhouse-prime
     to: morpho-market-64d65c9a2d91
     kind: deposits-into
-    label: "91.2%"
+    label: "91.1%"
   - from: morpho-steakhouse-prime
     to: morpho-market-34377fc4f617
     kind: deposits-into

--- a/reports/graph/cap-stcusd.yaml
+++ b/reports/graph/cap-stcusd.yaml
@@ -66,11 +66,13 @@ nodes:
     label: Morpho Steakhouse Prime USDC
     address: "0xbeef088055857739C12CD3765F20b7679Def0f51"
     category: dependency
+    morphoVault: v2
     note: ~$29.13M (60% of USDC FRV)
   - id: morpho-usdc-prime
     label: Morpho Gauntlet USDC Prime
     address: "0x8c106EEDAd96553e64287A5A6839c3Cc78afA3D0"
     category: dependency
+    morphoVault: v2
     note: ~$19.73M (40% of USDC FRV)
   - id: aave-v3-usdc
     label: Aave V3 USDC Core
@@ -88,6 +90,50 @@ nodes:
     label: Symbiotic Restaking
     category: dependency
     note: Per-operator vaults; instant slashing on default
+
+# BEGIN GENERATED MORPHO MARKET NODES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - id: morpho-market-64d65c9a2d91
+    label: "cbBTC/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
+    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Steakhouse Prime USDC"
+  - id: morpho-market-34377fc4f617
+    label: "weETH/USDC · 77% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x34377fc4f617c51818e92c79df31ff270c6a91bc94ad32e367fdf59b9f4ac5dd/"
+    note: "Morpho market 0x34377fc4f617c51818e92c79df31ff270c6a91bc94ad32e367fdf59b9f4ac5dd used by Steakhouse Prime USDC"
+  - id: morpho-market-3a85e6197511
+    label: "WBTC/USDC · 86% LLTV · 0x3a85e6197511"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49/"
+    note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49 used by Steakhouse Prime USDC"
+  - id: morpho-market-94b823e6bd8e
+    label: "WETH/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x94b823e6bd8ea533b4e33fbc307faea0b307301bc48763acc4d4aa4def7636cd/"
+    note: "Morpho market 0x94b823e6bd8ea533b4e33fbc307faea0b307301bc48763acc4d4aa4def7636cd used by Steakhouse Prime USDC"
+  - id: morpho-market-7e585a933ffe
+    label: "wstETH/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8/"
+    note: "Morpho market 0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8 used by Steakhouse Prime USDC"
+  - id: morpho-market-09dc9e7eb5d8
+    label: "WBTC/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1/"
+    note: "Morpho market 0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1 used by Steakhouse Prime USDC"
+  - id: morpho-market-bc99de6a8890
+    label: "cbBTC/USDC · 86% LLTV · 0xbc99de6a8890"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe/"
+    note: "Morpho market 0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe used by Steakhouse Prime USDC"
+  - id: morpho-market-b323495f7e41
+    label: "wstETH/USDC · 86% LLTV · 0xb323495f7e41"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc/"
+    note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc used by Steakhouse Prime USDC"
+# END GENERATED MORPHO MARKET NODES
 
 edges:
   # === Governance flow ===
@@ -157,3 +203,67 @@ edges:
     to: symbiotic
     kind: routes-through
     label: slashing collateral
+
+# BEGIN GENERATED MORPHO MARKET EDGES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - from: morpho-steakhouse-prime
+    to: morpho-market-64d65c9a2d91
+    kind: deposits-into
+    label: "91.2%"
+  - from: morpho-steakhouse-prime
+    to: morpho-market-34377fc4f617
+    kind: deposits-into
+    label: "4.0%"
+  - from: morpho-steakhouse-prime
+    to: morpho-market-3a85e6197511
+    kind: deposits-into
+    label: "2.4%"
+  - from: morpho-steakhouse-prime
+    to: morpho-market-94b823e6bd8e
+    kind: deposits-into
+    label: "1.2%"
+  - from: morpho-steakhouse-prime
+    to: morpho-market-7e585a933ffe
+    kind: deposits-into
+    label: "1.0%"
+  - from: morpho-steakhouse-prime
+    to: morpho-market-09dc9e7eb5d8
+    kind: deposits-into
+    label: "<0.1%"
+  - from: morpho-steakhouse-prime
+    to: morpho-market-bc99de6a8890
+    kind: deposits-into
+    label: "<0.1%"
+  - from: morpho-steakhouse-prime
+    to: morpho-market-b323495f7e41
+    kind: deposits-into
+    label: "<0.1%"
+  - from: morpho-usdc-prime
+    to: morpho-market-64d65c9a2d91
+    kind: deposits-into
+    label: "47.1%"
+  - from: morpho-usdc-prime
+    to: morpho-market-3a85e6197511
+    kind: deposits-into
+    label: "45.6%"
+  - from: morpho-usdc-prime
+    to: morpho-market-b323495f7e41
+    kind: deposits-into
+    label: "3.6%"
+  - from: morpho-usdc-prime
+    to: morpho-market-7e585a933ffe
+    kind: deposits-into
+    label: "1.8%"
+  - from: morpho-usdc-prime
+    to: morpho-market-94b823e6bd8e
+    kind: deposits-into
+    label: "1.4%"
+  - from: morpho-usdc-prime
+    to: morpho-market-09dc9e7eb5d8
+    kind: deposits-into
+    label: "0.1%"
+  - from: morpho-usdc-prime
+    to: morpho-market-bc99de6a8890
+    kind: deposits-into
+    label: "<0.1%"
+# END GENERATED MORPHO MARKET EDGES

--- a/reports/graph/gauntlet-gusda.yaml
+++ b/reports/graph/gauntlet-gusda.yaml
@@ -84,6 +84,74 @@ nodes:
     label: Morpho Lending Markets
     category: dependency
     note: Multi-chain USDC lending markets (Ethereum, Base, Arbitrum, Optimism)
+  - id: gauntlet-frontier
+    label: Gauntlet USDC Frontier (MetaMorpho V2)
+    address: "0x9a1D6bd5b8642C41F25e0958129B85f8E1176F3e"
+    category: dependency
+    morphoVault: v2
+    note: Ethereum-mainnet same-chain allocation; riskier assets (sUSDD, PRIME)
+  - id: gauntlet-vault-owner
+    label: Gauntlet Vault Owner (4-of-7)
+    address: "0xC684c6587712e5E7BDf9fD64415F23Bd2b05fAec"
+    category: governance
+  - id: gauntlet-vault-curator
+    label: Gauntlet Vault Curator (3-of-7)
+    address: "0x9E33faAE38ff641094fa68c65c2cE600b3410585"
+    category: governance
+
+# BEGIN GENERATED MORPHO MARKET NODES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - id: morpho-market-e83d72fa5b00
+    label: "AA_FalconXUSDC/USDC · 77% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xe83d72fa5b00dcd46d9e0e860d95aa540d5ec106da5833108a9f826f21f36f52/"
+    note: "Morpho market 0xe83d72fa5b00dcd46d9e0e860d95aa540d5ec106da5833108a9f826f21f36f52 used by Gauntlet USDC Frontier"
+  - id: morpho-market-f02d2e8f427a
+    label: "PT-sUSDD-27AUG2026/USDC · 91.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xf02d2e8f427a2b91785b3d09690ef9d3811bf674ba97b00bafc7665004a6dd97/"
+    note: "Morpho market 0xf02d2e8f427a2b91785b3d09690ef9d3811bf674ba97b00bafc7665004a6dd97 used by Gauntlet USDC Frontier"
+  - id: morpho-market-755f954513d3
+    label: "PRIME/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x755f954513d31d5f24aaf3d0cdc5e913a28383f8ea8ff85be9ffffa7371fb64d/"
+    note: "Morpho market 0x755f954513d31d5f24aaf3d0cdc5e913a28383f8ea8ff85be9ffffa7371fb64d used by Gauntlet USDC Frontier"
+  - id: morpho-market-bf02d6c6852f
+    label: "LBTC/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0/"
+    note: "Morpho market 0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0 used by Gauntlet USDC Frontier"
+  - id: morpho-market-5cebfae10f5e
+    label: "PT-USDG-28MAY2026/USDC · 94.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x5cebfae10f5e88d33df2421923f3d9f32359429fda2f78edacc9b4fdb09b0553/"
+    note: "Morpho market 0x5cebfae10f5e88d33df2421923f3d9f32359429fda2f78edacc9b4fdb09b0553 used by Gauntlet USDC Frontier"
+  - id: morpho-market-64d65c9a2d91
+    label: "cbBTC/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
+    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Gauntlet USDC Frontier"
+  - id: morpho-market-61765602144e
+    label: "weETH/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664/"
+    note: "Morpho market 0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664 used by Gauntlet USDC Frontier"
+  - id: morpho-market-ad73d5e139a9
+    label: "sUSDD/USDC · 91.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xad73d5e139a939a0c7dc7b821e5a103a3a9cf45c4352b373b1dabc421c7f3d59/"
+    note: "Morpho market 0xad73d5e139a939a0c7dc7b821e5a103a3a9cf45c4352b373b1dabc421c7f3d59 used by Gauntlet USDC Frontier"
+  - id: morpho-market-729badf297ee
+    label: "syrupUSDC/USDC · 91.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x729badf297ee9f2f6b3f717b96fd355fc6ec00422284ce1968e76647b258cf44/"
+    note: "Morpho market 0x729badf297ee9f2f6b3f717b96fd355fc6ec00422284ce1968e76647b258cf44 used by Gauntlet USDC Frontier"
+  - id: morpho-market-bbf7ce1b40d3
+    label: "siUSD/USDC · 91.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99/"
+    note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99 used by Gauntlet USDC Frontier"
+# END GENERATED MORPHO MARKET NODES
 
 edges:
   # === Governance: multisig → timelock ===
@@ -150,9 +218,67 @@ edges:
     to: morpho
     kind: deposits-into
     label: USDC
+  - from: gtusda-vault
+    to: gauntlet-frontier
+    kind: deposits-into
+    label: "USDC (same-chain Frontier)"
+
+  # === MetaMorpho vault governance ===
+  - from: gauntlet-vault-owner
+    to: gauntlet-frontier
+    kind: holds-role
+    label: "owner"
+  - from: gauntlet-vault-curator
+    to: gauntlet-frontier
+    kind: holds-role
+    label: "curator"
 
   # === Fee flow ===
   - from: gtusda-vault
     to: gauntlet-multisig
     kind: routes-fees-to
     label: feeRecipient
+
+# BEGIN GENERATED MORPHO MARKET EDGES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - from: gauntlet-frontier
+    to: morpho-market-e83d72fa5b00
+    kind: deposits-into
+    label: "71.5%"
+  - from: gauntlet-frontier
+    to: morpho-market-f02d2e8f427a
+    kind: deposits-into
+    label: "27.9%"
+  - from: gauntlet-frontier
+    to: morpho-market-755f954513d3
+    kind: deposits-into
+    label: "0.2%"
+  - from: gauntlet-frontier
+    to: morpho-market-bf02d6c6852f
+    kind: deposits-into
+    label: "0.1%"
+  - from: gauntlet-frontier
+    to: morpho-market-5cebfae10f5e
+    kind: deposits-into
+    label: "<0.1%"
+  - from: gauntlet-frontier
+    to: morpho-market-64d65c9a2d91
+    kind: deposits-into
+    label: "<0.1%"
+  - from: gauntlet-frontier
+    to: morpho-market-61765602144e
+    kind: deposits-into
+    label: "<0.1%"
+  - from: gauntlet-frontier
+    to: morpho-market-ad73d5e139a9
+    kind: deposits-into
+    label: "<0.1%"
+  - from: gauntlet-frontier
+    to: morpho-market-729badf297ee
+    kind: deposits-into
+    label: "<0.1%"
+  - from: gauntlet-frontier
+    to: morpho-market-bbf7ce1b40d3
+    kind: deposits-into
+    label: "<0.1%"
+# END GENERATED MORPHO MARKET EDGES

--- a/reports/graph/gauntlet-gusda.yaml
+++ b/reports/graph/gauntlet-gusda.yaml
@@ -89,6 +89,7 @@ nodes:
     address: "0x9a1D6bd5b8642C41F25e0958129B85f8E1176F3e"
     category: dependency
     morphoVault: v2
+    link: "https://app.morpho.org/ethereum/vault/0x9a1D6bd5b8642C41F25e0958129B85f8E1176F3e/"
     note: Ethereum-mainnet same-chain allocation; riskier assets (sUSDD, PRIME)
   - id: gauntlet-vault-owner
     label: Gauntlet Vault Owner (4-of-7)
@@ -244,11 +245,11 @@ edges:
   - from: gauntlet-frontier
     to: morpho-market-e83d72fa5b00
     kind: deposits-into
-    label: "71.5%"
+    label: "72.0%"
   - from: gauntlet-frontier
     to: morpho-market-f02d2e8f427a
     kind: deposits-into
-    label: "27.9%"
+    label: "27.5%"
   - from: gauntlet-frontier
     to: morpho-market-755f954513d3
     kind: deposits-into

--- a/reports/graph/gauntlet-gusda.yaml
+++ b/reports/graph/gauntlet-gusda.yaml
@@ -106,52 +106,52 @@ nodes:
     label: "AA_FalconXUSDC/USDC · 77% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xe83d72fa5b00dcd46d9e0e860d95aa540d5ec106da5833108a9f826f21f36f52/"
-    note: "Morpho market 0xe83d72fa5b00dcd46d9e0e860d95aa540d5ec106da5833108a9f826f21f36f52 used by Gauntlet USDC Frontier"
+    note: "Morpho market 0xe83d72fa5b00dcd46d9e0e860d95aa540d5ec106da5833108a9f826f21f36f52"
   - id: morpho-market-f02d2e8f427a
     label: "PT-sUSDD-27AUG2026/USDC · 91.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xf02d2e8f427a2b91785b3d09690ef9d3811bf674ba97b00bafc7665004a6dd97/"
-    note: "Morpho market 0xf02d2e8f427a2b91785b3d09690ef9d3811bf674ba97b00bafc7665004a6dd97 used by Gauntlet USDC Frontier"
+    note: "Morpho market 0xf02d2e8f427a2b91785b3d09690ef9d3811bf674ba97b00bafc7665004a6dd97"
   - id: morpho-market-755f954513d3
     label: "PRIME/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x755f954513d31d5f24aaf3d0cdc5e913a28383f8ea8ff85be9ffffa7371fb64d/"
-    note: "Morpho market 0x755f954513d31d5f24aaf3d0cdc5e913a28383f8ea8ff85be9ffffa7371fb64d used by Gauntlet USDC Frontier"
+    note: "Morpho market 0x755f954513d31d5f24aaf3d0cdc5e913a28383f8ea8ff85be9ffffa7371fb64d"
   - id: morpho-market-bf02d6c6852f
     label: "LBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0/"
-    note: "Morpho market 0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0 used by Gauntlet USDC Frontier"
+    note: "Morpho market 0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0"
   - id: morpho-market-5cebfae10f5e
     label: "PT-USDG-28MAY2026/USDC · 94.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x5cebfae10f5e88d33df2421923f3d9f32359429fda2f78edacc9b4fdb09b0553/"
-    note: "Morpho market 0x5cebfae10f5e88d33df2421923f3d9f32359429fda2f78edacc9b4fdb09b0553 used by Gauntlet USDC Frontier"
+    note: "Morpho market 0x5cebfae10f5e88d33df2421923f3d9f32359429fda2f78edacc9b4fdb09b0553"
   - id: morpho-market-64d65c9a2d91
     label: "cbBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
-    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Gauntlet USDC Frontier"
+    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"
   - id: morpho-market-61765602144e
     label: "weETH/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664/"
-    note: "Morpho market 0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664 used by Gauntlet USDC Frontier"
+    note: "Morpho market 0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664"
   - id: morpho-market-ad73d5e139a9
     label: "sUSDD/USDC · 91.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xad73d5e139a939a0c7dc7b821e5a103a3a9cf45c4352b373b1dabc421c7f3d59/"
-    note: "Morpho market 0xad73d5e139a939a0c7dc7b821e5a103a3a9cf45c4352b373b1dabc421c7f3d59 used by Gauntlet USDC Frontier"
+    note: "Morpho market 0xad73d5e139a939a0c7dc7b821e5a103a3a9cf45c4352b373b1dabc421c7f3d59"
   - id: morpho-market-729badf297ee
     label: "syrupUSDC/USDC · 91.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x729badf297ee9f2f6b3f717b96fd355fc6ec00422284ce1968e76647b258cf44/"
-    note: "Morpho market 0x729badf297ee9f2f6b3f717b96fd355fc6ec00422284ce1968e76647b258cf44 used by Gauntlet USDC Frontier"
+    note: "Morpho market 0x729badf297ee9f2f6b3f717b96fd355fc6ec00422284ce1968e76647b258cf44"
   - id: morpho-market-bbf7ce1b40d3
     label: "siUSD/USDC · 91.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99/"
-    note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99 used by Gauntlet USDC Frontier"
+    note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99"
 # END GENERATED MORPHO MARKET NODES
 
 edges:

--- a/reports/graph/infinifi.yaml
+++ b/reports/graph/infinifi.yaml
@@ -232,17 +232,17 @@ nodes:
     label: "siUSD/USDC · 91.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99/"
-    note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99 used by Waterline infiniFi USDC"
+    note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99"
   - id: morpho-market-6df56abb95e9
     label: "iUSD/USDC · 91.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x6df56abb95e9f3f96049448e1c98d208deb1add8a3d0c7a23e5e5466dba4edbd/"
-    note: "Morpho market 0x6df56abb95e9f3f96049448e1c98d208deb1add8a3d0c7a23e5e5466dba4edbd used by Waterline infiniFi USDC"
+    note: "Morpho market 0x6df56abb95e9f3f96049448e1c98d208deb1add8a3d0c7a23e5e5466dba4edbd"
   - id: morpho-market-a94d7d784ecd
     label: "PT-siUSD-20AUG2026/USDC · 91.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xa94d7d784ecd1194f23f82f6b1c1acbf1d5982bab63362d094710638d2b770dc/"
-    note: "Morpho market 0xa94d7d784ecd1194f23f82f6b1c1acbf1d5982bab63362d094710638d2b770dc used by Waterline infiniFi USDC"
+    note: "Morpho market 0xa94d7d784ecd1194f23f82f6b1c1acbf1d5982bab63362d094710638d2b770dc"
 # END GENERATED MORPHO MARKET NODES
 
 edges:

--- a/reports/graph/infinifi.yaml
+++ b/reports/graph/infinifi.yaml
@@ -215,6 +215,16 @@ nodes:
     category: dependency
     morphoVault: v1
 
+  # MetaMorpho vault governance (Waterline owner / Steakhouse curator)
+  - id: dep-steakhouse-owner
+    label: MetaMorpho Owner (5-of-8)
+    address: "0xd6086925EABDA100409Da2adaDFDea08EAB1081A"
+    category: governance
+  - id: dep-steakhouse-curator
+    label: MetaMorpho Curator (2-of-7)
+    address: "0xC5fA35a7DA6798211d4AcD6b1D36F2f3E8c6dBdB"
+    category: governance
+
 # BEGIN GENERATED MORPHO MARKET NODES
 # Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
   - id: morpho-market-bbf7ce1b40d3
@@ -392,6 +402,16 @@ edges:
   - from: farm-steakhouse
     to: dep-steakhouse-vault
     kind: deposits-into
+
+  # MetaMorpho vault governance
+  - from: dep-steakhouse-owner
+    to: dep-steakhouse-vault
+    kind: holds-role
+    label: "owner"
+  - from: dep-steakhouse-curator
+    to: dep-steakhouse-vault
+    kind: holds-role
+    label: "curator"
 
 # BEGIN GENERATED MORPHO MARKET EDGES
 # Managed by scripts/update_morpho_graph_markets.mjs — do not edit.

--- a/reports/graph/infinifi.yaml
+++ b/reports/graph/infinifi.yaml
@@ -213,6 +213,26 @@ nodes:
     label: Steakhouse infiniFi USDC (MetaMorpho)
     address: "0xBEEF1f5bD88285E5b239B6AACB991D38CCa23aC9"
     category: dependency
+    morphoVault: v1
+
+# BEGIN GENERATED MORPHO MARKET NODES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - id: morpho-market-bbf7ce1b40d3
+    label: "siUSD/USDC · 91.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99/"
+    note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99 used by Waterline infiniFi USDC"
+  - id: morpho-market-6df56abb95e9
+    label: "iUSD/USDC · 91.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x6df56abb95e9f3f96049448e1c98d208deb1add8a3d0c7a23e5e5466dba4edbd/"
+    note: "Morpho market 0x6df56abb95e9f3f96049448e1c98d208deb1add8a3d0c7a23e5e5466dba4edbd used by Waterline infiniFi USDC"
+  - id: morpho-market-a94d7d784ecd
+    label: "PT-siUSD-20AUG2026/USDC · 91.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xa94d7d784ecd1194f23f82f6b1c1acbf1d5982bab63362d094710638d2b770dc/"
+    note: "Morpho market 0xa94d7d784ecd1194f23f82f6b1c1acbf1d5982bab63362d094710638d2b770dc used by Waterline infiniFi USDC"
+# END GENERATED MORPHO MARKET NODES
 
 edges:
   # === Governance ===
@@ -372,3 +392,19 @@ edges:
   - from: farm-steakhouse
     to: dep-steakhouse-vault
     kind: deposits-into
+
+# BEGIN GENERATED MORPHO MARKET EDGES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - from: dep-steakhouse-vault
+    to: morpho-market-bbf7ce1b40d3
+    kind: deposits-into
+    label: "99.4%"
+  - from: dep-steakhouse-vault
+    to: morpho-market-6df56abb95e9
+    kind: deposits-into
+    label: "0.5%"
+  - from: dep-steakhouse-vault
+    to: morpho-market-a94d7d784ecd
+    kind: deposits-into
+    label: "<0.1%"
+# END GENERATED MORPHO MARKET EDGES

--- a/reports/graph/infinifi.yaml
+++ b/reports/graph/infinifi.yaml
@@ -214,6 +214,7 @@ nodes:
     address: "0xBEEF1f5bD88285E5b239B6AACB991D38CCa23aC9"
     category: dependency
     morphoVault: v1
+    link: "https://app.morpho.org/ethereum/vault/0xBEEF1f5bD88285E5b239B6AACB991D38CCa23aC9/"
 
   # MetaMorpho vault governance (Waterline owner / Steakhouse curator)
   - id: dep-steakhouse-owner

--- a/reports/graph/origin-arm.yaml
+++ b/reports/graph/origin-arm.yaml
@@ -77,6 +77,7 @@ nodes:
     label: WETH ARM Morpho Vault (Yearn-curated)
     address: "0x3Dfe70B05657949A5dB340754aD664810ac63b21"
     category: dependency
+    morphoVault: v1
     note: MetaMorpho v1.1; idle WETH lending
 
   # === Secondary liquidity ===
@@ -85,6 +86,25 @@ nodes:
     address: "0x95753095f15870acc0cb0ed224478ea61aeb0b8e"
     category: dependency
     note: ~$222K TVL secondary exit venue
+
+# BEGIN GENERATED MORPHO MARKET NODES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - id: morpho-market-37e7484d642d
+    label: "weETH/WETH · 94.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x37e7484d642d90f14451f1910ba4b7b8e4c3ccdd0ec28f8b2bdb35479e472ba7/"
+    note: "Morpho market 0x37e7484d642d90f14451f1910ba4b7b8e4c3ccdd0ec28f8b2bdb35479e472ba7 used by WETH ARM Vault"
+  - id: morpho-market-b8fc70e82bc5
+    label: "wstETH/WETH · 96.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e/"
+    note: "Morpho market 0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e used by WETH ARM Vault"
+  - id: morpho-market-d0e50cdac92f
+    label: "wstETH/WETH · 94.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d/"
+    note: "Morpho market 0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d used by WETH ARM Vault"
+# END GENERATED MORPHO MARKET NODES
 
 edges:
   # === Governance flow: xOGN → Origin Gov → Timelock → ARM ===
@@ -148,3 +168,19 @@ edges:
     to: curve-pool
     kind: routes-through
     label: secondary DEX exit
+
+# BEGIN GENERATED MORPHO MARKET EDGES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - from: morpho-vault
+    to: morpho-market-37e7484d642d
+    kind: deposits-into
+    label: "42.1%"
+  - from: morpho-vault
+    to: morpho-market-b8fc70e82bc5
+    kind: deposits-into
+    label: "41.5%"
+  - from: morpho-vault
+    to: morpho-market-d0e50cdac92f
+    kind: deposits-into
+    label: "16.3%"
+# END GENERATED MORPHO MARKET EDGES

--- a/reports/graph/origin-arm.yaml
+++ b/reports/graph/origin-arm.yaml
@@ -78,6 +78,7 @@ nodes:
     address: "0x3Dfe70B05657949A5dB340754aD664810ac63b21"
     category: dependency
     morphoVault: v1
+    link: "https://app.morpho.org/ethereum/vault/0x3Dfe70B05657949A5dB340754aD664810ac63b21/"
     note: MetaMorpho v1.1; idle WETH lending
 
   # MetaMorpho vault governance — Yearn Security + Curator
@@ -99,11 +100,6 @@ nodes:
 
 # BEGIN GENERATED MORPHO MARKET NODES
 # Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
-  - id: morpho-market-37e7484d642d
-    label: "weETH/WETH · 94.5% LLTV"
-    category: dependency
-    link: "https://app.morpho.org/ethereum/market/0x37e7484d642d90f14451f1910ba4b7b8e4c3ccdd0ec28f8b2bdb35479e472ba7/"
-    note: "Morpho market 0x37e7484d642d90f14451f1910ba4b7b8e4c3ccdd0ec28f8b2bdb35479e472ba7 used by WETH ARM Vault"
   - id: morpho-market-b8fc70e82bc5
     label: "wstETH/WETH · 96.5% LLTV"
     category: dependency
@@ -192,15 +188,11 @@ edges:
 # BEGIN GENERATED MORPHO MARKET EDGES
 # Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
   - from: morpho-vault
-    to: morpho-market-37e7484d642d
-    kind: deposits-into
-    label: "42.1%"
-  - from: morpho-vault
     to: morpho-market-b8fc70e82bc5
     kind: deposits-into
-    label: "41.5%"
+    label: "60.5%"
   - from: morpho-vault
     to: morpho-market-d0e50cdac92f
     kind: deposits-into
-    label: "16.3%"
+    label: "39.4%"
 # END GENERATED MORPHO MARKET EDGES

--- a/reports/graph/origin-arm.yaml
+++ b/reports/graph/origin-arm.yaml
@@ -104,12 +104,12 @@ nodes:
     label: "wstETH/WETH · 96.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e/"
-    note: "Morpho market 0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e used by WETH ARM Vault"
+    note: "Morpho market 0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e"
   - id: morpho-market-d0e50cdac92f
     label: "wstETH/WETH · 94.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d/"
-    note: "Morpho market 0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d used by WETH ARM Vault"
+    note: "Morpho market 0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d"
 # END GENERATED MORPHO MARKET NODES
 
 edges:

--- a/reports/graph/origin-arm.yaml
+++ b/reports/graph/origin-arm.yaml
@@ -80,6 +80,16 @@ nodes:
     morphoVault: v1
     note: MetaMorpho v1.1; idle WETH lending
 
+  # MetaMorpho vault governance — Yearn Security + Curator
+  - id: security
+    label: Security (4-of-7)
+    address: "0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"
+    category: governance
+  - id: curator
+    label: Curator (2-of-3)
+    address: "0x90D0f26025571295D18a6c041E47450B81886B51"
+    category: governance
+
   # === Secondary liquidity ===
   - id: curve-pool
     label: Curve OETH / ARM-WETH-stETH
@@ -168,6 +178,16 @@ edges:
     to: curve-pool
     kind: routes-through
     label: secondary DEX exit
+
+  # MetaMorpho vault governance — owner (Security) + curator
+  - from: security
+    to: morpho-vault
+    kind: holds-role
+    label: "owner"
+  - from: curator
+    to: morpho-vault
+    kind: holds-role
+    label: "curator"
 
 # BEGIN GENERATED MORPHO MARKET EDGES
 # Managed by scripts/update_morpho_graph_markets.mjs — do not edit.

--- a/reports/graph/origin-ousd.yaml
+++ b/reports/graph/origin-ousd.yaml
@@ -108,6 +108,7 @@ nodes:
     label: MetaMorpho Vault mOUSD-V2
     address: "0xFB154c729A16802c4ad1E8f7FF539a8b9f49c960"
     category: dependency
+    link: "https://app.morpho.org/ethereum/vault/0xFB154c729A16802c4ad1E8f7FF539a8b9f49c960/"
     note: Largest single dependency; nested MetaMorpho adapter (not expandable)
   - id: security
     label: Security (4-of-7)

--- a/reports/graph/origin-ousd.yaml
+++ b/reports/graph/origin-ousd.yaml
@@ -108,7 +108,12 @@ nodes:
     label: MetaMorpho Vault mOUSD-V2
     address: "0xFB154c729A16802c4ad1E8f7FF539a8b9f49c960"
     category: dependency
-    note: Largest single dependency; curator 0xe5e2...98c0
+    note: Largest single dependency; nested MetaMorpho adapter (not expandable)
+  - id: security
+    label: Security (4-of-7)
+    address: "0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"
+    category: governance
+    note: Yearn Security multisig — owner + curator of the mOUSD-V2 MetaMorpho vault
   - id: curve-pool
     label: Curve OUSD/USDC Pool
     address: "0x6d18E1a7faeB1F0467A77C0d293872ab685426dc"
@@ -224,6 +229,12 @@ edges:
     to: morphousd-vault
     kind: deposits-into
     label: USDC supply
+
+  # === Morpho vault governance — Yearn Security owns + curates ===
+  - from: security
+    to: morphousd-vault
+    kind: holds-role
+    label: "owner + curator"
   - from: amo-strategy
     to: curve-gauge
     kind: deposits-into

--- a/reports/graph/yearn-yvdai.yaml
+++ b/reports/graph/yearn-yvdai.yaml
@@ -95,6 +95,7 @@ nodes:
     address: "0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3"
     category: dependency
     morphoVault: v1
+    link: "https://app.morpho.org/ethereum/vault/0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3/"
 
   # External dependencies (Sky conversion infrastructure)
   - id: psm-lite

--- a/reports/graph/yearn-yvdai.yaml
+++ b/reports/graph/yearn-yvdai.yaml
@@ -113,17 +113,17 @@ nodes:
     label: "cbBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
-    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Yearn USDC"
+    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"
   - id: morpho-market-3a85e6197511
     label: "WBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49/"
-    note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49 used by Yearn USDC"
+    note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49"
   - id: morpho-market-b323495f7e41
     label: "wstETH/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc/"
-    note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc used by Yearn USDC"
+    note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc"
 # END GENERATED MORPHO MARKET NODES
 
 edges:

--- a/reports/graph/yearn-yvdai.yaml
+++ b/reports/graph/yearn-yvdai.yaml
@@ -90,10 +90,7 @@ nodes:
     label: Yearn USDC (Morpho MetaMorpho)
     address: "0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3"
     category: dependency
-  - id: morpho-blue
-    label: Morpho Blue
-    address: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
-    category: dependency
+    morphoVault: v1
 
   # External dependencies (Sky conversion infrastructure)
   - id: psm-lite
@@ -104,6 +101,25 @@ nodes:
     label: Sky DAI ↔ USDS Exchanger
     address: "0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A"
     category: dependency
+
+# BEGIN GENERATED MORPHO MARKET NODES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - id: morpho-market-64d65c9a2d91
+    label: "cbBTC/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
+    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Yearn USDC"
+  - id: morpho-market-3a85e6197511
+    label: "WBTC/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49/"
+    note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49 used by Yearn USDC"
+  - id: morpho-market-b323495f7e41
+    label: "wstETH/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc/"
+    note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc used by Yearn USDC"
+# END GENERATED MORPHO MARKET NODES
 
 edges:
   # Deployment / vault infrastructure
@@ -198,7 +214,19 @@ edges:
     to: yearn-usdc-metamorpho
     kind: deposits-into
     label: "~8.41% via Yearn USDC"
+
+# BEGIN GENERATED MORPHO MARKET EDGES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
   - from: yearn-usdc-metamorpho
-    to: morpho-blue
+    to: morpho-market-64d65c9a2d91
     kind: deposits-into
-    label: "cbBTC, WBTC, wstETH markets"
+    label: "56.3%"
+  - from: yearn-usdc-metamorpho
+    to: morpho-market-3a85e6197511
+    kind: deposits-into
+    label: "36.8%"
+  - from: yearn-usdc-metamorpho
+    to: morpho-market-b323495f7e41
+    kind: deposits-into
+    label: "6.7%"
+# END GENERATED MORPHO MARKET EDGES

--- a/reports/graph/yearn-yvdai.yaml
+++ b/reports/graph/yearn-yvdai.yaml
@@ -42,6 +42,10 @@ nodes:
     label: Security (4-of-7)
     address: "0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"
     category: governance
+  - id: curator
+    label: Curator (2-of-3)
+    address: "0x90D0f26025571295D18a6c041E47450B81886B51"
+    category: governance
   - id: timelock
     label: Strategy Manager (7-day Timelock)
     address: "0x88Ba032be87d5EF1fbE87336b7090767F367BF73"
@@ -214,6 +218,16 @@ edges:
     to: yearn-usdc-metamorpho
     kind: deposits-into
     label: "~8.41% via Yearn USDC"
+
+  # MetaMorpho vault governance — owner (Security) + curator
+  - from: security
+    to: yearn-usdc-metamorpho
+    kind: holds-role
+    label: "owner"
+  - from: curator
+    to: yearn-usdc-metamorpho
+    kind: holds-role
+    label: "curator"
 
 # BEGIN GENERATED MORPHO MARKET EDGES
 # Managed by scripts/update_morpho_graph_markets.mjs — do not edit.

--- a/reports/graph/yearn-yvusd.yaml
+++ b/reports/graph/yearn-yvusd.yaml
@@ -181,11 +181,6 @@ nodes:
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89/"
     note: "Morpho market 0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89 used by Yearn OG USDC"
-  - id: morpho-market-64d65c9a2d91
-    label: "cbBTC/USDC · 86% LLTV"
-    category: dependency
-    link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
-    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Yearn OG USDC"
   - id: morpho-market-bbf7ce1b40d3
     label: "siUSD/USDC · 91.5% LLTV"
     category: dependency
@@ -201,16 +196,16 @@ nodes:
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83/"
     note: "Morpho market 0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83 used by Yearn OG USDC"
-  - id: morpho-market-61765602144e
-    label: "weETH/USDC · 86% LLTV"
-    category: dependency
-    link: "https://app.morpho.org/ethereum/market/0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664/"
-    note: "Morpho market 0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664 used by Yearn OG USDC"
   - id: morpho-market-ad656d430bb3
     label: "WOUSD/USDC · 91.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc/"
     note: "Morpho market 0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc used by Yearn OG USDC"
+  - id: morpho-market-61765602144e
+    label: "weETH/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664/"
+    note: "Morpho market 0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664 used by Yearn OG USDC"
 # END GENERATED MORPHO MARKET NODES
 
 edges:
@@ -393,33 +388,29 @@ edges:
   - from: morpho-v1-og-vault
     to: morpho-market-e3df58f9d301
     kind: deposits-into
-    label: "17.2%"
+    label: "35.3%"
   - from: morpho-v1-og-vault
     to: morpho-market-f8c5aa31ea6b
     kind: deposits-into
-    label: "16.9%"
-  - from: morpho-v1-og-vault
-    to: morpho-market-64d65c9a2d91
-    kind: deposits-into
-    label: "13.6%"
+    label: "15.9%"
   - from: morpho-v1-og-vault
     to: morpho-market-bbf7ce1b40d3
     kind: deposits-into
-    label: "9.4%"
+    label: "7.9%"
   - from: morpho-v1-og-vault
     to: morpho-market-bf02d6c6852f
     kind: deposits-into
-    label: "2.2%"
+    label: "1.0%"
   - from: morpho-v1-og-vault
     to: morpho-market-973e9dd45799
     kind: deposits-into
-    label: "1.1%"
-  - from: morpho-v1-og-vault
-    to: morpho-market-61765602144e
-    kind: deposits-into
-    label: "0.4%"
+    label: "0.7%"
   - from: morpho-v1-og-vault
     to: morpho-market-ad656d430bb3
+    kind: deposits-into
+    label: "0.1%"
+  - from: morpho-v1-og-vault
+    to: morpho-market-61765602144e
     kind: deposits-into
     label: "0.1%"
 # END GENERATED MORPHO MARKET EDGES

--- a/reports/graph/yearn-yvusd.yaml
+++ b/reports/graph/yearn-yvusd.yaml
@@ -113,6 +113,7 @@ nodes:
     address: "0xF9bdDd4A9b3A45f980e11fDDE96e16364dDBEc49"
     category: dependency
     morphoVault: v1
+    link: "https://app.morpho.org/ethereum/vault/0xF9bdDd4A9b3A45f980e11fDDE96e16364dDBEc49/"
     note: Yearn-curated Morpho V1 vault; low-mid risk (internal score 2.7). 62.4% concentration — largest single point of failure
   - id: morpho-protocol
     label: Morpho Protocol (lending base)
@@ -170,46 +171,46 @@ nodes:
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xb8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e/"
     note: "Morpho market 0xb8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e used by Yearn OG USDC"
-  - id: morpho-market-f8c5aa31ea6b
-    label: "PT-USD3-17DEC2026/USDC · 86% LLTV"
-    category: dependency
-    link: "https://app.morpho.org/ethereum/market/0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89/"
-    note: "Morpho market 0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89 used by Yearn OG USDC"
   - id: morpho-market-e3df58f9d301
     label: "USD3/USDC · 91.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xe3df58f9d3011b7481ff36b939fa5f8da642f34ea5792d25d3958dbf1efa26d7/"
     note: "Morpho market 0xe3df58f9d3011b7481ff36b939fa5f8da642f34ea5792d25d3958dbf1efa26d7 used by Yearn OG USDC"
-  - id: morpho-market-bbf7ce1b40d3
-    label: "siUSD/USDC · 91.5% LLTV"
+  - id: morpho-market-f8c5aa31ea6b
+    label: "PT-USD3-17DEC2026/USDC · 86% LLTV"
     category: dependency
-    link: "https://app.morpho.org/ethereum/market/0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99/"
-    note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99 used by Yearn OG USDC"
+    link: "https://app.morpho.org/ethereum/market/0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89/"
+    note: "Morpho market 0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89 used by Yearn OG USDC"
   - id: morpho-market-64d65c9a2d91
     label: "cbBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
     note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Yearn OG USDC"
-  - id: morpho-market-973e9dd45799
-    label: "YFI/USDC · 77% LLTV"
+  - id: morpho-market-bbf7ce1b40d3
+    label: "siUSD/USDC · 91.5% LLTV"
     category: dependency
-    link: "https://app.morpho.org/ethereum/market/0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83/"
-    note: "Morpho market 0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83 used by Yearn OG USDC"
+    link: "https://app.morpho.org/ethereum/market/0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99/"
+    note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99 used by Yearn OG USDC"
   - id: morpho-market-bf02d6c6852f
     label: "LBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0/"
     note: "Morpho market 0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0 used by Yearn OG USDC"
-  - id: morpho-market-ad656d430bb3
-    label: "WOUSD/USDC · 91.5% LLTV"
+  - id: morpho-market-973e9dd45799
+    label: "YFI/USDC · 77% LLTV"
     category: dependency
-    link: "https://app.morpho.org/ethereum/market/0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc/"
-    note: "Morpho market 0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc used by Yearn OG USDC"
+    link: "https://app.morpho.org/ethereum/market/0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83/"
+    note: "Morpho market 0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83 used by Yearn OG USDC"
   - id: morpho-market-61765602144e
     label: "weETH/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664/"
     note: "Morpho market 0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664 used by Yearn OG USDC"
+  - id: morpho-market-ad656d430bb3
+    label: "WOUSD/USDC · 91.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc/"
+    note: "Morpho market 0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc used by Yearn OG USDC"
 # END GENERATED MORPHO MARKET NODES
 
 edges:
@@ -388,37 +389,37 @@ edges:
   - from: morpho-v1-og-vault
     to: morpho-market-b8fef900b383
     kind: deposits-into
-    label: "38.4%"
-  - from: morpho-v1-og-vault
-    to: morpho-market-f8c5aa31ea6b
-    kind: deposits-into
-    label: "25.1%"
+    label: "38.7%"
   - from: morpho-v1-og-vault
     to: morpho-market-e3df58f9d301
     kind: deposits-into
-    label: "23.4%"
+    label: "17.2%"
   - from: morpho-v1-og-vault
-    to: morpho-market-bbf7ce1b40d3
+    to: morpho-market-f8c5aa31ea6b
     kind: deposits-into
-    label: "8.7%"
+    label: "16.9%"
   - from: morpho-v1-og-vault
     to: morpho-market-64d65c9a2d91
     kind: deposits-into
-    label: "2.6%"
+    label: "13.6%"
   - from: morpho-v1-og-vault
-    to: morpho-market-973e9dd45799
+    to: morpho-market-bbf7ce1b40d3
     kind: deposits-into
-    label: "0.9%"
+    label: "9.4%"
   - from: morpho-v1-og-vault
     to: morpho-market-bf02d6c6852f
     kind: deposits-into
-    label: "0.5%"
+    label: "2.2%"
+  - from: morpho-v1-og-vault
+    to: morpho-market-973e9dd45799
+    kind: deposits-into
+    label: "1.1%"
+  - from: morpho-v1-og-vault
+    to: morpho-market-61765602144e
+    kind: deposits-into
+    label: "0.4%"
   - from: morpho-v1-og-vault
     to: morpho-market-ad656d430bb3
     kind: deposits-into
     label: "0.1%"
-  - from: morpho-v1-og-vault
-    to: morpho-market-61765602144e
-    kind: deposits-into
-    label: "<0.1%"
 # END GENERATED MORPHO MARKET EDGES

--- a/reports/graph/yearn-yvusd.yaml
+++ b/reports/graph/yearn-yvusd.yaml
@@ -170,42 +170,42 @@ nodes:
     label: "OETH/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xb8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e/"
-    note: "Morpho market 0xb8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e used by Yearn OG USDC"
+    note: "Morpho market 0xb8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e"
   - id: morpho-market-e3df58f9d301
     label: "USD3/USDC · 91.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xe3df58f9d3011b7481ff36b939fa5f8da642f34ea5792d25d3958dbf1efa26d7/"
-    note: "Morpho market 0xe3df58f9d3011b7481ff36b939fa5f8da642f34ea5792d25d3958dbf1efa26d7 used by Yearn OG USDC"
+    note: "Morpho market 0xe3df58f9d3011b7481ff36b939fa5f8da642f34ea5792d25d3958dbf1efa26d7"
   - id: morpho-market-f8c5aa31ea6b
     label: "PT-USD3-17DEC2026/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89/"
-    note: "Morpho market 0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89 used by Yearn OG USDC"
+    note: "Morpho market 0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89"
   - id: morpho-market-bbf7ce1b40d3
     label: "siUSD/USDC · 91.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99/"
-    note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99 used by Yearn OG USDC"
+    note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99"
   - id: morpho-market-bf02d6c6852f
     label: "LBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0/"
-    note: "Morpho market 0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0 used by Yearn OG USDC"
+    note: "Morpho market 0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0"
   - id: morpho-market-973e9dd45799
     label: "YFI/USDC · 77% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83/"
-    note: "Morpho market 0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83 used by Yearn OG USDC"
+    note: "Morpho market 0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83"
   - id: morpho-market-ad656d430bb3
     label: "WOUSD/USDC · 91.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc/"
-    note: "Morpho market 0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc used by Yearn OG USDC"
+    note: "Morpho market 0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc"
   - id: morpho-market-61765602144e
     label: "weETH/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664/"
-    note: "Morpho market 0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664 used by Yearn OG USDC"
+    note: "Morpho market 0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664"
 # END GENERATED MORPHO MARKET NODES
 
 edges:

--- a/reports/graph/yearn-yvusd.yaml
+++ b/reports/graph/yearn-yvusd.yaml
@@ -108,6 +108,7 @@ nodes:
     label: Morpho V1 Yearn OG USDC Vault
     address: "0xF9bdDd4A9b3A45f980e11fDDE96e16364dDBEc49"
     category: dependency
+    morphoVault: v1
     note: Yearn-curated Morpho V1 vault; low-mid risk (internal score 2.7). 62.4% concentration — largest single point of failure
   - id: morpho-protocol
     label: Morpho Protocol (lending base)
@@ -157,6 +158,55 @@ nodes:
     chain: katana
     category: dependency
     note: Young (2025) L2; remote Yearn yvUSDC vault destination
+
+# BEGIN GENERATED MORPHO MARKET NODES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - id: morpho-market-b8fef900b383
+    label: "OETH/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xb8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e/"
+    note: "Morpho market 0xb8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e used by Yearn OG USDC"
+  - id: morpho-market-f8c5aa31ea6b
+    label: "PT-USD3-17DEC2026/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89/"
+    note: "Morpho market 0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89 used by Yearn OG USDC"
+  - id: morpho-market-e3df58f9d301
+    label: "USD3/USDC · 91.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xe3df58f9d3011b7481ff36b939fa5f8da642f34ea5792d25d3958dbf1efa26d7/"
+    note: "Morpho market 0xe3df58f9d3011b7481ff36b939fa5f8da642f34ea5792d25d3958dbf1efa26d7 used by Yearn OG USDC"
+  - id: morpho-market-bbf7ce1b40d3
+    label: "siUSD/USDC · 91.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99/"
+    note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99 used by Yearn OG USDC"
+  - id: morpho-market-64d65c9a2d91
+    label: "cbBTC/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
+    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Yearn OG USDC"
+  - id: morpho-market-973e9dd45799
+    label: "YFI/USDC · 77% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83/"
+    note: "Morpho market 0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83 used by Yearn OG USDC"
+  - id: morpho-market-bf02d6c6852f
+    label: "LBTC/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0/"
+    note: "Morpho market 0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0 used by Yearn OG USDC"
+  - id: morpho-market-ad656d430bb3
+    label: "WOUSD/USDC · 91.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc/"
+    note: "Morpho market 0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc used by Yearn OG USDC"
+  - id: morpho-market-61765602144e
+    label: "weETH/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664/"
+    note: "Morpho market 0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664 used by Yearn OG USDC"
+# END GENERATED MORPHO MARKET NODES
 
 edges:
   # Vault / accountant wiring
@@ -318,3 +368,43 @@ edges:
     to: threejane-usd3
     kind: routes-through
     label: "underlying"
+
+# BEGIN GENERATED MORPHO MARKET EDGES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - from: morpho-v1-og-vault
+    to: morpho-market-b8fef900b383
+    kind: deposits-into
+    label: "38.4%"
+  - from: morpho-v1-og-vault
+    to: morpho-market-f8c5aa31ea6b
+    kind: deposits-into
+    label: "25.1%"
+  - from: morpho-v1-og-vault
+    to: morpho-market-e3df58f9d301
+    kind: deposits-into
+    label: "23.4%"
+  - from: morpho-v1-og-vault
+    to: morpho-market-bbf7ce1b40d3
+    kind: deposits-into
+    label: "8.7%"
+  - from: morpho-v1-og-vault
+    to: morpho-market-64d65c9a2d91
+    kind: deposits-into
+    label: "2.6%"
+  - from: morpho-v1-og-vault
+    to: morpho-market-973e9dd45799
+    kind: deposits-into
+    label: "0.9%"
+  - from: morpho-v1-og-vault
+    to: morpho-market-bf02d6c6852f
+    kind: deposits-into
+    label: "0.5%"
+  - from: morpho-v1-og-vault
+    to: morpho-market-ad656d430bb3
+    kind: deposits-into
+    label: "0.1%"
+  - from: morpho-v1-og-vault
+    to: morpho-market-61765602144e
+    kind: deposits-into
+    label: "<0.1%"
+# END GENERATED MORPHO MARKET EDGES

--- a/reports/graph/yearn-yvusd.yaml
+++ b/reports/graph/yearn-yvusd.yaml
@@ -46,6 +46,10 @@ nodes:
     label: Security (4-of-7)
     address: "0xe5e2BAf96198c56380DDd5e992D7d1adA0E989C0"
     category: governance
+  - id: curator
+    label: Curator (2-of-3)
+    address: "0x90D0f26025571295D18a6c041E47450B81886B51"
+    category: governance
   - id: timelock
     label: Strategy Manager (7-day Timelock)
     address: "0x88ba032be87d5eF1FbE87336b7090767f367bF73"
@@ -319,6 +323,16 @@ edges:
   - from: morpho-v1-og-vault
     to: morpho-protocol
     kind: routes-through
+
+  # MetaMorpho vault governance — owner (Security) + curator
+  - from: security
+    to: morpho-v1-og-vault
+    kind: holds-role
+    label: "owner"
+  - from: curator
+    to: morpho-v1-og-vault
+    kind: holds-role
+    label: "curator"
 
   - from: katana-yvusdc
     to: vault-bridge-token

--- a/reports/graph/yearn-yvusdc.yaml
+++ b/reports/graph/yearn-yvusdc.yaml
@@ -128,17 +128,17 @@ nodes:
     label: "cbBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
-    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Yearn USDC"
+    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"
   - id: morpho-market-3a85e6197511
     label: "WBTC/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49/"
-    note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49 used by Yearn USDC"
+    note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49"
   - id: morpho-market-b323495f7e41
     label: "wstETH/USDC · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc/"
-    note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc used by Yearn USDC"
+    note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc"
 # END GENERATED MORPHO MARKET NODES
 
 edges:

--- a/reports/graph/yearn-yvusdc.yaml
+++ b/reports/graph/yearn-yvusdc.yaml
@@ -117,7 +117,7 @@ nodes:
     category: dependency
     note: Sky sub-DAO; admin keys live under Sky governance
   - id: morpho-curator
-    label: Morpho Curator (Yearn Ops)
+    label: Curator (2-of-3)
     address: "0x90D0f26025571295D18a6c041E47450B81886B51"
     category: governance
 

--- a/reports/graph/yearn-yvusdc.yaml
+++ b/reports/graph/yearn-yvusdc.yaml
@@ -75,6 +75,7 @@ nodes:
     address: "0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3"
     category: strategy
     morphoVault: v1
+    link: "https://app.morpho.org/ethereum/vault/0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3/"
   - id: pawn-broker
     label: stcUSD/USDC Pawn Broker (14.9%, not in queue, self-contained)
     address: "0xe63a2abc24cd9538398d825a4bfe5778d25687df"

--- a/reports/graph/yearn-yvusdc.yaml
+++ b/reports/graph/yearn-yvusdc.yaml
@@ -74,6 +74,7 @@ nodes:
     label: Yearn USDC — Morpho (7.2%)
     address: "0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3"
     category: strategy
+    morphoVault: v1
   - id: pawn-broker
     label: stcUSD/USDC Pawn Broker (14.9%, not in queue, self-contained)
     address: "0xe63a2abc24cd9538398d825a4bfe5778d25687df"
@@ -101,10 +102,6 @@ nodes:
     label: Sky DAI ↔ USDS Exchanger
     address: "0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A"
     category: dependency
-  - id: morpho-blue
-    label: Morpho Blue
-    address: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
-    category: dependency
   - id: stcUSD
     label: stcUSD — Cap (ERC-4626)
     address: "0x88887bE419578051FF9F4eb6C858A951921D8888"
@@ -123,6 +120,25 @@ nodes:
     label: Morpho Curator (Yearn Ops)
     address: "0x90D0f26025571295D18a6c041E47450B81886B51"
     category: governance
+
+# BEGIN GENERATED MORPHO MARKET NODES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - id: morpho-market-64d65c9a2d91
+    label: "cbBTC/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
+    note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Yearn USDC"
+  - id: morpho-market-3a85e6197511
+    label: "WBTC/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49/"
+    note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49 used by Yearn USDC"
+  - id: morpho-market-b323495f7e41
+    label: "wstETH/USDC · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc/"
+    note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc used by Yearn USDC"
+# END GENERATED MORPHO MARKET NODES
 
 edges:
   # Deployment / vault infrastructure
@@ -221,10 +237,6 @@ edges:
   - from: usds-depositor
     to: dai-usds-exchanger
     kind: routes-through
-  - from: yearn-usdc
-    to: morpho-blue
-    kind: deposits-into
-    label: "USDC supply (MetaMorpho)"
   - from: pawn-broker
     to: stcUSD
     kind: deposits-into
@@ -251,3 +263,19 @@ edges:
     to: yearn-usdc
     kind: holds-role
     label: "Curator"
+
+# BEGIN GENERATED MORPHO MARKET EDGES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - from: yearn-usdc
+    to: morpho-market-64d65c9a2d91
+    kind: deposits-into
+    label: "56.3%"
+  - from: yearn-usdc
+    to: morpho-market-3a85e6197511
+    kind: deposits-into
+    label: "36.8%"
+  - from: yearn-usdc
+    to: morpho-market-b323495f7e41
+    kind: deposits-into
+    label: "6.7%"
+# END GENERATED MORPHO MARKET EDGES

--- a/reports/graph/yearn-yvusdt.yaml
+++ b/reports/graph/yearn-yvusdt.yaml
@@ -42,6 +42,10 @@ nodes:
     label: Security (4-of-7)
     address: "0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"
     category: governance
+  - id: curator
+    label: Curator (2-of-3)
+    address: "0x90D0f26025571295D18a6c041E47450B81886B51"
+    category: governance
   - id: timelock
     label: Strategy Manager (7-day Timelock)
     address: "0x88Ba032be87d5EF1fbE87336b7090767F367BF73"
@@ -161,6 +165,10 @@ edges:
     to: metamorpo-usdt
     kind: controls
     label: "MetaMorpho owner"
+  - from: curator
+    to: metamorpo-usdt
+    kind: holds-role
+    label: "curator"
 
   # Role manager wiring
   - from: daddy

--- a/reports/graph/yearn-yvusdt.yaml
+++ b/reports/graph/yearn-yvusdt.yaml
@@ -79,6 +79,7 @@ nodes:
     address: "0x0963232eB842BAF53E8e517691f81745C1F228a0"
     category: strategy
     morphoVault: v1
+    link: "https://app.morpho.org/ethereum/vault/0x0963232eB842BAF53E8e517691f81745C1F228a0/"
 
   # External dependencies
   - id: spark-lend-usdt

--- a/reports/graph/yearn-yvusdt.yaml
+++ b/reports/graph/yearn-yvusdt.yaml
@@ -94,22 +94,22 @@ nodes:
     label: "WBTC/USDT · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xa921ef34e2fc7a27ccc50ae7e4b154e16c9799d3387076c421423ef52ac4df99/"
-    note: "Morpho market 0xa921ef34e2fc7a27ccc50ae7e4b154e16c9799d3387076c421423ef52ac4df99 used by Yearn USDT"
+    note: "Morpho market 0xa921ef34e2fc7a27ccc50ae7e4b154e16c9799d3387076c421423ef52ac4df99"
   - id: morpho-market-e7e9694b754c
     label: "wstETH/USDT · 86% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xe7e9694b754c4d4f7e21faf7223f6fa71abaeb10296a4c43a54a7977149687d2/"
-    note: "Morpho market 0xe7e9694b754c4d4f7e21faf7223f6fa71abaeb10296a4c43a54a7977149687d2 used by Yearn USDT"
+    note: "Morpho market 0xe7e9694b754c4d4f7e21faf7223f6fa71abaeb10296a4c43a54a7977149687d2"
   - id: morpho-market-3274643db77a
     label: "sUSDS/USDT · 96.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x3274643db77a064abd3bc851de77556a4ad2e2f502f4f0c80845fa8f909ecf0b/"
-    note: "Morpho market 0x3274643db77a064abd3bc851de77556a4ad2e2f502f4f0c80845fa8f909ecf0b used by Yearn USDT"
+    note: "Morpho market 0x3274643db77a064abd3bc851de77556a4ad2e2f502f4f0c80845fa8f909ecf0b"
   - id: morpho-market-b7843fe78e7e
     label: "XAUt/USDT · 77% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xb7843fe78e7e7fd3106a1b939645367967d1f986c2e45edb8932ad1896450877/"
-    note: "Morpho market 0xb7843fe78e7e7fd3106a1b939645367967d1f986c2e45edb8932ad1896450877 used by Yearn USDT"
+    note: "Morpho market 0xb7843fe78e7e7fd3106a1b939645367967d1f986c2e45edb8932ad1896450877"
 # END GENERATED MORPHO MARKET NODES
 
 edges:

--- a/reports/graph/yearn-yvusdt.yaml
+++ b/reports/graph/yearn-yvusdt.yaml
@@ -74,6 +74,7 @@ nodes:
     label: MetaMorpho Vault (ymv-USDT) (43.94%)
     address: "0x0963232eB842BAF53E8e517691f81745C1F228a0"
     category: strategy
+    morphoVault: v1
 
   # External dependencies
   - id: spark-lend-usdt
@@ -81,10 +82,30 @@ nodes:
     address: "0xC13e21B648A5Ee794902342038FF3aDAB66BE987"
     category: dependency
     note: Sky sub-DAO; admin keys live under Sky governance
-  - id: morpho
-    label: Morpho Protocol
-    address: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
+
+# BEGIN GENERATED MORPHO MARKET NODES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - id: morpho-market-a921ef34e2fc
+    label: "WBTC/USDT · 86% LLTV"
     category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xa921ef34e2fc7a27ccc50ae7e4b154e16c9799d3387076c421423ef52ac4df99/"
+    note: "Morpho market 0xa921ef34e2fc7a27ccc50ae7e4b154e16c9799d3387076c421423ef52ac4df99 used by Yearn USDT"
+  - id: morpho-market-e7e9694b754c
+    label: "wstETH/USDT · 86% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xe7e9694b754c4d4f7e21faf7223f6fa71abaeb10296a4c43a54a7977149687d2/"
+    note: "Morpho market 0xe7e9694b754c4d4f7e21faf7223f6fa71abaeb10296a4c43a54a7977149687d2 used by Yearn USDT"
+  - id: morpho-market-3274643db77a
+    label: "sUSDS/USDT · 96.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0x3274643db77a064abd3bc851de77556a4ad2e2f502f4f0c80845fa8f909ecf0b/"
+    note: "Morpho market 0x3274643db77a064abd3bc851de77556a4ad2e2f502f4f0c80845fa8f909ecf0b used by Yearn USDT"
+  - id: morpho-market-b7843fe78e7e
+    label: "XAUt/USDT · 77% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xb7843fe78e7e7fd3106a1b939645367967d1f986c2e45edb8932ad1896450877/"
+    note: "Morpho market 0xb7843fe78e7e7fd3106a1b939645367967d1f986c2e45edb8932ad1896450877 used by Yearn USDT"
+# END GENERATED MORPHO MARKET NODES
 
 edges:
   # Deployment / vault infrastructure
@@ -167,7 +188,23 @@ edges:
     to: spark-lend-usdt
     kind: deposits-into
     label: "USDT supply"
+
+# BEGIN GENERATED MORPHO MARKET EDGES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
   - from: metamorpo-usdt
-    to: morpho
+    to: morpho-market-a921ef34e2fc
     kind: deposits-into
-    label: "USDT deposit"
+    label: "67.2%"
+  - from: metamorpo-usdt
+    to: morpho-market-e7e9694b754c
+    kind: deposits-into
+    label: "23.5%"
+  - from: metamorpo-usdt
+    to: morpho-market-3274643db77a
+    kind: deposits-into
+    label: "5.8%"
+  - from: metamorpo-usdt
+    to: morpho-market-b7843fe78e7e
+    kind: deposits-into
+    label: "3.3%"
+# END GENERATED MORPHO MARKET EDGES

--- a/reports/graph/yearn-yvwbtc.yaml
+++ b/reports/graph/yearn-yvwbtc.yaml
@@ -34,6 +34,7 @@ nodes:
     label: ymv-WBTC (MetaMorpho)
     address: "0x2bB005127069A0F0325Fb7370967E8A2b64FB77E"
     category: strategy
+    morphoVault: v1
     note: "Immutable MetaMorpho V1_1 ERC-4626 vault. Owner: Security 4-of-7 / Guardian: ySafe 6-of-9 / Curator: 2-of-3 Safe. Fee: 0%, 3-day curator timelock."
 
   # Governance
@@ -81,22 +82,25 @@ nodes:
     label: WBTC (BitGo-custodied)
     address: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
     category: dependency
-    note: Underlying asset for vault and Morpho Blue loan token
-  - id: morpho-blue
-    label: Morpho Blue
-    address: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
+    note: Underlying asset for vault and Morpho market loan token
+
+# BEGIN GENERATED MORPHO MARKET NODES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - id: morpho-idle-wbtc
+    label: "Idle WBTC"
     category: dependency
-    note: Immutable lending primitive (v1). Holds 100% of strategy TVL (82% idle market, 18% WBTC/LBTC market).
-  - id: lbtc
-    label: LBTC (Lombard BTC)
-    address: "0x8236a87084f8B84306f72007F36F2618A5634494"
+    note: "Idle WBTC held in Yearn WBTC"
+  - id: morpho-market-f6a056627a51
+    label: "LBTC/WBTC · 94.5% LLTV"
     category: dependency
-    note: Collateral token in active WBTC/LBTC market (94.5% LLTV)
-  - id: cbbtc
-    label: cbBTC (Coinbase BTC)
-    address: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+    link: "https://app.morpho.org/ethereum/market/0xf6a056627a51e511ec7f48332421432ea6971fc148d8f3c451e14ea108026549/"
+    note: "Morpho market 0xf6a056627a51e511ec7f48332421432ea6971fc148d8f3c451e14ea108026549 used by Yearn WBTC"
+  - id: morpho-market-39d6cc9211d0
+    label: "cbBTC/WBTC · 94.5% LLTV"
     category: dependency
-    note: Collateral token in queued WBTC/cbBTC market (no current position)
+    link: "https://app.morpho.org/ethereum/market/0x39d6cc9211d023cc16708a2378d821d394d8cfaa3640e3a4d4638d292e10035d/"
+    note: "Morpho market 0x39d6cc9211d023cc16708a2378d821d394d8cfaa3640e3a4d4638d292e10035d used by Yearn WBTC"
+# END GENERATED MORPHO MARKET NODES
 
 edges:
   # Deployment / vault infrastructure
@@ -111,25 +115,11 @@ edges:
     to: dumper
     kind: routes-fees-to
 
-  # Capital flow: vault → strategy → Morpho Blue
+  # Capital flow: vault → strategy → Morpho markets
   - from: yvWBTC
     to: ymv-wbtc
     kind: allocates-to
     label: "100%"
-  - from: ymv-wbtc
-    to: morpho-blue
-    kind: deposits-into
-    label: "82% idle / 18% WBTC-LBTC"
-
-  # Morpho Blue dependency chain
-  - from: morpho-blue
-    to: lbtc
-    kind: routes-through
-    label: "collateral (active)"
-  - from: morpho-blue
-    to: cbbtc
-    kind: routes-through
-    label: "collateral (queued)"
 
   # Governance roles on vault
   - from: daddy
@@ -191,3 +181,19 @@ edges:
     to: ymv-wbtc
     kind: holds-role
     label: "curator"
+
+# BEGIN GENERATED MORPHO MARKET EDGES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - from: ymv-wbtc
+    to: morpho-idle-wbtc
+    kind: deposits-into
+    label: "81.9%"
+  - from: ymv-wbtc
+    to: morpho-market-f6a056627a51
+    kind: deposits-into
+    label: "18.0%"
+  - from: ymv-wbtc
+    to: morpho-market-39d6cc9211d0
+    kind: deposits-into
+    label: "<0.1%"
+# END GENERATED MORPHO MARKET EDGES

--- a/reports/graph/yearn-yvwbtc.yaml
+++ b/reports/graph/yearn-yvwbtc.yaml
@@ -95,12 +95,12 @@ nodes:
     label: "LBTC/WBTC · 94.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xf6a056627a51e511ec7f48332421432ea6971fc148d8f3c451e14ea108026549/"
-    note: "Morpho market 0xf6a056627a51e511ec7f48332421432ea6971fc148d8f3c451e14ea108026549 used by Yearn WBTC"
+    note: "Morpho market 0xf6a056627a51e511ec7f48332421432ea6971fc148d8f3c451e14ea108026549"
   - id: morpho-market-39d6cc9211d0
     label: "cbBTC/WBTC · 94.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0x39d6cc9211d023cc16708a2378d821d394d8cfaa3640e3a4d4638d292e10035d/"
-    note: "Morpho market 0x39d6cc9211d023cc16708a2378d821d394d8cfaa3640e3a4d4638d292e10035d used by Yearn WBTC"
+    note: "Morpho market 0x39d6cc9211d023cc16708a2378d821d394d8cfaa3640e3a4d4638d292e10035d"
 # END GENERATED MORPHO MARKET NODES
 
 edges:

--- a/reports/graph/yearn-yvwbtc.yaml
+++ b/reports/graph/yearn-yvwbtc.yaml
@@ -35,6 +35,7 @@ nodes:
     address: "0x2bB005127069A0F0325Fb7370967E8A2b64FB77E"
     category: strategy
     morphoVault: v1
+    link: "https://app.morpho.org/ethereum/vault/0x2bB005127069A0F0325Fb7370967E8A2b64FB77E/"
     note: "Immutable MetaMorpho V1_1 ERC-4626 vault. Owner: Security 4-of-7 / Guardian: ySafe 6-of-9 / Curator: 2-of-3 Safe. Fee: 0%, 3-day curator timelock."
 
   # Governance

--- a/reports/graph/yearn-yvweth.yaml
+++ b/reports/graph/yearn-yvweth.yaml
@@ -240,9 +240,9 @@ edges:
   - from: yearn-og-weth
     to: morpho-market-b8fc70e82bc5
     kind: deposits-into
-    label: "94.8%"
+    label: "94.6%"
   - from: yearn-og-weth
     to: morpho-market-d0e50cdac92f
     kind: deposits-into
-    label: "5.1%"
+    label: "5.3%"
 # END GENERATED MORPHO MARKET EDGES

--- a/reports/graph/yearn-yvweth.yaml
+++ b/reports/graph/yearn-yvweth.yaml
@@ -42,6 +42,10 @@ nodes:
     label: Security (4-of-7)
     address: "0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"
     category: governance
+  - id: curator
+    label: Curator (2-of-3)
+    address: "0x90D0f26025571295D18a6c041E47450B81886B51"
+    category: governance
   - id: timelock
     label: Strategy Manager (7-day Timelock)
     address: "0x88Ba032be87d5EF1fbE87336b7090767F367BF73"
@@ -225,6 +229,10 @@ edges:
     to: yearn-og-weth
     kind: controls
     label: "owner()"
+  - from: curator
+    to: yearn-og-weth
+    kind: holds-role
+    label: "curator"
 
 # BEGIN GENERATED MORPHO MARKET EDGES
 # Managed by scripts/update_morpho_graph_markets.mjs — do not edit.

--- a/reports/graph/yearn-yvweth.yaml
+++ b/reports/graph/yearn-yvweth.yaml
@@ -88,6 +88,7 @@ nodes:
     address: "0xE89371eAaAC6D46d4C3ED23453241987916224FC"
     category: strategy
     morphoVault: v1
+    link: "https://app.morpho.org/ethereum/vault/0xE89371eAaAC6D46d4C3ED23453241987916224FC/"
     note: Morpho MetaMorpho vault — confirmed via MORPHO() returning 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb
 
   # External dependencies

--- a/reports/graph/yearn-yvweth.yaml
+++ b/reports/graph/yearn-yvweth.yaml
@@ -114,12 +114,12 @@ nodes:
     label: "wstETH/WETH · 96.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e/"
-    note: "Morpho market 0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e used by Yearn OG WETH"
+    note: "Morpho market 0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e"
   - id: morpho-market-d0e50cdac92f
     label: "wstETH/WETH · 94.5% LLTV"
     category: dependency
     link: "https://app.morpho.org/ethereum/market/0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d/"
-    note: "Morpho market 0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d used by Yearn OG WETH"
+    note: "Morpho market 0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d"
 # END GENERATED MORPHO MARKET NODES
 
 edges:

--- a/reports/graph/yearn-yvweth.yaml
+++ b/reports/graph/yearn-yvweth.yaml
@@ -83,6 +83,7 @@ nodes:
     label: Yearn OG WETH (2.2% / 9.1% effective)
     address: "0xE89371eAaAC6D46d4C3ED23453241987916224FC"
     category: strategy
+    morphoVault: v1
     note: Morpho MetaMorpho vault — confirmed via MORPHO() returning 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb
 
   # External dependencies
@@ -101,10 +102,20 @@ nodes:
   - id: spark-lend
     label: Spark Lend WETH Market (Sky)
     category: dependency
-  - id: morpho
-    label: Morpho Lending Markets
-    address: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
+
+# BEGIN GENERATED MORPHO MARKET NODES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - id: morpho-market-b8fc70e82bc5
+    label: "wstETH/WETH · 96.5% LLTV"
     category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e/"
+    note: "Morpho market 0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e used by Yearn OG WETH"
+  - id: morpho-market-d0e50cdac92f
+    label: "wstETH/WETH · 94.5% LLTV"
+    category: dependency
+    link: "https://app.morpho.org/ethereum/market/0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d/"
+    note: "Morpho market 0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d used by Yearn OG WETH"
+# END GENERATED MORPHO MARKET NODES
 
 edges:
   # Deployment / vault infrastructure
@@ -209,12 +220,20 @@ edges:
     to: lido-steth
     kind: routes-through
     label: "WETH → wstETH (collateral)"
-  - from: yearn-og-weth
-    to: morpho
-    kind: deposits-into
-    label: "WETH → Morpho lending (atomic)"
   # Security multisig owns the Yearn OG WETH MetaMorpho vault contract
   - from: security
     to: yearn-og-weth
     kind: controls
     label: "owner()"
+
+# BEGIN GENERATED MORPHO MARKET EDGES
+# Managed by scripts/update_morpho_graph_markets.mjs — do not edit.
+  - from: yearn-og-weth
+    to: morpho-market-b8fc70e82bc5
+    kind: deposits-into
+    label: "94.8%"
+  - from: yearn-og-weth
+    to: morpho-market-d0e50cdac92f
+    kind: deposits-into
+    label: "5.1%"
+# END GENERATED MORPHO MARKET EDGES

--- a/scripts/check_graphs.mjs
+++ b/scripts/check_graphs.mjs
@@ -22,6 +22,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import yaml from "js-yaml";
+import { MORPHO_CHAINS, GENERATED_NODE_PREFIX } from "./update_morpho_graph_markets.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const GRAPH_DIR = path.join(ROOT, "reports", "graph");
@@ -130,6 +131,29 @@ export function findGraphIssues(graphs, reportSlugs) {
         add("warn", slug, `nodes '${seenAddr.get(key)}' and '${n.id}' share address ${n.address}`);
       } else {
         seenAddr.set(key, n.id);
+      }
+    }
+
+    // Morpho vault tagging: the tag is the only signal the updater expands on,
+    // so its invariants are linted here (mirrors src/lib/graph.ts validation).
+    for (const n of nodes) {
+      if (n.morphoVault !== undefined && n.morphoVault !== "v1" && n.morphoVault !== "v2") {
+        add("error", slug, `node '${n.id}' has invalid morphoVault '${n.morphoVault}' (expected "v1" or "v2")`);
+      }
+      if (n.morphoVault !== undefined && !n.address) {
+        add("error", slug, `node '${n.id}' is tagged morphoVault but has no address`);
+      }
+      if (n.morphoVault !== undefined && String(n.id).startsWith(GENERATED_NODE_PREFIX)) {
+        add("error", slug, `generated Morpho market node '${n.id}' must not carry morphoVault`);
+      }
+      if (n.morphoVault !== undefined) {
+        const chain = String(n.chain ?? graph.chain ?? "ethereum").toLowerCase();
+        if (!MORPHO_CHAINS.has(chain)) {
+          add("error", slug, `node '${n.id}' is tagged morphoVault on unsupported chain '${chain}'`);
+        }
+      }
+      if (n.link !== undefined && !/^https:\/\//.test(n.link)) {
+        add("error", slug, `node '${n.id}' has a non-https link '${n.link}'`);
       }
     }
 

--- a/scripts/update_morpho_graph_markets.mjs
+++ b/scripts/update_morpho_graph_markets.mjs
@@ -40,6 +40,9 @@ const USER_AGENT = "yearn-risk-score-graph-updater/1.0 (+https://github.com/year
 export const MORPHO_CHAIN_SEGMENTS = { ethereum: "ethereum", base: "base" };
 export const MORPHO_CHAINS = new Set(Object.keys(MORPHO_CHAIN_SEGMENTS));
 
+/** Chain id used by the Morpho GraphQL `chainId_in` filter. */
+export const MORPHO_CHAIN_IDS = { ethereum: 1, base: 8453 };
+
 export const NODES_START = "# BEGIN GENERATED MORPHO MARKET NODES";
 export const NODES_END = "# END GENERATED MORPHO MARKET NODES";
 export const EDGES_START = "# BEGIN GENERATED MORPHO MARKET EDGES";
@@ -162,6 +165,9 @@ export function marketNodeId(marketId, usedIds) {
 export function buildAllocations(vault, usedIds) {
   const { totalAssets, assetSymbol, name } = vault;
   const items = [];
+  // Markets that share a collateral/loan pair and LLTV would render identical
+  // cards; track the base label and append a shortened market id on collision.
+  const usedLabels = new Set();
 
   for (const alloc of vault.allocations ?? []) {
     // Include every allocation with positive supplied assets — even when the
@@ -190,7 +196,13 @@ export function buildAllocations(vault, usedIds) {
 
     const pair = `${alloc.collateralSymbol}/${alloc.loanSymbol}`;
     const lltv = formatLltv(alloc.lltv);
-    const display = `${pair} · ${lltv} LLTV`;
+    const base = `${pair} · ${lltv} LLTV`;
+    let display = base;
+    if (usedLabels.has(base)) {
+      const short = String(alloc.marketId).replace(/^0x/, "").slice(0, 12);
+      display = `${base} · 0x${short}`;
+    }
+    usedLabels.add(base);
 
     items.push({
       id: marketNodeId(alloc.marketId, usedIds),
@@ -414,8 +426,8 @@ function truncate(text) {
 }
 
 const V1_QUERY = `
-query MorphoV1Allocations($addresses: [String!]!) {
-  vaults(first: 50, where: { address_in: $addresses }) {
+query MorphoV1Allocations($addresses: [String!]!, $chainIds: [Int!]!) {
+  vaults(first: 50, where: { address_in: $addresses, chainId_in: $chainIds }) {
     items {
       address
       name
@@ -439,8 +451,8 @@ query MorphoV1Allocations($addresses: [String!]!) {
 `;
 
 const V2_QUERY = `
-query MorphoV2Allocations($addresses: [String!]!) {
-  vaultV2s(first: 10, where: { address_in: $addresses }) {
+query MorphoV2Allocations($addresses: [String!]!, $chainIds: [Int!]!) {
+  vaultV2s(first: 10, where: { address_in: $addresses, chainId_in: $chainIds }) {
     items {
       address
       name
@@ -483,8 +495,18 @@ function missingVaultError(version, chain, address) {
 }
 
 export function parseV1Items(items, queries, chain) {
+  const expectedChainId = MORPHO_CHAIN_IDS[String(chain).toLowerCase()];
   const byAddress = new Map();
   for (const item of items ?? []) {
+    const returnedChainId = item.chain?.id;
+    if (
+      expectedChainId !== undefined &&
+      returnedChainId !== undefined &&
+      Number(returnedChainId) !== expectedChainId
+    )
+      throw new Error(
+        `Vault ${item.address} returned chain id ${returnedChainId}, expected ${expectedChainId} (${chain})`,
+      );
     const addr = String(item.address).toLowerCase();
     const totalAssets = toBigInt(item.state?.totalAssets, `${addr} totalAssets`);
     const allocations = (item.state?.allocation ?? []).map((a) => ({
@@ -512,8 +534,18 @@ export function parseV1Items(items, queries, chain) {
 }
 
 export function parseV2Items(items, queries, chain) {
+  const expectedChainId = MORPHO_CHAIN_IDS[String(chain).toLowerCase()];
   const byAddress = new Map();
   for (const item of items ?? []) {
+    const returnedChainId = item.chain?.id;
+    if (
+      expectedChainId !== undefined &&
+      returnedChainId !== undefined &&
+      Number(returnedChainId) !== expectedChainId
+    )
+      throw new Error(
+        `Vault V2 ${item.address} returned chain id ${returnedChainId}, expected ${expectedChainId} (${chain})`,
+      );
     const addr = String(item.address).toLowerCase();
     const totalAssets = toBigInt(item.totalAssets, `${addr} totalAssets`);
     const idleAssets = toBigInt(item.idleAssets, `${addr} idleAssets`);
@@ -593,9 +625,10 @@ function batch(addresses, size) {
 export async function fetchV1(queries, fetchFn) {
   const result = new Map();
   for (const [chain, qs] of groupByChain(queries)) {
+    const chainIds = [MORPHO_CHAIN_IDS[chain]];
     for (const chunk of batch(qs, 5)) {
       const addresses = chunk.map((q) => q.address.toLowerCase());
-      const data = await postGraphql(V1_QUERY, { addresses }, fetchFn);
+      const data = await postGraphql(V1_QUERY, { addresses, chainIds }, fetchFn);
       const parsed = parseV1Items(data.vaults?.items, chunk, chain);
       for (const [addr, vault] of parsed) result.set(`v1:${chain}:${addr}`, vault);
     }
@@ -606,9 +639,10 @@ export async function fetchV1(queries, fetchFn) {
 export async function fetchV2(queries, fetchFn) {
   const result = new Map();
   for (const [chain, qs] of groupByChain(queries)) {
+    const chainIds = [MORPHO_CHAIN_IDS[chain]];
     for (const chunk of batch(qs, 1)) {
       const addresses = chunk.map((q) => q.address.toLowerCase());
-      const data = await postGraphql(V2_QUERY, { addresses }, fetchFn);
+      const data = await postGraphql(V2_QUERY, { addresses, chainIds }, fetchFn);
       const parsed = parseV2Items(data.vaultV2s?.items, chunk, chain);
       for (const [addr, vault] of parsed) result.set(`v2:${chain}:${addr}`, vault);
     }
@@ -698,8 +732,9 @@ async function main() {
     bySlug.get(occ.slug).push(occ);
   }
 
-  let changed = 0;
-  let unchanged = 0;
+  // Phase 1: compute every resulting graph in memory. Any failure here throws
+  // before a single file is touched, so `--write` is all-or-nothing.
+  const results = [];
   for (const { slug, text } of graphs) {
     const occ = bySlug.get(slug);
     if (!occ) continue;
@@ -709,18 +744,28 @@ async function main() {
       allocByKey,
     );
     const next = applySections(text, marketNodes, edges);
-    if (next === text) {
+    results.push({ slug, next, dirty: next !== text, marketNodes, edges });
+  }
+
+  // Phase 2: report, and only after every graph has been computed, write.
+  let changed = 0;
+  let unchanged = 0;
+  for (const r of results) {
+    if (!r.dirty) {
       unchanged++;
-      console.log(`  [unchanged] ${slug} (${marketNodes.length} market nodes, ${edges.length} edges)`);
-      continue;
-    }
-    changed++;
-    if (write) {
-      const file = path.join(GRAPH_DIR, `${slug}.yaml`);
-      fs.writeFileSync(file, next);
-      console.log(`  [written  ] ${slug} (${marketNodes.length} market nodes, ${edges.length} edges)`);
+      console.log(`  [unchanged] ${r.slug} (${r.marketNodes.length} market nodes, ${r.edges.length} edges)`);
+    } else if (write) {
+      changed++;
+      console.log(`  [written  ] ${r.slug} (${r.marketNodes.length} market nodes, ${r.edges.length} edges)`);
     } else {
-      console.log(`  [stale    ] ${slug} (${marketNodes.length} market nodes, ${edges.length} edges)`);
+      changed++;
+      console.log(`  [stale    ] ${r.slug} (${r.marketNodes.length} market nodes, ${r.edges.length} edges)`);
+    }
+  }
+
+  if (write) {
+    for (const r of results) {
+      if (r.dirty) fs.writeFileSync(path.join(GRAPH_DIR, `${r.slug}.yaml`), r.next);
     }
   }
 

--- a/scripts/update_morpho_graph_markets.mjs
+++ b/scripts/update_morpho_graph_markets.mjs
@@ -1,0 +1,750 @@
+#!/usr/bin/env node
+/**
+ * Expand explicitly tagged Morpho vault nodes in dependency-graph YAML into
+ * their current underlying market allocations, fetched from the Morpho GraphQL
+ * API.
+ *
+ * A vault node is expanded only when it carries an explicit `morphoVault: v1`
+ * or `morphoVault: v2` tag (never inferred from labels, IDs, notes, or address
+ * probing). The tag also names the API collection to query, so a deployed
+ * vault's immutable generation is recorded once in reviewed YAML rather than
+ * probed on every run.
+ *
+ * Generated content is written into two marker-delimited sections so that
+ * hand-authored YAML — comments, formatting, everything outside the markers —
+ * is preserved byte-for-byte. Reruns replace only the managed regions.
+ *
+ * Usage:
+ *   node scripts/update_morpho_graph_markets.mjs [--write] [--graph <slug>]...
+ *
+ *   Without --write the script runs in check mode: it fetches and computes the
+ *   generated sections, prints which graphs would change, and exits non-zero
+ *   when any managed content is stale. --write applies the changes. --graph
+ *   restricts the run to one or more graph slugs (repeatable); the default is
+ *   every graph in reports/graph/.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const GRAPH_DIR = path.join(ROOT, "reports", "graph");
+
+export const MORPHO_API_URL = "https://api.morpho.org/graphql";
+export const MORPHO_APP_URL = "https://app.morpho.org";
+const USER_AGENT = "yearn-risk-score-graph-updater/1.0 (+https://github.com/yearn/risk-score)";
+
+/** Chains for which a Morpho app market URL can be built. */
+export const MORPHO_CHAIN_SEGMENTS = { ethereum: "ethereum", base: "base" };
+export const MORPHO_CHAINS = new Set(Object.keys(MORPHO_CHAIN_SEGMENTS));
+
+export const NODES_START = "# BEGIN GENERATED MORPHO MARKET NODES";
+export const NODES_END = "# END GENERATED MORPHO MARKET NODES";
+export const EDGES_START = "# BEGIN GENERATED MORPHO MARKET EDGES";
+export const EDGES_END = "# END GENERATED MORPHO MARKET EDGES";
+
+/** Prefix used for generated market-node IDs; validated against in graph.ts. */
+export const GENERATED_NODE_PREFIX = "morpho-market-";
+
+// The API serializes integer scalars as JSON numbers when the value is a safe
+// integer and as decimal strings otherwise (e.g. 18-decimal assets), so every
+// integer field must be normalised through BigInt.
+function toBigInt(value, context) {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "string") {
+    const t = value.trim();
+    if (t === "") return 0n;
+    if (!/^\d+$/.test(t)) throw new Error(`${context}: non-integer string ${JSON.stringify(value)}`);
+    return BigInt(t);
+  }
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value))
+      throw new Error(`${context}: unsafe numeric value ${value}; expected a string from the API`);
+    return BigInt(value);
+  }
+  if (value === null || value === undefined) return 0n;
+  throw new Error(`${context}: unsupported value ${JSON.stringify(value)}`);
+}
+
+export function morphoChainSegment(chain) {
+  return MORPHO_CHAIN_SEGMENTS[String(chain).toLowerCase()];
+}
+
+export function morphoMarketUrl(chain, marketId) {
+  const segment = morphoChainSegment(chain);
+  if (!segment) throw new Error(`unsupported Morpho chain '${chain}' (expected one of: ${[...MORPHO_CHAINS].join(", ")})`);
+  return `${MORPHO_APP_URL}/${segment}/market/${marketId}/`;
+}
+
+/**
+ * Format a WAD-scaled LLTV (1e18 = 100%) as a human percentage, trimming the
+ * trailing zero from a single decimal place: 860000000000000000 → "86%",
+ * 945000000000000000 → "94.5%".
+ */
+export function formatLltv(lltv) {
+  const bp = toBigInt(lltv, "lltv") / 100000000000000n; // 1e18 / 1e4 basis points
+  const whole = bp / 100n;
+  const frac = bp % 100n;
+  let out = String(whole);
+  if (frac > 0n) {
+    const trimmed = String(frac).padStart(2, "0").replace(/0+$/, "");
+    if (trimmed) out += `.${trimmed}`;
+  }
+  return `${out}%`;
+}
+
+/**
+ * Allocation share as a percentage string, computed in raw underlying units.
+ * Returns null for exactly zero supply. Values below 0.1% are kept (not
+ * rounded to 0) and labelled "<0.1%".
+ */
+export function allocationLabel(supply, total) {
+  if (total <= 0n) throw new Error("allocationLabel: totalAssets must be positive");
+  if (supply <= 0n) return null;
+  const tenths = (supply * 1000n) / total;
+  if (tenths === 0n) return "<0.1%";
+  return `${tenths / 10n}.${tenths % 10n}%`;
+}
+
+/* ------------------------------------------------------------------ planning */
+
+/**
+ * Find every node tagged `morphoVault` across the parsed graphs. Each
+ * occurrence keeps its graph/node identity so one fetched allocation can be
+ * rendered into every graph that references the vault.
+ *
+ * @returns {{occurrences: Array, queries: Array}}
+ */
+export function findMorphoVaults(graphs) {
+  const occurrences = [];
+  const querySet = new Map(); // key -> query, preserving first-seen order
+  for (const { slug, graph } of graphs) {
+    for (const node of graph.nodes ?? []) {
+      if (node.morphoVault !== "v1" && node.morphoVault !== "v2") continue;
+      const version = node.morphoVault;
+      const address = node.address;
+      const chain = String(node.chain ?? graph.chain ?? "ethereum").toLowerCase();
+      if (!address)
+        throw new Error(`[${slug}] node '${node.id}' is tagged morphoVault:${version} but has no address`);
+      if (!MORPHO_CHAINS.has(chain))
+        throw new Error(`[${slug}] node '${node.id}' uses unsupported Morpho chain '${chain}'`);
+      const key = `${version}:${chain}:${address.toLowerCase()}`;
+      if (!querySet.has(key)) querySet.set(key, { version, chain, address });
+      occurrences.push({ slug, nodeId: node.id, version, chain, address, nodeLabel: node.label });
+    }
+  }
+  return { occurrences, queries: [...querySet.values()] };
+}
+
+/**
+ * Turn a 32-byte market ID into a deterministic, collision-free node ID. Uses
+ * at least 12 hex characters and extends until unique against `usedIds`.
+ */
+export function marketNodeId(marketId, usedIds) {
+  const hex = String(marketId).replace(/^0x/, "");
+  if (!/^[0-9a-f]{12,64}$/i.test(hex))
+    throw new Error(`marketNodeId: marketId is not a 32-byte hex identifier: ${marketId}`);
+  for (let len = 12; len <= hex.length; len++) {
+    const id = `${GENERATED_NODE_PREFIX}${hex.slice(0, len).toLowerCase()}`;
+    if (!usedIds.has(id)) return id;
+  }
+  throw new Error(`marketNodeId: cannot find a unique id for marketId ${marketId}`);
+}
+
+/**
+ * Build the sorted set of allocations for one vault, computing percentage
+ * labels in raw units and sorting markets by allocation descending then market
+ * ID ascending. Idle assets (null collateral) are kept as a synthetic
+ * allocation so displayed shares reconcile to 100%.
+ */
+export function buildAllocations(vault, usedIds) {
+  const { totalAssets, assetSymbol, name } = vault;
+  const items = [];
+  const usedLabels = new Set();
+
+  for (const alloc of vault.allocations ?? []) {
+    // Include every allocation with positive supplied assets — even when the
+    // market's current supply cap is zero, the vault remains exposed until the
+    // assets are withdrawn, so the position still counts toward risk. Supply
+    // caps are deliberately not consulted here.
+    if (alloc.supplyAssets <= 0n) continue;
+    const label = allocationLabel(alloc.supplyAssets, totalAssets);
+    if (label === null) continue;
+
+    if (!alloc.collateralSymbol) {
+      // Idle assets are not a lending market: no Morpho link, but they must be
+      // shown for the allocations to reconcile.
+      const id = uniqueBaseId(`morpho-idle-${slugify(assetSymbol)}`, usedIds);
+      items.push({
+        id,
+        marketId: null,
+        label: `Idle ${assetSymbol}`,
+        note: `Idle ${assetSymbol} held in ${name}`,
+        link: null,
+        pct: label,
+        supplyAssets: alloc.supplyAssets,
+      });
+      continue;
+    }
+
+    const pair = `${alloc.collateralSymbol}/${alloc.loanSymbol}`;
+    const lltv = formatLltv(alloc.lltv);
+    const base = `${pair} · ${lltv} LLTV`;
+    let display = base;
+    if (usedLabels.has(base)) {
+      const short = String(alloc.marketId).replace(/^0x/, "").slice(0, 12);
+      display = `${base} · 0x${short}`;
+    }
+    usedLabels.add(base);
+
+    items.push({
+      id: marketNodeId(alloc.marketId, usedIds),
+      marketId: alloc.marketId,
+      label: display,
+      note: `Morpho market ${alloc.marketId} used by ${name}`,
+      link: morphoMarketUrl(vault.chain, alloc.marketId),
+      pct: label,
+      supplyAssets: alloc.supplyAssets,
+    });
+  }
+
+  items.sort((a, b) => {
+    if (a.supplyAssets !== b.supplyAssets)
+      return a.supplyAssets > b.supplyAssets ? -1 : 1;
+    const am = a.marketId ?? "";
+    const bm = b.marketId ?? "";
+    return am < bm ? -1 : am > bm ? 1 : 0;
+  });
+  return items;
+}
+
+function slugify(value) {
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "asset";
+}
+
+function uniqueBaseId(base, usedIds) {
+  let id = base;
+  let n = 2;
+  while (usedIds.has(id)) id = `${base}-${n++}`;
+  usedIds.add(id);
+  return id;
+}
+
+function isGeneratedId(id) {
+  const s = String(id);
+  return s.startsWith(GENERATED_NODE_PREFIX) || s.startsWith("morpho-idle-");
+}
+
+/**
+ * Build the generated node/edge lists for one graph. Vaults are processed in
+ * graph/node order; a market seen from two vaults in the same graph becomes a
+ * single node with one edge per vault.
+ */
+export function buildGraphSections(graph, occurrences, allocByKey) {
+  // Collision base is hand-authored nodes only: the generated nodes from a
+  // previous run live inside the managed region and are replaced wholesale, so
+  // they must not shift this run's ID derivation (otherwise the output would
+  // not be idempotent).
+  const usedIds = new Set(
+    (graph.nodes ?? []).filter((n) => !isGeneratedId(n.id)).map((n) => n.id),
+  );
+  const marketNodes = [];
+  const edges = [];
+  const seenMarket = new Map(); // marketId -> node id
+
+  for (const occ of occurrences) {
+    const key = `${occ.version}:${occ.chain}:${occ.address.toLowerCase()}`;
+    const vault = allocByKey.get(key);
+    if (!vault) continue;
+    const items = buildAllocations(vault, usedIds);
+    for (const item of items) {
+      const nodeKey = item.marketId ?? `idle:${vault.chain}:${vault.address.toLowerCase()}`;
+      let nodeId = seenMarket.get(nodeKey);
+      if (!nodeId) {
+        nodeId = item.id;
+        seenMarket.set(nodeKey, nodeId);
+        marketNodes.push({
+          id: item.id,
+          label: item.label,
+          category: "dependency",
+          link: item.link,
+          note: item.note,
+        });
+      }
+      edges.push({ from: occ.nodeId, to: nodeId, kind: "deposits-into", label: item.pct });
+    }
+  }
+
+  return { marketNodes, edges };
+}
+
+/* ---------------------------------------------------------------- rendering */
+
+function yamlScalar(value) {
+  // Notes and labels are quoted in the generated blocks; keep the quotes
+  // consistent and always safe by JSON-stringifying (valid YAML for scalars).
+  return JSON.stringify(value);
+}
+
+function renderNode(node) {
+  const lines = [`  - id: ${node.id}`];
+  lines.push(`    label: ${yamlScalar(node.label)}`);
+  lines.push(`    category: ${node.category}`);
+  if (node.link) lines.push(`    link: ${yamlScalar(node.link)}`);
+  if (node.note) lines.push(`    note: ${yamlScalar(node.note)}`);
+  return lines;
+}
+
+function renderEdge(edge) {
+  const lines = [`  - from: ${edge.from}`];
+  lines.push(`    to: ${edge.to}`);
+  lines.push(`    kind: ${edge.kind}`);
+  lines.push(`    label: ${yamlScalar(edge.label)}`);
+  return lines;
+}
+
+export function renderNodesBlock(marketNodes) {
+  const lines = [NODES_START, "# Managed by scripts/update_morpho_graph_markets.mjs — do not edit."];
+  for (const node of marketNodes) lines.push(...renderNode(node));
+  lines.push(NODES_END);
+  return lines;
+}
+
+export function renderEdgesBlock(edges) {
+  const lines = [EDGES_START, "# Managed by scripts/update_morpho_graph_markets.mjs — do not edit."];
+  for (const edge of edges) lines.push(...renderEdge(edge));
+  lines.push(EDGES_END);
+  return lines;
+}
+
+/** Replace content between two marker lines; returns null when absent. */
+export function replaceManagedSection(text, start, end, blockLines) {
+  const lines = text.split("\n");
+  let startIdx = -1;
+  let endIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === start) startIdx = i;
+    if (startIdx !== -1 && lines[i].trim() === end) {
+      endIdx = i;
+      break;
+    }
+  }
+  if (startIdx === -1 || endIdx === -1) return null;
+  const replaced = [...lines.slice(0, startIdx), ...blockLines, ...lines.slice(endIdx + 1)];
+  return replaced.join("\n");
+}
+
+function insertBlockBefore(lines, targetLine, blockLines) {
+  const idx = lines.findIndex((l) => l.trim() === targetLine);
+  if (idx === -1) throw new Error(`insertBlockBefore: target line ${JSON.stringify(targetLine)} not found`);
+  let insert = [...blockLines];
+  if (idx > 0 && lines[idx - 1].trim() !== "") insert = ["", ...insert];
+  insert = [...insert, ""];
+  return [...lines.slice(0, idx), ...insert, ...lines.slice(idx)].join("\n");
+}
+
+function appendBlockAtEnd(lines, blockLines) {
+  let insert = [...blockLines];
+  if (lines[lines.length - 1] !== "") insert = ["", ...insert];
+  return [...lines, ...insert, ""].join("\n");
+}
+
+/**
+ * Apply generated node/edge blocks to a graph file's text. Preserves every
+ * byte outside the managed regions; a rerun with unchanged data is a no-op.
+ */
+export function applySections(text, marketNodes, edges) {
+  const nodesBlock = renderNodesBlock(marketNodes);
+  const edgesBlock = renderEdgesBlock(edges);
+
+  let result = replaceManagedSection(text, NODES_START, NODES_END, nodesBlock);
+  if (result === null) result = insertBlockBefore(text.split("\n"), "edges:", nodesBlock);
+
+  const withNodes = result;
+  result = replaceManagedSection(result, EDGES_START, EDGES_END, edgesBlock);
+  if (result === null) result = appendBlockAtEnd(withNodes.split("\n"), edgesBlock);
+
+  return result;
+}
+
+/* ---------------------------------------------------------------- API fetch */
+
+export async function postGraphql(query, variables, fetchFn = fetch) {
+  let response;
+  try {
+    response = await fetchFn(MORPHO_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "User-Agent": USER_AGENT,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+  } catch (err) {
+    throw new Error(`Morpho API request failed: ${err.message}`);
+  }
+
+  let text;
+  try {
+    text = await response.text();
+  } catch (err) {
+    throw new Error(`failed to read Morpho API response: ${err.message}`);
+  }
+
+  if (!response.ok)
+    throw new Error(`Morpho API returned HTTP ${response.status}: ${truncate(text)}`);
+
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new Error(`Morpho API returned invalid JSON (HTTP ${response.status})`);
+  }
+
+  if (payload?.errors?.length)
+    throw new Error(`Morpho GraphQL errors: ${JSON.stringify(payload.errors)}`);
+  if (!payload?.data || typeof payload.data !== "object")
+    throw new Error("Morpho GraphQL response contained no data");
+
+  return payload.data;
+}
+
+function truncate(text) {
+  const s = String(text ?? "");
+  return s.length > 400 ? `${s.slice(0, 400)}…` : s;
+}
+
+const V1_QUERY = `
+query MorphoV1Allocations($addresses: [String!]!) {
+  vaults(first: 50, where: { address_in: $addresses }) {
+    items {
+      address
+      name
+      chain { id }
+      asset { symbol }
+      state {
+        totalAssets
+        allocation {
+          supplyAssets
+          market {
+            marketId
+            lltv
+            loanAsset { symbol }
+            collateralAsset { symbol }
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+const V2_QUERY = `
+query MorphoV2Allocations($addresses: [String!]!) {
+  vaultV2s(first: 10, where: { address_in: $addresses }) {
+    items {
+      address
+      name
+      chain { id }
+      asset { symbol }
+      totalAssets
+      idleAssets
+      adapters(first: 3) {
+        items {
+          address
+          type
+          ... on MorphoMarketV1Adapter {
+            positions(first: 20) {
+              items {
+                state { supplyAssets }
+                market {
+                  marketId
+                  lltv
+                  loanAsset { symbol }
+                  collateralAsset { symbol }
+                }
+              }
+              pageInfo { countTotal count limit skip }
+            }
+          }
+        }
+        pageInfo { countTotal count limit skip }
+      }
+    }
+  }
+}
+`;
+
+function missingVaultError(version, chain, address) {
+  return (
+    `Morpho API returned no ${version === "v1" ? "vaults" : "vaultV2s"} entry for ` +
+    `${address} on ${chain} — the address is not a Morpho Vault ${version === "v1" ? "V1" : "V2"} ` +
+    `contract, or the morphoVault tag is wrong. Check the tag (and chain) on the node.`
+  );
+}
+
+export function parseV1Items(items, queries, chain) {
+  const byAddress = new Map();
+  for (const item of items ?? []) {
+    const addr = String(item.address).toLowerCase();
+    const totalAssets = toBigInt(item.state?.totalAssets, `${addr} totalAssets`);
+    const allocations = (item.state?.allocation ?? []).map((a) => ({
+      supplyAssets: toBigInt(a.supplyAssets, `${addr} supplyAssets`),
+      marketId: a.market?.marketId ?? null,
+      lltv: a.market?.lltv ?? null,
+      loanSymbol: a.market?.loanAsset?.symbol ?? null,
+      collateralSymbol: a.market?.collateralAsset?.symbol ?? null,
+    }));
+    byAddress.set(addr, {
+      version: "v1",
+      chain,
+      address: item.address,
+      name: item.name || item.address,
+      assetSymbol: item.asset?.symbol ?? "asset",
+      totalAssets,
+      allocations,
+    });
+  }
+  for (const q of queries) {
+    if (!byAddress.has(q.address.toLowerCase()))
+      throw new Error(missingVaultError("v1", q.chain, q.address));
+  }
+  return byAddress;
+}
+
+export function parseV2Items(items, queries, chain) {
+  const byAddress = new Map();
+  for (const item of items ?? []) {
+    const addr = String(item.address).toLowerCase();
+    const totalAssets = toBigInt(item.totalAssets, `${addr} totalAssets`);
+    const idleAssets = toBigInt(item.idleAssets, `${addr} idleAssets`);
+    const adapters = item.adapters ?? {};
+    const adapterPage = adapters.pageInfo ?? {};
+    if (adapterPage.count !== undefined && adapterPage.limit !== undefined && adapterPage.count >= adapterPage.limit)
+      throw new Error(
+        `Vault V2 ${item.address} returned ${adapterPage.count} adapters (page limit ${adapterPage.limit}); raise the limit or implement pagination`,
+      );
+
+    const allocations = [];
+    for (const adapter of adapters.items ?? []) {
+      const type = adapter.type;
+      if (type !== "MorphoMarketV1Adapter" && type !== "MorphoMarketV1")
+        throw new Error(
+          `Vault V2 ${item.address} uses unsupported adapter ${JSON.stringify(type)} at ${adapter.address}`,
+        );
+      const positions = adapter.positions ?? {};
+      const posPage = positions.pageInfo ?? {};
+      if (posPage.count !== undefined && posPage.limit !== undefined && posPage.count >= posPage.limit)
+        throw new Error(
+          `Vault V2 ${item.address} adapter ${adapter.address} returned ${posPage.count} positions (page limit ${posPage.limit}); raise the limit or implement pagination`,
+        );
+      for (const position of positions.items ?? []) {
+        allocations.push({
+          supplyAssets: toBigInt(position.state?.supplyAssets, `${addr} position supplyAssets`),
+          marketId: position.market?.marketId ?? null,
+          lltv: position.market?.lltv ?? null,
+          loanSymbol: position.market?.loanAsset?.symbol ?? null,
+          collateralSymbol: position.market?.collateralAsset?.symbol ?? null,
+        });
+      }
+    }
+
+    if (idleAssets > 0n) {
+      allocations.push({
+        supplyAssets: idleAssets,
+        marketId: null,
+        lltv: null,
+        loanSymbol: null,
+        collateralSymbol: null,
+      });
+    }
+
+    byAddress.set(addr, {
+      version: "v2",
+      chain,
+      address: item.address,
+      name: item.name || item.address,
+      assetSymbol: item.asset?.symbol ?? "asset",
+      totalAssets,
+      allocations,
+    });
+  }
+  for (const q of queries) {
+    if (!byAddress.has(q.address.toLowerCase()))
+      throw new Error(missingVaultError("v2", q.chain, q.address));
+  }
+  return byAddress;
+}
+
+function groupByChain(queries) {
+  const grouped = new Map();
+  for (const q of queries) {
+    if (!grouped.has(q.chain)) grouped.set(q.chain, []);
+    grouped.get(q.chain).push(q);
+  }
+  return grouped;
+}
+
+function batch(addresses, size) {
+  const out = [];
+  for (let i = 0; i < addresses.length; i += size) out.push(addresses.slice(i, i + size));
+  return out;
+}
+
+export async function fetchV1(queries, fetchFn) {
+  const result = new Map();
+  for (const [chain, qs] of groupByChain(queries)) {
+    for (const chunk of batch(qs, 5)) {
+      const addresses = chunk.map((q) => q.address.toLowerCase());
+      const data = await postGraphql(V1_QUERY, { addresses }, fetchFn);
+      const parsed = parseV1Items(data.vaults?.items, chunk, chain);
+      for (const [addr, vault] of parsed) result.set(`v1:${chain}:${addr}`, vault);
+    }
+  }
+  return result;
+}
+
+export async function fetchV2(queries, fetchFn) {
+  const result = new Map();
+  for (const [chain, qs] of groupByChain(queries)) {
+    for (const chunk of batch(qs, 1)) {
+      const addresses = chunk.map((q) => q.address.toLowerCase());
+      const data = await postGraphql(V2_QUERY, { addresses }, fetchFn);
+      const parsed = parseV2Items(data.vaultV2s?.items, chunk, chain);
+      for (const [addr, vault] of parsed) result.set(`v2:${chain}:${addr}`, vault);
+    }
+  }
+  return result;
+}
+
+/* ------------------------------------------------------------------ driver */
+
+function loadGraphs(slugs) {
+  const files = fs.existsSync(GRAPH_DIR)
+    ? fs.readdirSync(GRAPH_DIR).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+    : [];
+  const graphs = [];
+  for (const file of files) {
+    const slug = file.replace(/\.ya?ml$/, "");
+    if (slugs && !slugs.includes(slug)) continue;
+    const text = fs.readFileSync(path.join(GRAPH_DIR, file), "utf-8");
+    const graph = yaml.load(text);
+    graphs.push({ slug, file, text, graph });
+  }
+  if (slugs) {
+    const found = new Set(graphs.map((g) => g.slug));
+    for (const slug of slugs) {
+      if (!found.has(slug))
+        throw new Error(`no graph file found for slug '${slug}'`);
+    }
+  }
+  return graphs;
+}
+
+function usage() {
+  return [
+    "Usage: node scripts/update_morpho_graph_markets.mjs [--write] [--graph <slug>]...",
+    "",
+    "  --write         apply generated sections (default: check-only, exit 1 if stale)",
+    "  --graph <slug>  restrict to one graph (repeatable); default: all graphs",
+  ].join("\n");
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.includes("--help") || argv.includes("-h")) {
+    console.log(usage());
+    return;
+  }
+  const write = argv.includes("--write");
+  const slugs = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--write") continue;
+    if (argv[i] === "--graph") {
+      if (!argv[i + 1]) {
+        console.error(`--graph requires a slug argument\n\n${usage()}`);
+        process.exit(2);
+      }
+      slugs.push(argv[i + 1]);
+      i++;
+    } else if (argv[i].startsWith("--")) {
+      console.error(`unknown option '${argv[i]}'\n\n${usage()}`);
+      process.exit(2);
+    }
+  }
+
+  const graphs = loadGraphs(slugs.length ? slugs : null);
+  const { occurrences, queries } = findMorphoVaults(graphs);
+  if (queries.length === 0) {
+    console.log("No nodes tagged morphoVault in the selected graphs — nothing to do.");
+    return;
+  }
+  console.log(`Found ${occurrences.length} tagged vault occurrence(s), ${queries.length} unique vault query(ies).`);
+
+  const v1 = queries.filter((q) => q.version === "v1");
+  const v2 = queries.filter((q) => q.version === "v2");
+  const allocByKey = new Map();
+  if (v1.length) {
+    const fetched = await fetchV1(v1, fetch);
+    for (const [k, v] of fetched) allocByKey.set(k, v);
+  }
+  if (v2.length) {
+    const fetched = await fetchV2(v2, fetch);
+    for (const [k, v] of fetched) allocByKey.set(k, v);
+  }
+
+  const bySlug = new Map();
+  for (const occ of occurrences) {
+    if (!bySlug.has(occ.slug)) bySlug.set(occ.slug, []);
+    bySlug.get(occ.slug).push(occ);
+  }
+
+  let changed = 0;
+  let unchanged = 0;
+  for (const { slug, text } of graphs) {
+    const occ = bySlug.get(slug);
+    if (!occ) continue;
+    const { marketNodes, edges } = buildGraphSections(
+      { slug, ...(yaml.load(text)) },
+      occ,
+      allocByKey,
+    );
+    const next = applySections(text, marketNodes, edges);
+    if (next === text) {
+      unchanged++;
+      console.log(`  [unchanged] ${slug} (${marketNodes.length} market nodes, ${edges.length} edges)`);
+      continue;
+    }
+    changed++;
+    if (write) {
+      const file = path.join(GRAPH_DIR, `${slug}.yaml`);
+      fs.writeFileSync(file, next);
+      console.log(`  [written  ] ${slug} (${marketNodes.length} market nodes, ${edges.length} edges)`);
+    } else {
+      console.log(`  [stale    ] ${slug} (${marketNodes.length} market nodes, ${edges.length} edges)`);
+    }
+  }
+
+  if (!write) {
+    if (changed > 0) {
+      console.error(`\n${changed} graph(s) have stale generated Morpho market sections. Re-run with --write to update.`);
+      process.exit(1);
+    }
+    console.log(`\nAll ${unchanged} graph(s) up to date.`);
+    return;
+  }
+  console.log(`\nUpdated ${changed} graph(s); ${unchanged} unchanged.`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((err) => {
+    console.error(`[update-morpho-graph-markets] ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/update_morpho_graph_markets.mjs
+++ b/scripts/update_morpho_graph_markets.mjs
@@ -162,7 +162,6 @@ export function marketNodeId(marketId, usedIds) {
 export function buildAllocations(vault, usedIds) {
   const { totalAssets, assetSymbol, name } = vault;
   const items = [];
-  const usedLabels = new Set();
 
   for (const alloc of vault.allocations ?? []) {
     // Include every allocation with positive supplied assets — even when the
@@ -191,13 +190,7 @@ export function buildAllocations(vault, usedIds) {
 
     const pair = `${alloc.collateralSymbol}/${alloc.loanSymbol}`;
     const lltv = formatLltv(alloc.lltv);
-    const base = `${pair} · ${lltv} LLTV`;
-    let display = base;
-    if (usedLabels.has(base)) {
-      const short = String(alloc.marketId).replace(/^0x/, "").slice(0, 12);
-      display = `${base} · 0x${short}`;
-    }
-    usedLabels.add(base);
+    const display = `${pair} · ${lltv} LLTV`;
 
     items.push({
       id: marketNodeId(alloc.marketId, usedIds),

--- a/scripts/update_morpho_graph_markets.mjs
+++ b/scripts/update_morpho_graph_markets.mjs
@@ -165,9 +165,6 @@ export function marketNodeId(marketId, usedIds) {
 export function buildAllocations(vault, usedIds) {
   const { totalAssets, assetSymbol, name } = vault;
   const items = [];
-  // Markets that share a collateral/loan pair and LLTV would render identical
-  // cards; track the base label and append a shortened market id on collision.
-  const usedLabels = new Set();
 
   for (const alloc of vault.allocations ?? []) {
     // Include every allocation with positive supplied assets — even when the
@@ -196,19 +193,13 @@ export function buildAllocations(vault, usedIds) {
 
     const pair = `${alloc.collateralSymbol}/${alloc.loanSymbol}`;
     const lltv = formatLltv(alloc.lltv);
-    const base = `${pair} · ${lltv} LLTV`;
-    let display = base;
-    if (usedLabels.has(base)) {
-      const short = String(alloc.marketId).replace(/^0x/, "").slice(0, 12);
-      display = `${base} · 0x${short}`;
-    }
-    usedLabels.add(base);
+    const display = `${pair} · ${lltv} LLTV`;
 
     items.push({
       id: marketNodeId(alloc.marketId, usedIds),
       marketId: alloc.marketId,
       label: display,
-      note: `Morpho market ${alloc.marketId} used by ${name}`,
+      note: `Morpho market ${alloc.marketId}`,
       link: morphoMarketUrl(vault.chain, alloc.marketId),
       pct: label,
       supplyAssets: alloc.supplyAssets,

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -19,6 +19,14 @@ export interface GraphNode {
   category: string;
   link?: string;
   note?: string;
+  /**
+   * Marks this node as a Morpho vault whose per-market allocations are
+   * expanded by `scripts/update_morpho_graph_markets.mjs`. The value records
+   * the vault contract's generation (`v1` = Morpho Vault / MetaMorpho,
+   * `v2` = Morpho Vault V2), which is immutable at a given address. Only
+   * explicitly tagged nodes are probed — never detected from labels or IDs.
+   */
+  morphoVault?: "v1" | "v2";
   /** Set at build time by expandCrossLinks; never present in YAML. */
   _inlinedFromSlug?: string;
 }
@@ -101,6 +109,26 @@ function validate(slug: string, raw: unknown): Graph {
     if (!catIds.has(n.category))
       throw new Error(
         `[graph:${slug}] node '${n.id}' has unknown category '${n.category}'`,
+      );
+    if (
+      n.morphoVault !== undefined &&
+      n.morphoVault !== "v1" &&
+      n.morphoVault !== "v2"
+    )
+      throw new Error(
+        `[graph:${slug}] node '${n.id}' has invalid morphoVault '${n.morphoVault}' (expected "v1" or "v2")`,
+      );
+    if (n.morphoVault !== undefined && !n.address)
+      throw new Error(
+        `[graph:${slug}] node '${n.id}' is tagged morphoVault but has no address`,
+      );
+    if (n.morphoVault !== undefined && n.id.startsWith("morpho-market-"))
+      throw new Error(
+        `[graph:${slug}] generated Morpho market node '${n.id}' must not carry morphoVault`,
+      );
+    if (n.link !== undefined && !/^https:\/\//.test(n.link))
+      throw new Error(
+        `[graph:${slug}] node '${n.id}' has a non-https link '${n.link}'`,
       );
   }
   for (const e of g.edges) {

--- a/src/pages/graph/[slug].astro
+++ b/src/pages/graph/[slug].astro
@@ -357,8 +357,11 @@ const heading = graphHeading(title, slug!);
       // Addressless linked nodes (Morpho markets) open a generic external
       // link, not a block explorer.
       const extLinkTitle = n.address ? "Open on block explorer" : "Open external link";
+      // `n.link` is authored YAML data (validated only for an https:// prefix),
+      // so escape it here too — the details panel already escapes it, but this
+      // card fragment interpolates it into innerHTML the same way.
       const extLinkFragment = n.link
-        ? `<a class="card-extlink" href="${n.link}" target="_blank" rel="noopener noreferrer" title="${extLinkTitle}" tabindex="-1">↗</a>`
+        ? `<a class="card-extlink" href="${escapeHtml(n.link)}" target="_blank" rel="noopener noreferrer" title="${extLinkTitle}" tabindex="-1">↗</a>`
         : "";
       const eyebrowText = n.inlinedFromSlug
         ? `${n.categoryLabel} · via ${n.inlinedFromSlug}`

--- a/src/pages/graph/[slug].astro
+++ b/src/pages/graph/[slug].astro
@@ -66,7 +66,9 @@ const cyData = {
       address: n.address ?? "",
       chain,
       chainLabel: chainLabel(chain),
-      link: n.address ? explorerUrl(n.address, chain) : "",
+      // Prefer an authored `link` (e.g. a Morpho market URL on an addressless
+      // node); fall back to the chain explorer for addressed nodes.
+      link: n.link ?? (n.address ? explorerUrl(n.address, chain) : ""),
       note: n.note ?? "",
       crossLink: crossLinks.get(n.id) ?? null,
       inlinedFromSlug: n._inlinedFromSlug ?? null,
@@ -352,8 +354,11 @@ const heading = graphHeading(title, slug!);
         : "";
       // Extended to every addressed card: the explorer used to be reachable
       // only from cross-linked cards, because plain cards hijacked the click.
+      // Addressless linked nodes (Morpho markets) open a generic external
+      // link, not a block explorer.
+      const extLinkTitle = n.address ? "Open on block explorer" : "Open external link";
       const extLinkFragment = n.link
-        ? `<a class="card-extlink" href="${n.link}" target="_blank" rel="noopener noreferrer" title="Open on block explorer" tabindex="-1">↗</a>`
+        ? `<a class="card-extlink" href="${n.link}" target="_blank" rel="noopener noreferrer" title="${extLinkTitle}" tabindex="-1">↗</a>`
         : "";
       const eyebrowText = n.inlinedFromSlug
         ? `${n.categoryLabel} · via ${n.inlinedFromSlug}`
@@ -719,7 +724,13 @@ const heading = graphHeading(title, slug!);
             </div>
             <a class="panel-link" href="${escapeHtml(n.link)}" target="_blank" rel="noopener noreferrer">Open on block explorer ↗</a>
           </div>`
-        : `<div class="panel-section"><div class="panel-note-empty">No onchain address recorded for this node.</div></div>`;
+        : n.link
+          ? `
+          <div class="panel-section">
+            <div class="panel-h">External link</div>
+            <a class="panel-link" href="${escapeHtml(n.link)}" target="_blank" rel="noopener noreferrer">Open external link ↗</a>
+          </div>`
+          : `<div class="panel-section"><div class="panel-note-empty">No onchain address recorded for this node.</div></div>`;
 
       // `note` is authored on a third of all nodes and was previously parsed,
       // shipped to the browser, and then never rendered anywhere.

--- a/src/pages/graph/[slug].astro
+++ b/src/pages/graph/[slug].astro
@@ -66,9 +66,12 @@ const cyData = {
       address: n.address ?? "",
       chain,
       chainLabel: chainLabel(chain),
-      // Prefer an authored `link` (e.g. a Morpho market URL on an addressless
-      // node); fall back to the chain explorer for addressed nodes.
-      link: n.link ?? (n.address ? explorerUrl(n.address, chain) : ""),
+      // `link` is the authored external link (e.g. a Morpho market/vault URL);
+      // `explorerLink` is the block-explorer fallback for addressed nodes.
+      // They are kept separate so a node can carry both (a Morpho vault has an
+      // EVM address *and* an app.morpho.org page).
+      link: n.link ?? "",
+      explorerLink: n.address ? explorerUrl(n.address, chain) : "",
       note: n.note ?? "",
       crossLink: crossLinks.get(n.id) ?? null,
       inlinedFromSlug: n._inlinedFromSlug ?? null,
@@ -275,6 +278,7 @@ const heading = graphHeading(title, slug!);
       chain: string;
       chainLabel: string;
       link: string;
+      explorerLink: string;
       note: string;
       crossLink: CrossLink | null;
       inlinedFromSlug: string | null;
@@ -316,6 +320,11 @@ const heading = graphHeading(title, slug!);
         .replace(/"/g, "&quot;");
     }
 
+    /** Whether an external link points at the Morpho app (market or vault). */
+    function isMorphoUrl(url: string): boolean {
+      return url.includes("app.morpho.org");
+    }
+
     /* ---------------------------------------------------------------- cards */
 
     function buildCard(n: CyNode): HTMLElement {
@@ -354,14 +363,17 @@ const heading = graphHeading(title, slug!);
         : "";
       // Extended to every addressed card: the explorer used to be reachable
       // only from cross-linked cards, because plain cards hijacked the click.
-      // Addressless linked nodes (Morpho markets) open a generic external
-      // link, not a block explorer.
-      const extLinkTitle = n.address ? "Open on block explorer" : "Open external link";
+      // Prefer an authored link (Morpho market/vault page) and fall back to
+      // the block explorer for addressed nodes.
+      const extLinkHref = n.link || n.explorerLink;
+      const extLinkTitle = n.link
+        ? (isMorphoUrl(n.link) ? "Open on Morpho" : "Open external link")
+        : "Open on block explorer";
       // `n.link` is authored YAML data (validated only for an https:// prefix),
       // so escape it here too — the details panel already escapes it, but this
       // card fragment interpolates it into innerHTML the same way.
-      const extLinkFragment = n.link
-        ? `<a class="card-extlink" href="${escapeHtml(n.link)}" target="_blank" rel="noopener noreferrer" title="${extLinkTitle}" tabindex="-1">↗</a>`
+      const extLinkFragment = extLinkHref
+        ? `<a class="card-extlink" href="${escapeHtml(extLinkHref)}" target="_blank" rel="noopener noreferrer" title="${extLinkTitle}" tabindex="-1">↗</a>`
         : "";
       const eyebrowText = n.inlinedFromSlug
         ? `${n.categoryLabel} · via ${n.inlinedFromSlug}`
@@ -717,23 +729,29 @@ const heading = graphHeading(title, slug!);
         .map(escapeHtml)
         .join(" · ");
 
-      const addressBlock = n.address
-        ? `
+      const addressBlock = (() => {
+        const explorerFragment = n.address
+          ? `
           <div class="panel-section">
             <div class="panel-h">Address</div>
             <div class="panel-addr">
               <code>${escapeHtml(n.address)}</code>
               <button class="panel-copy" type="button" data-copy="${escapeHtml(n.address)}">Copy</button>
             </div>
-            <a class="panel-link" href="${escapeHtml(n.link)}" target="_blank" rel="noopener noreferrer">Open on block explorer ↗</a>
+            <a class="panel-link" href="${escapeHtml(n.explorerLink)}" target="_blank" rel="noopener noreferrer">Open on block explorer ↗</a>
           </div>`
-        : n.link
+          : "";
+        const externalFragment = n.link
           ? `
           <div class="panel-section">
             <div class="panel-h">External link</div>
-            <a class="panel-link" href="${escapeHtml(n.link)}" target="_blank" rel="noopener noreferrer">Open external link ↗</a>
+            <a class="panel-link" href="${escapeHtml(n.link)}" target="_blank" rel="noopener noreferrer">${isMorphoUrl(n.link) ? "Open on Morpho" : "Open external link"} ↗</a>
           </div>`
+          : "";
+        return explorerFragment || externalFragment
+          ? `${explorerFragment}${externalFragment}`
           : `<div class="panel-section"><div class="panel-note-empty">No onchain address recorded for this node.</div></div>`;
+      })();
 
       // `note` is authored on a third of all nodes and was previously parsed,
       // shipped to the browser, and then never rendered anywhere.

--- a/tests/update_morpho_graph_markets.test.mjs
+++ b/tests/update_morpho_graph_markets.test.mjs
@@ -222,7 +222,7 @@ test("same pair with different LLTVs produces distinct labels", () => {
   assert.equal(items[1].label, "wstETH/WETH · 96.5% LLTV");
 });
 
-test("same pair and LLTV keeps a simple label (no market-id suffix)", () => {
+test("same pair and LLTV appends a shortened market id", () => {
   const v = vaultData({
     totalAssets: 1000n,
     allocations: [
@@ -232,9 +232,9 @@ test("same pair and LLTV keeps a simple label (no market-id suffix)", () => {
   });
   const items = buildAllocations(v, new Set());
   assert.equal(items.length, 2);
-  // Labels stay name + LLTV only; the full market id remains in `note`/`link`.
+  // First occurrence keeps the plain name + LLTV; the collision gets a suffix.
   assert.equal(items[0].label, "cbBTC/USDC · 86% LLTV");
-  assert.equal(items[1].label, "cbBTC/USDC · 86% LLTV");
+  assert.equal(items[1].label, "cbBTC/USDC · 86% LLTV · 0xbc99de6a8890");
   assert.ok(items[0].note.includes("0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"));
   assert.ok(items[1].note.includes("0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe"));
 });
@@ -382,6 +382,40 @@ test("parseV2Items fails with an actionable message on missing address", () => {
   assert.throws(
     () => parseV2Items([], [{ version: "v2", chain: "ethereum", address: "0xAAA" }], "ethereum"),
     /not a Morpho Vault V2.*Check the tag/s,
+  );
+});
+
+test("parseV1Items rejects a vault returned on the wrong chain", () => {
+  const items = [
+    {
+      address: "0xAAA",
+      name: "Vault",
+      chain: { id: 8453 }, // base — but we filtered for ethereum
+      asset: { symbol: "USDC" },
+      state: { totalAssets: 1000, allocation: [] },
+    },
+  ];
+  assert.throws(
+    () => parseV1Items(items, [{ version: "v1", chain: "ethereum", address: "0xAAA" }], "ethereum"),
+    /returned chain id 8453, expected 1/,
+  );
+});
+
+test("parseV2Items rejects a vault returned on the wrong chain", () => {
+  const items = [
+    {
+      address: "0xAAA",
+      name: "Vault",
+      chain: { id: 1 }, // ethereum — but we filtered for base
+      asset: { symbol: "USDC" },
+      totalAssets: 1000,
+      idleAssets: 0,
+      adapters: { items: [], pageInfo: { countTotal: 0, count: 0, limit: 3, skip: 0 } },
+    },
+  ];
+  assert.throws(
+    () => parseV2Items(items, [{ version: "v2", chain: "base", address: "0xAAA" }], "base"),
+    /returned chain id 1, expected 8453/,
   );
 });
 

--- a/tests/update_morpho_graph_markets.test.mjs
+++ b/tests/update_morpho_graph_markets.test.mjs
@@ -1,0 +1,498 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { findGraphIssues } from "../scripts/check_graphs.mjs";
+import {
+  allocationLabel,
+  applySections,
+  buildAllocations,
+  buildGraphSections,
+  fetchV1,
+  fetchV2,
+  findMorphoVaults,
+  formatLltv,
+  marketNodeId,
+  morphoMarketUrl,
+  parseV1Items,
+  parseV2Items,
+  postGraphql,
+} from "../scripts/update_morpho_graph_markets.mjs";
+
+const REPORTS = new Set(["demo", "infinifi"]);
+
+/* ------------------------------------------------------------ fixtures */
+
+function graph(overrides = {}) {
+  return {
+    slug: "demo",
+    chain: "ethereum",
+    categories: [
+      { id: "vault", label: "Vault" },
+      { id: "strategy", label: "Strategy" },
+      { id: "dependency", label: "Dependency" },
+    ],
+    nodes: [
+      { id: "vault", label: "Demo Vault", category: "vault", address: "0xAAA" },
+      { id: "morpho-vault", label: "Yearn USDC", category: "strategy", address: "0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3", morphoVault: "v1" },
+    ],
+    edges: [{ from: "vault", to: "morpho-vault", kind: "allocates-to", label: "10%" }],
+    ...overrides,
+  };
+}
+
+/** A valid 32-byte (64-hex) market id from a short hex prefix. */
+function mid(hex) {
+  return `0x${hex.padEnd(64, "0")}`;
+}
+
+/** A parsed allocation entry, in the shape the generator consumes. */
+function alloc(supply, marketId, lltv, collateral, loan) {
+  return {
+    supplyAssets: BigInt(supply),
+    marketId,
+    lltv,
+    loanSymbol: loan,
+    collateralSymbol: collateral,
+  };
+}
+
+function vaultData(overrides = {}) {
+  return {
+    version: "v1",
+    chain: "ethereum",
+    address: "0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3",
+    name: "Yearn USDC",
+    assetSymbol: "USDC",
+    totalAssets: 1000n,
+    allocations: [],
+    ...overrides,
+  };
+}
+
+/* --------------------------------------------------------- validation */
+
+test("findGraphIssues flags invalid morphoVault value", () => {
+  const g = graph();
+  g.nodes[1].morphoVault = "v3";
+  const issues = findGraphIssues([{ slug: "demo", graph: g }], REPORTS);
+  assert.ok(issues.some((i) => i.level === "error" && /invalid morphoVault/.test(i.message)));
+});
+
+test("findGraphIssues flags morphoVault without an address", () => {
+  const g = graph();
+  delete g.nodes[1].address;
+  const issues = findGraphIssues([{ slug: "demo", graph: g }], REPORTS);
+  assert.ok(issues.some((i) => i.level === "error" && /has no address/.test(i.message)));
+});
+
+test("findGraphIssues accepts v1 and v2 tags", () => {
+  for (const version of ["v1", "v2"]) {
+    const g = graph();
+    g.nodes[1].morphoVault = version;
+    const issues = findGraphIssues([{ slug: "demo", graph: g }], REPORTS);
+    assert.ok(!issues.some((i) => /morphoVault/.test(i.message)), `tag ${version} should pass`);
+  }
+});
+
+test("findGraphIssues flags morphoVault on an unsupported chain", () => {
+  const g = graph();
+  g.nodes[1].chain = "polygon";
+  const issues = findGraphIssues([{ slug: "demo", graph: g }], REPORTS);
+  assert.ok(issues.some((i) => i.level === "error" && /unsupported chain 'polygon'/.test(i.message)));
+});
+
+test("findGraphIssues flags a generated market node carrying morphoVault", () => {
+  const g = graph();
+  g.nodes.push({ id: "morpho-market-64d65c9a2d91", label: "x", category: "dependency", address: "0xAAA", morphoVault: "v1" });
+  const issues = findGraphIssues([{ slug: "demo", graph: g }], REPORTS);
+  assert.ok(issues.some((i) => i.level === "error" && /must not carry morphoVault/.test(i.message)));
+});
+
+test("findGraphIssues flags a non-https link", () => {
+  const g = graph();
+  g.nodes[1].link = "http://app.morpho.org/market/x/";
+  const issues = findGraphIssues([{ slug: "demo", graph: g }], REPORTS);
+  assert.ok(issues.some((i) => i.level === "error" && /non-https link/.test(i.message)));
+});
+
+test("findGraphIssues accepts an https link", () => {
+  const g = graph();
+  g.nodes[1].link = "https://app.morpho.org/ethereum/market/x/";
+  const issues = findGraphIssues([{ slug: "demo", graph: g }], REPORTS);
+  assert.ok(!issues.some((i) => /link/.test(i.message)));
+});
+
+/* ----------------------------------------------------------- discovery */
+
+test("only explicitly tagged nodes are discovered", () => {
+  const g = graph();
+  // Untagged node whose label, id and address all look Morpho-y.
+  g.nodes.push({ id: "steakhouse-meta", label: "Steakhouse MetaMorpho", category: "dependency", address: "0xBEEF1f5bD88285E5b239B6AACB991D38CCa23aC9" });
+  const { occurrences, queries } = findMorphoVaults([{ slug: "demo", graph: g }]);
+  assert.equal(occurrences.length, 1);
+  assert.equal(queries.length, 1);
+  assert.equal(occurrences[0].nodeId, "morpho-vault");
+});
+
+test("the same vault referenced by two graphs yields one query", () => {
+  const a = graph();
+  const b = graph({ slug: "other" });
+  const { occurrences, queries } = findMorphoVaults([
+    { slug: "demo", graph: a },
+    { slug: "other", graph: b },
+  ]);
+  assert.equal(occurrences.length, 2);
+  assert.equal(queries.length, 1);
+  assert.equal(queries[0].address, "0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3");
+});
+
+test("a tagged Morpho vault in a non-Yearn graph is discovered", () => {
+  const g = graph({
+    slug: "infinifi",
+    nodes: [
+      { id: "siUSD", label: "siUSD", category: "vault", address: "0xAAA" },
+      { id: "dep-steakhouse-vault", label: "Steakhouse infiniFi USDC", category: "dependency", address: "0xBEEF1f5bD88285E5b239B6AACB991D38CCa23aC9", morphoVault: "v1" },
+    ],
+    edges: [],
+  });
+  const { occurrences, queries } = findMorphoVaults([{ slug: "infinifi", graph: g }]);
+  assert.equal(occurrences.length, 1);
+  assert.equal(occurrences[0].slug, "infinifi");
+  assert.equal(queries[0].address, "0xBEEF1f5bD88285E5b239B6AACB991D38CCa23aC9");
+});
+
+/* -------------------------------------------------------- percentages */
+
+test("allocationLabel computes an exact BigInt percentage", () => {
+  // 56.4% of 1000
+  assert.equal(allocationLabel(564n, 1000n), "56.4%");
+  // 36.9%
+  assert.equal(allocationLabel(369n, 1000n), "36.9%");
+  // 6.7%
+  assert.equal(allocationLabel(67n, 1000n), "6.7%");
+  // 100%
+  assert.equal(allocationLabel(1000n, 1000n), "100.0%");
+});
+
+test("allocationLabel returns null for zero supply", () => {
+  assert.equal(allocationLabel(0n, 1000n), null);
+});
+
+test("allocationLabel labels tiny positive shares <0.1%", () => {
+  assert.equal(allocationLabel(1n, 10000n), "<0.1%");
+  assert.equal(allocationLabel(9n, 10000n), "<0.1%");
+});
+
+test("formatLltv renders WAD LLTV with trimming", () => {
+  assert.equal(formatLltv("860000000000000000"), "86%");
+  assert.equal(formatLltv("945000000000000000"), "94.5%");
+  assert.equal(formatLltv("965000000000000000"), "96.5%");
+  assert.equal(formatLltv(0), "0%");
+});
+
+/* ---------------------------------------------------------- allocation */
+
+test("zero allocations are omitted; tiny ones kept", () => {
+  const v = vaultData({
+    totalAssets: 1000000n,
+    allocations: [
+      alloc(0, mid("aaaa"), "860000000000000000", "cbBTC", "USDC"),
+      alloc(5, mid("bbbb"), "860000000000000000", "WBTC", "USDC"),
+      alloc(999995, mid("cccc"), "860000000000000000", "wstETH", "USDC"),
+    ],
+  });
+  const used = new Set();
+  const items = buildAllocations(v, used);
+  assert.equal(items.length, 2);
+  assert.ok(items.some((i) => i.pct === "<0.1%"));
+  assert.ok(!items.some((i) => i.marketId === mid("aaaa")));
+});
+
+test("same pair with different LLTVs produces distinct labels", () => {
+  const v = vaultData({
+    totalAssets: 1000n,
+    allocations: [
+      alloc(500, mid("a1a1"), "945000000000000000", "wstETH", "WETH"),
+      alloc(500, mid("b2b2"), "965000000000000000", "wstETH", "WETH"),
+    ],
+  });
+  const items = buildAllocations(v, new Set());
+  assert.equal(items.length, 2);
+  assert.equal(items[0].label, "wstETH/WETH · 94.5% LLTV");
+  assert.equal(items[1].label, "wstETH/WETH · 96.5% LLTV");
+});
+
+test("same pair and LLTV appends a shortened market id", () => {
+  const v = vaultData({
+    totalAssets: 1000n,
+    allocations: [
+      alloc(600, "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64", "860000000000000000", "cbBTC", "USDC"),
+      alloc(400, "0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe", "860000000000000000", "cbBTC", "USDC"),
+    ],
+  });
+  const items = buildAllocations(v, new Set());
+  assert.equal(items.length, 2);
+  assert.equal(items[0].label, "cbBTC/USDC · 86% LLTV");
+  assert.equal(items[1].label, "cbBTC/USDC · 86% LLTV · 0xbc99de6a8890");
+});
+
+test("positive idle assets become a synthetic Idle node", () => {
+  const v = vaultData({
+    totalAssets: 1000n,
+    allocations: [
+      alloc(820, null, null, null, null), // idle (collateral null)
+      alloc(180, "0xf6a056627a51e511ec7f48332421432ea6971fc148d8f3c451e14ea108026549", "945000000000000000", "LBTC", "WBTC"),
+    ],
+  });
+  const items = buildAllocations(v, new Set());
+  const idle = items.find((i) => i.marketId === null);
+  assert.ok(idle, "idle node should exist");
+  assert.equal(idle.label, "Idle USDC");
+  assert.equal(idle.link, null);
+  assert.equal(idle.pct, "82.0%");
+});
+
+test("markets sort by allocation descending then market id", () => {
+  const v = vaultData({
+    totalAssets: 1000n,
+    allocations: [
+      alloc(100, mid("eeee"), "860000000000000000", "A", "USDC"),
+      alloc(700, mid("aaaa"), "860000000000000000", "B", "USDC"),
+      alloc(700, mid("bbbb"), "860000000000000000", "C", "USDC"),
+    ],
+  });
+  const items = buildAllocations(v, new Set());
+  assert.deepEqual(
+    items.map((i) => i.supplyAssets),
+    [700n, 700n, 100n],
+  );
+  assert.equal(items[0].marketId, mid("aaaa"));
+  assert.equal(items[1].marketId, mid("bbbb"));
+});
+
+test("marketNodeId detects and resolves collisions", () => {
+  const marketId = "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64";
+  const used = new Set(["morpho-market-64d65c9a2d91"]);
+  assert.equal(marketNodeId(marketId, used), "morpho-market-64d65c9a2d91c");
+});
+
+test("morphoMarketUrl builds the full market link", () => {
+  assert.equal(
+    morphoMarketUrl("ethereum", "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"),
+    "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/",
+  );
+  assert.throws(() => morphoMarketUrl("polygon", "0xaaa"));
+});
+
+/* ---------------------------------------------------------- V2 parsing */
+
+test("parseV2Items parses direct MorphoMarketV1Adapter positions", () => {
+  const items = [
+    {
+      address: "0x8c106EEDAd96553e64287A5A6839c3Cc78afA3D0",
+      name: "Gauntlet USDC Prime",
+      asset: { symbol: "USDC" },
+      totalAssets: 70669397774691,
+      idleAssets: 0,
+      adapters: {
+        items: [
+          {
+            address: "0xDF62f57Ea333a842Db200d4892c90F98204fa22F",
+            type: "MorphoMarketV1",
+            positions: {
+              items: [
+                {
+                  state: { supplyAssets: 1328046542738 },
+                  market: {
+                    marketId: "0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8",
+                    lltv: "860000000000000000",
+                    loanAsset: { symbol: "USDC" },
+                    collateralAsset: { symbol: "wstETH" },
+                  },
+                },
+              ],
+              pageInfo: { countTotal: 1, count: 1, limit: 20, skip: 0 },
+            },
+          },
+        ],
+        pageInfo: { countTotal: 1, count: 1, limit: 3, skip: 0 },
+      },
+    },
+  ];
+  const parsed = parseV2Items(items, [{ version: "v2", chain: "ethereum", address: "0x8c106EEDAd96553e64287A5A6839c3Cc78afA3D0" }], "ethereum");
+  const vault = parsed.get("0x8c106eedad96553e64287a5a6839c3cc78afa3d0");
+  assert.equal(vault.version, "v2");
+  assert.equal(vault.allocations.length, 1);
+  assert.equal(vault.allocations[0].collateralSymbol, "wstETH");
+});
+
+test("parseV2Items fails on unsupported (nested) adapter", () => {
+  const items = [
+    {
+      address: "0xFB154c729A16802c4ad1E8f7FF539a8b9f49c960",
+      name: "OUSD Vault V2",
+      asset: { symbol: "USDC" },
+      totalAssets: 100,
+      idleAssets: 0,
+      adapters: {
+        items: [
+          { address: "0xD8F093dCE8504F10Ac798A978eF9E0C230B2f5fF", type: "MetaMorpho" },
+        ],
+        pageInfo: { countTotal: 1, count: 1, limit: 3, skip: 0 },
+      },
+    },
+  ];
+  assert.throws(
+    () => parseV2Items(items, [{ version: "v2", chain: "ethereum", address: "0xFB154c729A16802c4ad1E8f7FF539a8b9f49c960" }], "ethereum"),
+    /unsupported adapter "MetaMorpho".*0xD8F093dCE8504F10Ac798A978eF9E0C230B2f5fF/,
+  );
+});
+
+test("parseV2Items fails on a full adapter page (pagination ceiling)", () => {
+  const items = [
+    {
+      address: "0xAAA",
+      name: "Vault",
+      asset: { symbol: "USDC" },
+      totalAssets: 100,
+      idleAssets: 0,
+      adapters: {
+        items: [{ address: "0xBBB", type: "MorphoMarketV1" }],
+        pageInfo: { countTotal: 5, count: 3, limit: 3, skip: 0 },
+      },
+    },
+  ];
+  assert.throws(
+    () => parseV2Items(items, [{ version: "v2", chain: "ethereum", address: "0xAAA" }], "ethereum"),
+    /raise the limit or implement pagination/,
+  );
+});
+
+test("parseV1Items fails with an actionable message on missing address", () => {
+  assert.throws(
+    () => parseV1Items([], [{ version: "v1", chain: "ethereum", address: "0xAAA" }], "ethereum"),
+    /not a Morpho Vault V1.*Check the tag/s,
+  );
+});
+
+test("parseV2Items fails with an actionable message on missing address", () => {
+  assert.throws(
+    () => parseV2Items([], [{ version: "v2", chain: "ethereum", address: "0xAAA" }], "ethereum"),
+    /not a Morpho Vault V2.*Check the tag/s,
+  );
+});
+
+/* ------------------------------------------------------- GraphQL errors */
+
+test("postGraphql raises on non-2xx responses", async () => {
+  const bad = async () => ({ ok: false, status: 500, text: async () => "boom" });
+  await assert.rejects(() => postGraphql("q", {}, bad), /HTTP 500/);
+});
+
+test("postGraphql raises on invalid JSON", async () => {
+  const bad = async () => ({ ok: true, status: 200, text: async () => "not json" });
+  await assert.rejects(() => postGraphql("q", {}, bad), /invalid JSON/);
+});
+
+test("postGraphql raises on GraphQL errors", async () => {
+  const bad = async () => ({
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify({ errors: [{ message: "nope" }], data: null }),
+  });
+  await assert.rejects(() => postGraphql("q", {}, bad), /GraphQL errors/);
+});
+
+test("postGraphql raises on missing data", async () => {
+  const bad = async () => ({ ok: true, status: 200, text: async () => JSON.stringify({}) });
+  await assert.rejects(() => postGraphql("q", {}, bad), /no data/);
+});
+
+test("fetchV1 and fetchV2 are offline-testable via injected fetch", async () => {
+  // A minimal fake covering the V1 path (batching, lowercase addresses).
+  const calls = [];
+  const fake = async (url, init) => {
+    calls.push(JSON.parse(init.body).variables.addresses);
+    return {
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          data: {
+            vaults: {
+              items: [
+                {
+                  address: "0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3",
+                  name: "Yearn USDC",
+                  chain: { id: 1 },
+                  asset: { symbol: "USDC" },
+                  state: { totalAssets: 1000, allocation: [] },
+                },
+              ],
+            },
+          },
+        }),
+    };
+  };
+  const result = await fetchV1([{ version: "v1", chain: "ethereum", address: "0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3" }], fake);
+  assert.equal(calls[0][0], "0x68aea7b82df6ccdf76235d46445ed83f85f845a3");
+  assert.ok(result.has("v1:ethereum:0x68aea7b82df6ccdf76235d46445ed83f85f845a3"));
+});
+
+/* ---------------------------------------------------- marker manipulation */
+
+const TEXT = `slug: demo
+chain: ethereum
+nodes:
+  - id: vault
+    label: Vault
+    category: vault
+
+edges:
+  - from: vault
+    to: morpho-vault
+    kind: allocates-to
+`;
+
+test("applySections inserts marker blocks and preserves surrounding bytes", () => {
+  const nodes = [
+    { id: "morpho-market-64d65c9a2d91", label: "cbBTC/USDC · 86% LLTV", category: "dependency", link: "https://app.morpho.org/ethereum/market/x/", note: "Morpho market x used by Yearn USDC" },
+  ];
+  const edges = [{ from: "morpho-vault", to: "morpho-market-64d65c9a2d91", kind: "deposits-into", label: "56.4%" }];
+  const next = applySections(TEXT, nodes, edges);
+
+  assert.ok(next.includes("# BEGIN GENERATED MORPHO MARKET NODES"));
+  assert.ok(next.includes("# BEGIN GENERATED MORPHO MARKET EDGES"));
+  // Byte-preservation outside the markers.
+  assert.ok(next.startsWith("slug: demo\nchain: ethereum\nnodes:\n  - id: vault\n"));
+  assert.ok(next.includes("  - from: vault\n    to: morpho-vault\n    kind: allocates-to\n"));
+});
+
+test("applySections is idempotent on a second run", () => {
+  const nodes = [
+    { id: "morpho-market-64d65c9a2d91", label: "cbBTC/USDC · 86% LLTV", category: "dependency", link: "https://app.morpho.org/ethereum/market/x/", note: "Morpho market x used by Yearn USDC" },
+  ];
+  const edges = [{ from: "morpho-vault", to: "morpho-market-64d65c9a2d91", kind: "deposits-into", label: "56.4%" }];
+  const once = applySections(TEXT, nodes, edges);
+  const twice = applySections(once, nodes, edges);
+  assert.equal(twice, once);
+});
+
+test("buildGraphSections ignores previous generated nodes when deriving ids", () => {
+  // Simulate a graph that already contains a generated node from a prior run.
+  const g = graph();
+  g.nodes.push({ id: "morpho-market-64d65c9a2d91", label: "stale", category: "dependency", link: "https://x/", note: "stale" });
+  const occ = [{ slug: "demo", nodeId: "morpho-vault", version: "v1", chain: "ethereum", address: "0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3", nodeLabel: "Yearn USDC" }];
+  const allocByKey = new Map([
+    [
+      "v1:ethereum:0x68aea7b82df6ccdf76235d46445ed83f85f845a3",
+      vaultData({
+        totalAssets: 1000n,
+        allocations: [alloc(1000, "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64", "860000000000000000", "cbBTC", "USDC")],
+      }),
+    ],
+  ]);
+  const { marketNodes } = buildGraphSections(g, occ, allocByKey);
+  // Stable, not shifted by the stale generated node.
+  assert.equal(marketNodes[0].id, "morpho-market-64d65c9a2d91");
+});

--- a/tests/update_morpho_graph_markets.test.mjs
+++ b/tests/update_morpho_graph_markets.test.mjs
@@ -222,7 +222,7 @@ test("same pair with different LLTVs produces distinct labels", () => {
   assert.equal(items[1].label, "wstETH/WETH · 96.5% LLTV");
 });
 
-test("same pair and LLTV appends a shortened market id", () => {
+test("same pair and LLTV keeps a simple label (no market-id suffix)", () => {
   const v = vaultData({
     totalAssets: 1000n,
     allocations: [
@@ -232,8 +232,11 @@ test("same pair and LLTV appends a shortened market id", () => {
   });
   const items = buildAllocations(v, new Set());
   assert.equal(items.length, 2);
+  // Labels stay name + LLTV only; the full market id remains in `note`/`link`.
   assert.equal(items[0].label, "cbBTC/USDC · 86% LLTV");
-  assert.equal(items[1].label, "cbBTC/USDC · 86% LLTV · 0xbc99de6a8890");
+  assert.equal(items[1].label, "cbBTC/USDC · 86% LLTV");
+  assert.ok(items[0].note.includes("0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"));
+  assert.ok(items[1].note.includes("0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe"));
 });
 
 test("positive idle assets become a synthetic Idle node", () => {

--- a/tests/update_morpho_graph_markets.test.mjs
+++ b/tests/update_morpho_graph_markets.test.mjs
@@ -222,7 +222,7 @@ test("same pair with different LLTVs produces distinct labels", () => {
   assert.equal(items[1].label, "wstETH/WETH · 96.5% LLTV");
 });
 
-test("same pair and LLTV appends a shortened market id", () => {
+test("same pair and LLTV keeps a simple label (no market-id suffix)", () => {
   const v = vaultData({
     totalAssets: 1000n,
     allocations: [
@@ -232,11 +232,11 @@ test("same pair and LLTV appends a shortened market id", () => {
   });
   const items = buildAllocations(v, new Set());
   assert.equal(items.length, 2);
-  // First occurrence keeps the plain name + LLTV; the collision gets a suffix.
+  // Labels stay name + LLTV only; the full market id remains in note/link.
   assert.equal(items[0].label, "cbBTC/USDC · 86% LLTV");
-  assert.equal(items[1].label, "cbBTC/USDC · 86% LLTV · 0xbc99de6a8890");
-  assert.ok(items[0].note.includes("0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"));
-  assert.ok(items[1].note.includes("0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe"));
+  assert.equal(items[1].label, "cbBTC/USDC · 86% LLTV");
+  assert.equal(items[0].note, "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64");
+  assert.equal(items[1].note, "Morpho market 0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe");
 });
 
 test("positive idle assets become a synthetic Idle node", () => {


### PR DESCRIPTION
## Summary

Implements #402: a repeatable generator that expands explicitly tagged Morpho vault nodes (`morphoVault: v1|v2`) in any dependency graph YAML into their current underlying market allocations, fetched from the Morpho GraphQL API.

The full capital path is now visible per graph — `vault → strategy / Morpho vault → individual Morpho markets` — with percentage-labelled `deposits-into` edges.

## What changed

- **`scripts/update_morpho_graph_markets.mjs`** (new) — graph-wide scanner; queries deduplicated by `(version, chain, address)` and filtered by `chainId_in`; BigInt allocation math; idle/dust handling; V2 direct `MorphoMarketV1Adapter` support (nested adapters fail closed); marker-delimited, idempotent, transactional writes (`--write`, `--graph`, check mode).
- **`src/lib/graph.ts` + `scripts/check_graphs.mjs`** — `morphoVault` enum + validation (value, required address, Morpho-supported chain, no tag on generated nodes, `https://` links).
- **`src/pages/graph/[slug].astro`** — prefer an authored `link` (Morpho market/vault page) over the block-explorer fallback; a node can show both, and Morpho links render as "Open on Morpho".
- **`reports/graph/SKILL.md`** — document `link` + `morphoVault` and the generator.
- **Graph corpus** — tagged 8 V1 vaults (Yearn USDC/USDT/WBTC/WETH/OG USDC, Waterline infiniFi, WETH ARM) and 3 V2 vaults (Cap Steakhouse Prime + Gauntlet Prime, Gauntlet USDC Frontier); added owner/curator multisigs with Safe thresholds (verified onchain); generated market nodes; removed redundant generic Morpho Blue/Morpho protocol nodes.

## Validation

- `npm test` — 55/55 pass (offline, mocked GraphQL fixtures).
- `node scripts/update_morpho_graph_markets.mjs` — idempotent.
- `npm run check-graphs` — 0 errors (16 pre-existing warnings unrelated to this change).
- `npm run build` — passes (108 pages).

## Notes

- `origin-ousd` `morphousd-vault` (OUSD Vault V2) is intentionally left untagged: it uses a nested `MetaMorpho` adapter, which fails closed by design. Its owner/curator (Yearn Security 4-of-7) is still shown.
- Market labels and notes are kept simple — `cbBTC/USDC · 86% LLTV`, note is the full 32-byte id only. The full id remains in `note`/`link` for disambiguation.
- Review feedback applied: `chainId_in` query filtering + response chain-id validation, and transactional `--write` (compute all, then write).
