### PR TITLE
Cross-link the same Morpho market across graphs (test)

### DIFF
--- a/reports/graph/SKILL.md
+++ b/reports/graph/SKILL.md
@@ -78,6 +78,7 @@ The schema is enforced at build time by the validator in `src/lib/graph.ts`. Aut
 | `link` | no | string | External URL for the card's `↗` affordance and the details panel. **Must use `https://`.** Prefer it to the block-explorer link for addressless nodes (e.g. Morpho market IDs, which are 32-byte identifiers — never put a market ID in `address`). |
 | `note` | no | string | Free-form context. **Rendered as prose in the details panel** when the card is clicked — write it for a human reader, not as a shorthand memo. |
 | `morphoVault` | no | enum `"v1" \| "v2"` | Tags this node as a Morpho vault whose per-market allocations are expanded by `scripts/update_morpho_graph_markets.mjs`. Records the vault contract's immutable generation. Requires `address`. **Only explicitly tagged nodes are probed** — never detected from labels, IDs, notes, or address probing. Do not tag generic Morpho protocol/market nodes, Morpho strategies that merely use flashloans, or wrapper/farm contracts that deposit into a separate vault node. |
+| `morphoMarket` | no | string (32-byte id) | Set by the generator on generated Morpho market nodes. The full `marketId`, used to cross-link the same market across graphs (a market is shared by many vaults). Generated only; do not author by hand. |
 
 **Edge fields:**
 
@@ -319,6 +320,7 @@ What the generator does:
 
 - Scans every `reports/graph/*.yaml`, finds tagged nodes, and fetches their allocations from the Morpho GraphQL API (`https://api.morpho.org/graphql`).
 - Emits a `dependency` node per non-zero market (label `cbBTC/USDC · 86% LLTV`, `link` to the Morpho market page, full 32-byte `marketId` in the `note`) and a `deposits-into` edge from the vault node to each market carrying its percentage label.
+- Writes the full `marketId` in a `morphoMarket` field on each market node. The graph renderer cross-references this field across the whole corpus, so a market card lists every other graph whose vaults supply the same market ("Also supplied by").
 - Represents idle assets (`collateralAsset` is null) as a synthetic `Idle <asset>` node with no Morpho link, so displayed allocations reconcile to 100%. Tiny positive shares are labelled `<0.1%`, never rounded to 0.
 - Writes into two marker-delimited sections — `# BEGIN/END GENERATED MORPHO MARKET NODES` (before `edges:`) and `# BEGIN/END GENERATED MORPHO MARKET EDGES` (inside the edge list) — preserving every byte outside those regions. V2 vaults are supported for direct `MorphoMarketV1Adapter` positions; nested/unsupported adapters fail closed.
 

--- a/reports/graph/cap-stcusd.yaml
+++ b/reports/graph/cap-stcusd.yaml
@@ -117,41 +117,49 @@ nodes:
   - id: morpho-market-64d65c9a2d91
     label: "cbBTC/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"
     link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
     note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Steakhouse Prime USDC"
   - id: morpho-market-34377fc4f617
     label: "weETH/USDC · 77% LLTV"
     category: dependency
+    morphoMarket: "0x34377fc4f617c51818e92c79df31ff270c6a91bc94ad32e367fdf59b9f4ac5dd"
     link: "https://app.morpho.org/ethereum/market/0x34377fc4f617c51818e92c79df31ff270c6a91bc94ad32e367fdf59b9f4ac5dd/"
     note: "Morpho market 0x34377fc4f617c51818e92c79df31ff270c6a91bc94ad32e367fdf59b9f4ac5dd used by Steakhouse Prime USDC"
   - id: morpho-market-3a85e6197511
     label: "WBTC/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49"
     link: "https://app.morpho.org/ethereum/market/0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49/"
     note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49 used by Steakhouse Prime USDC"
   - id: morpho-market-94b823e6bd8e
     label: "WETH/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x94b823e6bd8ea533b4e33fbc307faea0b307301bc48763acc4d4aa4def7636cd"
     link: "https://app.morpho.org/ethereum/market/0x94b823e6bd8ea533b4e33fbc307faea0b307301bc48763acc4d4aa4def7636cd/"
     note: "Morpho market 0x94b823e6bd8ea533b4e33fbc307faea0b307301bc48763acc4d4aa4def7636cd used by Steakhouse Prime USDC"
   - id: morpho-market-7e585a933ffe
     label: "wstETH/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8"
     link: "https://app.morpho.org/ethereum/market/0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8/"
     note: "Morpho market 0x7e585a933ffe8443c371b4f8cfeb4430f5f6a14c2f32a898c26662c67a1cb8b8 used by Steakhouse Prime USDC"
   - id: morpho-market-bc99de6a8890
     label: "cbBTC/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe"
     link: "https://app.morpho.org/ethereum/market/0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe/"
     note: "Morpho market 0xbc99de6a88904cd0e69042ad6f266e63182801f030c636507c3caf590ffd84fe used by Steakhouse Prime USDC"
   - id: morpho-market-09dc9e7eb5d8
     label: "WBTC/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1"
     link: "https://app.morpho.org/ethereum/market/0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1/"
     note: "Morpho market 0x09dc9e7eb5d8fc54b2bc41d1135fd4e99057a580f680321faeb90c7a21e631c1 used by Steakhouse Prime USDC"
   - id: morpho-market-b323495f7e41
     label: "wstETH/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc"
     link: "https://app.morpho.org/ethereum/market/0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc/"
     note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc used by Steakhouse Prime USDC"
 # END GENERATED MORPHO MARKET NODES
@@ -252,7 +260,7 @@ edges:
   - from: morpho-steakhouse-prime
     to: morpho-market-34377fc4f617
     kind: deposits-into
-    label: "3.9%"
+    label: "3.8%"
   - from: morpho-steakhouse-prime
     to: morpho-market-3a85e6197511
     kind: deposits-into

--- a/reports/graph/gauntlet-gusda.yaml
+++ b/reports/graph/gauntlet-gusda.yaml
@@ -105,51 +105,61 @@ nodes:
   - id: morpho-market-e83d72fa5b00
     label: "AA_FalconXUSDC/USDC · 77% LLTV"
     category: dependency
+    morphoMarket: "0xe83d72fa5b00dcd46d9e0e860d95aa540d5ec106da5833108a9f826f21f36f52"
     link: "https://app.morpho.org/ethereum/market/0xe83d72fa5b00dcd46d9e0e860d95aa540d5ec106da5833108a9f826f21f36f52/"
     note: "Morpho market 0xe83d72fa5b00dcd46d9e0e860d95aa540d5ec106da5833108a9f826f21f36f52 used by Gauntlet USDC Frontier"
   - id: morpho-market-f02d2e8f427a
     label: "PT-sUSDD-27AUG2026/USDC · 91.5% LLTV"
     category: dependency
+    morphoMarket: "0xf02d2e8f427a2b91785b3d09690ef9d3811bf674ba97b00bafc7665004a6dd97"
     link: "https://app.morpho.org/ethereum/market/0xf02d2e8f427a2b91785b3d09690ef9d3811bf674ba97b00bafc7665004a6dd97/"
     note: "Morpho market 0xf02d2e8f427a2b91785b3d09690ef9d3811bf674ba97b00bafc7665004a6dd97 used by Gauntlet USDC Frontier"
   - id: morpho-market-755f954513d3
     label: "PRIME/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x755f954513d31d5f24aaf3d0cdc5e913a28383f8ea8ff85be9ffffa7371fb64d"
     link: "https://app.morpho.org/ethereum/market/0x755f954513d31d5f24aaf3d0cdc5e913a28383f8ea8ff85be9ffffa7371fb64d/"
     note: "Morpho market 0x755f954513d31d5f24aaf3d0cdc5e913a28383f8ea8ff85be9ffffa7371fb64d used by Gauntlet USDC Frontier"
   - id: morpho-market-bf02d6c6852f
     label: "LBTC/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0"
     link: "https://app.morpho.org/ethereum/market/0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0/"
     note: "Morpho market 0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0 used by Gauntlet USDC Frontier"
   - id: morpho-market-5cebfae10f5e
     label: "PT-USDG-28MAY2026/USDC · 94.5% LLTV"
     category: dependency
+    morphoMarket: "0x5cebfae10f5e88d33df2421923f3d9f32359429fda2f78edacc9b4fdb09b0553"
     link: "https://app.morpho.org/ethereum/market/0x5cebfae10f5e88d33df2421923f3d9f32359429fda2f78edacc9b4fdb09b0553/"
     note: "Morpho market 0x5cebfae10f5e88d33df2421923f3d9f32359429fda2f78edacc9b4fdb09b0553 used by Gauntlet USDC Frontier"
   - id: morpho-market-64d65c9a2d91
     label: "cbBTC/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"
     link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
     note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Gauntlet USDC Frontier"
   - id: morpho-market-61765602144e
     label: "weETH/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664"
     link: "https://app.morpho.org/ethereum/market/0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664/"
     note: "Morpho market 0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664 used by Gauntlet USDC Frontier"
   - id: morpho-market-ad73d5e139a9
     label: "sUSDD/USDC · 91.5% LLTV"
     category: dependency
+    morphoMarket: "0xad73d5e139a939a0c7dc7b821e5a103a3a9cf45c4352b373b1dabc421c7f3d59"
     link: "https://app.morpho.org/ethereum/market/0xad73d5e139a939a0c7dc7b821e5a103a3a9cf45c4352b373b1dabc421c7f3d59/"
     note: "Morpho market 0xad73d5e139a939a0c7dc7b821e5a103a3a9cf45c4352b373b1dabc421c7f3d59 used by Gauntlet USDC Frontier"
   - id: morpho-market-729badf297ee
     label: "syrupUSDC/USDC · 91.5% LLTV"
     category: dependency
+    morphoMarket: "0x729badf297ee9f2f6b3f717b96fd355fc6ec00422284ce1968e76647b258cf44"
     link: "https://app.morpho.org/ethereum/market/0x729badf297ee9f2f6b3f717b96fd355fc6ec00422284ce1968e76647b258cf44/"
     note: "Morpho market 0x729badf297ee9f2f6b3f717b96fd355fc6ec00422284ce1968e76647b258cf44 used by Gauntlet USDC Frontier"
   - id: morpho-market-bbf7ce1b40d3
     label: "siUSD/USDC · 91.5% LLTV"
     category: dependency
+    morphoMarket: "0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99"
     link: "https://app.morpho.org/ethereum/market/0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99/"
     note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99 used by Gauntlet USDC Frontier"
 # END GENERATED MORPHO MARKET NODES

--- a/reports/graph/infinifi.yaml
+++ b/reports/graph/infinifi.yaml
@@ -231,16 +231,19 @@ nodes:
   - id: morpho-market-bbf7ce1b40d3
     label: "siUSD/USDC · 91.5% LLTV"
     category: dependency
+    morphoMarket: "0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99"
     link: "https://app.morpho.org/ethereum/market/0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99/"
     note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99 used by Waterline infiniFi USDC"
   - id: morpho-market-6df56abb95e9
     label: "iUSD/USDC · 91.5% LLTV"
     category: dependency
+    morphoMarket: "0x6df56abb95e9f3f96049448e1c98d208deb1add8a3d0c7a23e5e5466dba4edbd"
     link: "https://app.morpho.org/ethereum/market/0x6df56abb95e9f3f96049448e1c98d208deb1add8a3d0c7a23e5e5466dba4edbd/"
     note: "Morpho market 0x6df56abb95e9f3f96049448e1c98d208deb1add8a3d0c7a23e5e5466dba4edbd used by Waterline infiniFi USDC"
   - id: morpho-market-a94d7d784ecd
     label: "PT-siUSD-20AUG2026/USDC · 91.5% LLTV"
     category: dependency
+    morphoMarket: "0xa94d7d784ecd1194f23f82f6b1c1acbf1d5982bab63362d094710638d2b770dc"
     link: "https://app.morpho.org/ethereum/market/0xa94d7d784ecd1194f23f82f6b1c1acbf1d5982bab63362d094710638d2b770dc/"
     note: "Morpho market 0xa94d7d784ecd1194f23f82f6b1c1acbf1d5982bab63362d094710638d2b770dc used by Waterline infiniFi USDC"
 # END GENERATED MORPHO MARKET NODES

--- a/reports/graph/origin-arm.yaml
+++ b/reports/graph/origin-arm.yaml
@@ -103,11 +103,13 @@ nodes:
   - id: morpho-market-b8fc70e82bc5
     label: "wstETH/WETH · 96.5% LLTV"
     category: dependency
+    morphoMarket: "0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e"
     link: "https://app.morpho.org/ethereum/market/0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e/"
     note: "Morpho market 0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e used by WETH ARM Vault"
   - id: morpho-market-d0e50cdac92f
     label: "wstETH/WETH · 94.5% LLTV"
     category: dependency
+    morphoMarket: "0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d"
     link: "https://app.morpho.org/ethereum/market/0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d/"
     note: "Morpho market 0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d used by WETH ARM Vault"
 # END GENERATED MORPHO MARKET NODES

--- a/reports/graph/yearn-yvdai.yaml
+++ b/reports/graph/yearn-yvdai.yaml
@@ -112,16 +112,19 @@ nodes:
   - id: morpho-market-64d65c9a2d91
     label: "cbBTC/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"
     link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
     note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Yearn USDC"
   - id: morpho-market-3a85e6197511
     label: "WBTC/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49"
     link: "https://app.morpho.org/ethereum/market/0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49/"
     note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49 used by Yearn USDC"
   - id: morpho-market-b323495f7e41
     label: "wstETH/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc"
     link: "https://app.morpho.org/ethereum/market/0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc/"
     note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc used by Yearn USDC"
 # END GENERATED MORPHO MARKET NODES

--- a/reports/graph/yearn-yvusd.yaml
+++ b/reports/graph/yearn-yvusd.yaml
@@ -169,46 +169,55 @@ nodes:
   - id: morpho-market-b8fef900b383
     label: "OETH/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0xb8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e"
     link: "https://app.morpho.org/ethereum/market/0xb8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e/"
     note: "Morpho market 0xb8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e used by Yearn OG USDC"
   - id: morpho-market-e3df58f9d301
     label: "USD3/USDC · 91.5% LLTV"
     category: dependency
+    morphoMarket: "0xe3df58f9d3011b7481ff36b939fa5f8da642f34ea5792d25d3958dbf1efa26d7"
     link: "https://app.morpho.org/ethereum/market/0xe3df58f9d3011b7481ff36b939fa5f8da642f34ea5792d25d3958dbf1efa26d7/"
     note: "Morpho market 0xe3df58f9d3011b7481ff36b939fa5f8da642f34ea5792d25d3958dbf1efa26d7 used by Yearn OG USDC"
   - id: morpho-market-f8c5aa31ea6b
     label: "PT-USD3-17DEC2026/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89"
     link: "https://app.morpho.org/ethereum/market/0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89/"
     note: "Morpho market 0xf8c5aa31ea6b2a068a9eddb46dd110cae57bf0f12be9583a3f9a818effecba89 used by Yearn OG USDC"
   - id: morpho-market-64d65c9a2d91
     label: "cbBTC/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"
     link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
     note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Yearn OG USDC"
   - id: morpho-market-bbf7ce1b40d3
     label: "siUSD/USDC · 91.5% LLTV"
     category: dependency
+    morphoMarket: "0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99"
     link: "https://app.morpho.org/ethereum/market/0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99/"
     note: "Morpho market 0xbbf7ce1b40d32d3e3048f5cf27eeaa6de8cb27b80194690aab191a63381d8c99 used by Yearn OG USDC"
   - id: morpho-market-bf02d6c6852f
     label: "LBTC/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0"
     link: "https://app.morpho.org/ethereum/market/0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0/"
     note: "Morpho market 0xbf02d6c6852fa0b8247d5514d0c91e6c1fbde9a168ac3fd2033028b5ee5ce6d0 used by Yearn OG USDC"
   - id: morpho-market-973e9dd45799
     label: "YFI/USDC · 77% LLTV"
     category: dependency
+    morphoMarket: "0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83"
     link: "https://app.morpho.org/ethereum/market/0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83/"
     note: "Morpho market 0x973e9dd45799efe8775417bcc420a3ab84a583587b2108985746e2fe201d0c83 used by Yearn OG USDC"
   - id: morpho-market-61765602144e
     label: "weETH/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664"
     link: "https://app.morpho.org/ethereum/market/0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664/"
     note: "Morpho market 0x61765602144e91e5ac9f9e98b8584eae308f9951596fd7f5e0f59f21cd2bf664 used by Yearn OG USDC"
   - id: morpho-market-ad656d430bb3
     label: "WOUSD/USDC · 91.5% LLTV"
     category: dependency
+    morphoMarket: "0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc"
     link: "https://app.morpho.org/ethereum/market/0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc/"
     note: "Morpho market 0xad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc used by Yearn OG USDC"
 # END GENERATED MORPHO MARKET NODES

--- a/reports/graph/yearn-yvusdc.yaml
+++ b/reports/graph/yearn-yvusdc.yaml
@@ -127,16 +127,19 @@ nodes:
   - id: morpho-market-64d65c9a2d91
     label: "cbBTC/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"
     link: "https://app.morpho.org/ethereum/market/0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64/"
     note: "Morpho market 0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64 used by Yearn USDC"
   - id: morpho-market-3a85e6197511
     label: "WBTC/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49"
     link: "https://app.morpho.org/ethereum/market/0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49/"
     note: "Morpho market 0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49 used by Yearn USDC"
   - id: morpho-market-b323495f7e41
     label: "wstETH/USDC · 86% LLTV"
     category: dependency
+    morphoMarket: "0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc"
     link: "https://app.morpho.org/ethereum/market/0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc/"
     note: "Morpho market 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc used by Yearn USDC"
 # END GENERATED MORPHO MARKET NODES

--- a/reports/graph/yearn-yvusdt.yaml
+++ b/reports/graph/yearn-yvusdt.yaml
@@ -93,21 +93,25 @@ nodes:
   - id: morpho-market-a921ef34e2fc
     label: "WBTC/USDT · 86% LLTV"
     category: dependency
+    morphoMarket: "0xa921ef34e2fc7a27ccc50ae7e4b154e16c9799d3387076c421423ef52ac4df99"
     link: "https://app.morpho.org/ethereum/market/0xa921ef34e2fc7a27ccc50ae7e4b154e16c9799d3387076c421423ef52ac4df99/"
     note: "Morpho market 0xa921ef34e2fc7a27ccc50ae7e4b154e16c9799d3387076c421423ef52ac4df99 used by Yearn USDT"
   - id: morpho-market-e7e9694b754c
     label: "wstETH/USDT · 86% LLTV"
     category: dependency
+    morphoMarket: "0xe7e9694b754c4d4f7e21faf7223f6fa71abaeb10296a4c43a54a7977149687d2"
     link: "https://app.morpho.org/ethereum/market/0xe7e9694b754c4d4f7e21faf7223f6fa71abaeb10296a4c43a54a7977149687d2/"
     note: "Morpho market 0xe7e9694b754c4d4f7e21faf7223f6fa71abaeb10296a4c43a54a7977149687d2 used by Yearn USDT"
   - id: morpho-market-3274643db77a
     label: "sUSDS/USDT · 96.5% LLTV"
     category: dependency
+    morphoMarket: "0x3274643db77a064abd3bc851de77556a4ad2e2f502f4f0c80845fa8f909ecf0b"
     link: "https://app.morpho.org/ethereum/market/0x3274643db77a064abd3bc851de77556a4ad2e2f502f4f0c80845fa8f909ecf0b/"
     note: "Morpho market 0x3274643db77a064abd3bc851de77556a4ad2e2f502f4f0c80845fa8f909ecf0b used by Yearn USDT"
   - id: morpho-market-b7843fe78e7e
     label: "XAUt/USDT · 77% LLTV"
     category: dependency
+    morphoMarket: "0xb7843fe78e7e7fd3106a1b939645367967d1f986c2e45edb8932ad1896450877"
     link: "https://app.morpho.org/ethereum/market/0xb7843fe78e7e7fd3106a1b939645367967d1f986c2e45edb8932ad1896450877/"
     note: "Morpho market 0xb7843fe78e7e7fd3106a1b939645367967d1f986c2e45edb8932ad1896450877 used by Yearn USDT"
 # END GENERATED MORPHO MARKET NODES

--- a/reports/graph/yearn-yvwbtc.yaml
+++ b/reports/graph/yearn-yvwbtc.yaml
@@ -94,11 +94,13 @@ nodes:
   - id: morpho-market-f6a056627a51
     label: "LBTC/WBTC · 94.5% LLTV"
     category: dependency
+    morphoMarket: "0xf6a056627a51e511ec7f48332421432ea6971fc148d8f3c451e14ea108026549"
     link: "https://app.morpho.org/ethereum/market/0xf6a056627a51e511ec7f48332421432ea6971fc148d8f3c451e14ea108026549/"
     note: "Morpho market 0xf6a056627a51e511ec7f48332421432ea6971fc148d8f3c451e14ea108026549 used by Yearn WBTC"
   - id: morpho-market-39d6cc9211d0
     label: "cbBTC/WBTC · 94.5% LLTV"
     category: dependency
+    morphoMarket: "0x39d6cc9211d023cc16708a2378d821d394d8cfaa3640e3a4d4638d292e10035d"
     link: "https://app.morpho.org/ethereum/market/0x39d6cc9211d023cc16708a2378d821d394d8cfaa3640e3a4d4638d292e10035d/"
     note: "Morpho market 0x39d6cc9211d023cc16708a2378d821d394d8cfaa3640e3a4d4638d292e10035d used by Yearn WBTC"
 # END GENERATED MORPHO MARKET NODES

--- a/reports/graph/yearn-yvweth.yaml
+++ b/reports/graph/yearn-yvweth.yaml
@@ -113,11 +113,13 @@ nodes:
   - id: morpho-market-b8fc70e82bc5
     label: "wstETH/WETH · 96.5% LLTV"
     category: dependency
+    morphoMarket: "0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e"
     link: "https://app.morpho.org/ethereum/market/0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e/"
     note: "Morpho market 0xb8fc70e82bc5bb53e773626fcc6a23f7eefa036918d7ef216ecfb1950a94a85e used by Yearn OG WETH"
   - id: morpho-market-d0e50cdac92f
     label: "wstETH/WETH · 94.5% LLTV"
     category: dependency
+    morphoMarket: "0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d"
     link: "https://app.morpho.org/ethereum/market/0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d/"
     note: "Morpho market 0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d used by Yearn OG WETH"
 # END GENERATED MORPHO MARKET NODES

--- a/scripts/update_morpho_graph_markets.mjs
+++ b/scripts/update_morpho_graph_markets.mjs
@@ -261,13 +261,17 @@ export function buildGraphSections(graph, occurrences, allocByKey) {
       if (!nodeId) {
         nodeId = item.id;
         seenMarket.set(nodeKey, nodeId);
-        marketNodes.push({
+        const node = {
           id: item.id,
           label: item.label,
           category: "dependency",
           link: item.link,
           note: item.note,
-        });
+        };
+        // Record the full 32-byte market id so cross-graph linking can key on
+        // it (same market appears across many vaults/graphs).
+        if (item.marketId) node.morphoMarket = item.marketId;
+        marketNodes.push(node);
       }
       edges.push({ from: occ.nodeId, to: nodeId, kind: "deposits-into", label: item.pct });
     }
@@ -288,6 +292,7 @@ function renderNode(node) {
   const lines = [`  - id: ${node.id}`];
   lines.push(`    label: ${yamlScalar(node.label)}`);
   lines.push(`    category: ${node.category}`);
+  if (node.morphoMarket) lines.push(`    morphoMarket: ${yamlScalar(node.morphoMarket)}`);
   if (node.link) lines.push(`    link: ${yamlScalar(node.link)}`);
   if (node.note) lines.push(`    note: ${yamlScalar(node.note)}`);
   return lines;

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -27,6 +27,12 @@ export interface GraphNode {
    * explicitly tagged nodes are probed — never detected from labels or IDs.
    */
   morphoVault?: "v1" | "v2";
+  /**
+   * The full 32-byte Morpho market id for a generated market node. Present on
+   * generated nodes only; used by cross-graph linking to find the same market
+   * across graphs (a market is shared by many vaults, unlike an EVM address).
+   */
+  morphoMarket?: string;
   /** Set at build time by expandCrossLinks; never present in YAML. */
   _inlinedFromSlug?: string;
 }
@@ -247,6 +253,53 @@ export function getReverseGraphIndex(): Map<string, CrossLinkEntry[]> {
   for (const list of reverse.values()) list.sort((a, b) => a.slug.localeCompare(b.slug));
   reverseIndexCache = reverse;
   return reverse;
+}
+
+/**
+ * A reference to a Morpho market from one graph: which vault(s) in that graph
+ * deposit into the market.
+ */
+export interface MorphoMarketRef {
+  slug: string;
+  title: string;
+  vaultLabels: string[];
+}
+
+/**
+ * Build a Morpho market-id → referencing-graphs index across the corpus.
+ * Unlike `getGraphIndex()` (keyed on EVM address, one owner per address), a
+ * Morpho market is *shared*: the same 32-byte `marketId` is supplied by many
+ * vaults in many graphs. This index answers "which other reports are exposed
+ * to this market", which is a systemic-concentration view a curator wants.
+ *
+ * Keyed on the lowercased full `morphoMarket` id.
+ */
+let morphoMarketIndexCache: Map<string, MorphoMarketRef[]> | undefined;
+
+export function getMorphoMarketIndex(): Map<string, MorphoMarketRef[]> {
+  if (morphoMarketIndexCache) return morphoMarketIndexCache;
+  const index = new Map<string, MorphoMarketRef[]>();
+  for (const slug of getGraphSlugs()) {
+    const g = getGraphBySlug(slug);
+    if (!g) continue;
+    for (const n of g.nodes) {
+      if (!n.morphoMarket) continue;
+      const depositors = g.edges
+        .filter((e) => e.to === n.id && e.kind === "deposits-into")
+        .map((e) => g.nodes.find((x) => x.id === e.from)?.label ?? e.from);
+      const key = n.morphoMarket.toLowerCase();
+      const refs = index.get(key) ?? [];
+      refs.push({
+        slug,
+        title: graphHeading(g.title, slug),
+        vaultLabels: [...new Set(depositors)],
+      });
+      index.set(key, refs);
+    }
+  }
+  for (const refs of index.values()) refs.sort((a, b) => a.slug.localeCompare(b.slug));
+  morphoMarketIndexCache = index;
+  return index;
 }
 
 /** One row of the `/graph/` index. */

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -376,6 +376,14 @@ export function expandCrossLinks(graph: Graph, currentSlug: string): Graph {
   const mergedCategories: GraphCategory[] = [...graph.categories];
   const seenIds = new Set(mergedNodes.map((n) => n.id));
   const seenCategoryIds = new Set(graph.categories.map((c) => c.id));
+  // A Morpho market is shared across vaults/graphs, so cross-graph expansion
+  // must merge the same market into one node rather than duplicating it (one
+  // native copy + one inlined copy would show the same market twice). Key on
+  // the full marketId; native nodes are seeded first.
+  const marketIdToNode = new Map<string, string>();
+  for (const n of mergedNodes) {
+    if (n.morphoMarket) marketIdToNode.set(n.morphoMarket.toLowerCase(), n.id);
+  }
 
   for (const hostNode of graph.nodes) {
     if (!hostNode.address) continue;
@@ -420,9 +428,17 @@ export function expandCrossLinks(graph: Graph, currentSlug: string): Graph {
         if (!idMap.has(targetLinkedId)) {
           const targetNode = linked.nodes.find((n) => n.id === targetLinkedId);
           if (!targetNode) continue;
-          const mergedId = `${entry.slug}::${targetLinkedId}`;
+          // If this is a Morpho market that already exists (native or inlined
+          // from another graph), reuse that node instead of creating a
+          // duplicate — the same market should appear once with multiple
+          // inbound `deposits-into` edges.
+          const marketKey = targetNode.morphoMarket?.toLowerCase();
+          const existingMarketNode = marketKey
+            ? marketIdToNode.get(marketKey)
+            : undefined;
+          const mergedId = existingMarketNode ?? `${entry.slug}::${targetLinkedId}`;
           idMap.set(targetLinkedId, mergedId);
-          if (!seenIds.has(mergedId)) {
+          if (!existingMarketNode && !seenIds.has(mergedId)) {
             mergedNodes.push({
               ...targetNode,
               id: mergedId,
@@ -433,6 +449,7 @@ export function expandCrossLinks(graph: Graph, currentSlug: string): Graph {
               _inlinedFromSlug: entry.slug,
             });
             seenIds.add(mergedId);
+            if (marketKey) marketIdToNode.set(marketKey, mergedId);
           }
         }
         if (!visited.has(targetLinkedId)) {

--- a/src/pages/graph/[slug].astro
+++ b/src/pages/graph/[slug].astro
@@ -5,6 +5,7 @@ import {
   getGraphBySlug,
   getGraphIndex,
   getReverseGraphIndex,
+  getMorphoMarketIndex,
   resolveCrossLink,
   expandCrossLinks,
   explorerUrl,
@@ -26,6 +27,7 @@ const baseGraph = getGraphBySlug(slug!);
 if (!baseGraph) return Astro.redirect("/reports/");
 
 const graphIndex = getGraphIndex();
+const morphoMarketIndex = getMorphoMarketIndex();
 // Inline the downstream subgraph of each cross-linked node so a reviewer
 // sees the strategies/dependencies behind external protocols on the same page.
 const graph = expandCrossLinks(baseGraph, slug!);
@@ -75,6 +77,12 @@ const cyData = {
       note: n.note ?? "",
       crossLink: crossLinks.get(n.id) ?? null,
       inlinedFromSlug: n._inlinedFromSlug ?? null,
+      // Other graphs whose vaults supply the same Morpho market.
+      morphoMarketRefs: n.morphoMarket
+        ? (morphoMarketIndex.get(n.morphoMarket.toLowerCase()) ?? []).filter(
+            (r) => r.slug !== slug,
+          )
+        : [],
     };
   }),
   edges: graph.edges.map((e: GraphEdge, i: number) => ({
@@ -282,6 +290,7 @@ const heading = graphHeading(title, slug!);
       note: string;
       crossLink: CrossLink | null;
       inlinedFromSlug: string | null;
+      morphoMarketRefs: { slug: string; title: string; vaultLabels: string[] }[];
     };
     type CyEdge = {
       id: string;
@@ -771,12 +780,33 @@ const heading = graphHeading(title, slug!);
           </div>`
         : "";
 
+      // A Morpho market is shared: other graphs' vaults supply the same market.
+      // List them so a reviewer sees the systemic concentration behind a market.
+      const marketRefsBlock = n.morphoMarketRefs?.length
+        ? `
+          <div class="panel-section">
+            <div class="panel-h">Also supplied by</div>
+            <div class="panel-ref-list">
+              ${n.morphoMarketRefs
+                .map(
+                  (r) => `
+                <a class="panel-ref" href="/graph/${escapeHtml(r.slug)}/">
+                  <span class="panel-ref-title">${escapeHtml(r.title)}</span>
+                  <span class="panel-ref-detail">${escapeHtml(r.vaultLabels.join(" · "))}</span>
+                </a>`,
+                )
+                .join("")}
+            </div>
+          </div>`
+        : "";
+
       panelContent.innerHTML = `
         <div class="panel-eyebrow">${eyebrow}</div>
         <h2 class="panel-title">${escapeHtml(n.label)}</h2>
         ${addressBlock}
         ${noteBlock}
         ${crossBlock}
+        ${marketRefsBlock}
         ${connectionRows(inboundByNode.get(id) ?? [], "in")}
         ${connectionRows(outboundByNode.get(id) ?? [], "out")}
       `;
@@ -1766,6 +1796,37 @@ const heading = graphHeading(title, slug!);
   }
   .panel-cross-row {
     margin-bottom: 0.35rem;
+  }
+  /* Shared Morpho-market cross-references in the details panel. */
+  .panel-ref-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .panel-ref {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 0.4rem 0.5rem;
+    border: 1px solid var(--graph-border);
+    border-radius: 5px;
+    text-decoration: none;
+    transition: border-color 0.15s;
+  }
+  .panel-ref:hover {
+    border-color: rgba(110, 167, 255, 0.6);
+    text-decoration: none;
+  }
+  .panel-ref-title {
+    font-size: 0.75rem;
+    color: #6ea7ff;
+  }
+  html.light .panel-ref-title {
+    color: #0675f9;
+  }
+  .panel-ref-detail {
+    font-size: 0.68rem;
+    color: var(--text-secondary);
   }
   .conn-list {
     display: flex;

--- a/tests/update_morpho_graph_markets.test.mjs
+++ b/tests/update_morpho_graph_markets.test.mjs
@@ -16,6 +16,7 @@ import {
   parseV1Items,
   parseV2Items,
   postGraphql,
+  renderNodesBlock,
 } from "../scripts/update_morpho_graph_markets.mjs";
 
 const REPORTS = new Set(["demo", "infinifi"]);
@@ -498,4 +499,32 @@ test("buildGraphSections ignores previous generated nodes when deriving ids", ()
   const { marketNodes } = buildGraphSections(g, occ, allocByKey);
   // Stable, not shifted by the stale generated node.
   assert.equal(marketNodes[0].id, "morpho-market-64d65c9a2d91");
+});
+
+test("generated market nodes carry morphoMarket; idle nodes do not", () => {
+  const g = graph();
+  const occ = [{ slug: "demo", nodeId: "morpho-vault", version: "v1", chain: "ethereum", address: "0x68Aea7b82Df6CcdF76235D46445Ed83f85F845A3", nodeLabel: "Yearn USDC" }];
+  const allocByKey = new Map([
+    [
+      "v1:ethereum:0x68aea7b82df6ccdf76235d46445ed83f85f845a3",
+      vaultData({
+        totalAssets: 1000n,
+        allocations: [
+          alloc(820, null, null, null, null), // idle
+          alloc(180, "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64", "860000000000000000", "cbBTC", "USDC"),
+        ],
+      }),
+    ],
+  ]);
+  const { marketNodes } = buildGraphSections(g, occ, allocByKey);
+  const market = marketNodes.find((n) => n.id.startsWith("morpho-market-"));
+  const idle = marketNodes.find((n) => n.id.startsWith("morpho-idle-"));
+  assert.equal(market.morphoMarket, "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64");
+  assert.equal(idle.morphoMarket, undefined);
+
+  // The serialized YAML emits morphoMarket exactly once (the market node only).
+  const block = renderNodesBlock(marketNodes).join("\n");
+  const occurrences = block.split("\n").filter((l) => l.trim().startsWith("morphoMarket:")).length;
+  assert.equal(occurrences, 1);
+  assert.ok(block.includes('morphoMarket: "0x64d65c9a2d91c36d56fbc42d69e979335320169b3df63bf92789e2c8883fcc64"'));
 });


### PR DESCRIPTION
## What this adds

Generated Morpho market nodes now carry their full 32-byte `morphoMarket` id, and the graph renderer builds a corpus-wide market-id index so a market card lists every **other** graph whose vaults supply the same market.

Example on `/graph/yearn-yvusd/`: clicking `cbBTC/USDC · 86% LLTV` shows an "Also supplied by" section linking to cap-stcusd (Steakhouse + Gauntlet Prime), gauntlet-gusda (Frontier), yearn-yvusdc and yearn-yvdai.

## Scope

- `scripts/update_morpho_graph_markets.mjs` — emit `morphoMarket` on market nodes (idle nodes excluded).
- `src/lib/graph.ts` — `morphoMarket` field + `getMorphoMarketIndex()`.
- `src/pages/graph/[slug].astro` — resolve market refs and render "Also supplied by" in the details panel.
- Corpus regenerated + tests + SKILL.md.

## Why a separate PR

This is a UX experiment — please eyeball it on the preview and decide if the "Also supplied by" panel section reads well. If it's too noisy, the fallback is to collapse it behind a smaller affordance.

## Validation

- `npm test` 54/54, `npm run build` passes, `npm run check-graphs` 0 errors.